### PR TITLE
Testing old_api with TestCase class

### DIFF
--- a/nengo/test/test_old_api.py
+++ b/nengo/test/test_old_api.py
@@ -1,59 +1,74 @@
+from unittest import TestCase
+
 import numpy as np
-from nengo.old_api import Network
 from matplotlib import pyplot as plt
+
+from nengo.simulator import Simulator
+from nengo.old_api import Network
 
 def rmse(a, b):
     return np.sqrt(np.mean((a - b) ** 2))
 
 
-def test_basic_1(show=False):
-    """
-    Create a network with sin(t) being represented by
-    a population of spiking neurons. Assert that the
-    decoded value from the population is close to the
-    true value (which is input to the population).
+class TestOldAPI(TestCase):
+    # -- Tests are in a class so that 
+    #    nengo_ocl can automatically run all
+    #    member unit tests for other simulators by
+    #    subclassing this class and overriding this attribute.
+    Simulator = Simulator
 
-    Expected duration of test: about .7 seconds
-    """
+    show = False
 
-    net = Network('Runtime Test', dt=0.001, seed=123)
-    print 'make_input'
-    net.make_input('in', value=np.sin)
-    print 'make A'
-    net.make('A', 1000, 1)
-    print 'connecting in -> A'
-    net.connect('in', 'A')
-    A_fast_probe = net.make_probe('A', dt_sample=0.01, pstc=0.001)
-    A_med_probe = net.make_probe('A', dt_sample=0.01, pstc=0.01)
-    A_slow_probe = net.make_probe('A', dt_sample=0.01, pstc=0.1)
-    in_probe = net.make_probe('in', dt_sample=0.01, pstc=0.01)
+    def test_basic_1(self):
+        """
+        Create a network with sin(t) being represented by
+        a population of spiking neurons. Assert that the
+        decoded value from the population is close to the
+        true value (which is input to the population).
 
-    net.run(1.0)
+        Expected duration of test: about .7 seconds
+        """
 
-    target = np.sin(np.arange(0, 1000, 10) / 1000.)
-    target.shape = (100, 1)
+        net = Network('Runtime Test', dt=0.001, seed=123,
+                     Simulator=self.Simulator)
+        print 'make_input'
+        net.make_input('in', value=np.sin)
+        print 'make A'
+        net.make('A', 1000, 1)
+        print 'connecting in -> A'
+        net.connect('in', 'A')
+        A_fast_probe = net.make_probe('A', dt_sample=0.01, pstc=0.001)
+        A_med_probe = net.make_probe('A', dt_sample=0.01, pstc=0.01)
+        A_slow_probe = net.make_probe('A', dt_sample=0.01, pstc=0.1)
+        in_probe = net.make_probe('in', dt_sample=0.01, pstc=0.01)
 
-    # target is off-by-one at the sampling frequency of dt=0.001
-    print rmse(target, in_probe.get_data())
-    assert rmse(target, in_probe.get_data()) < .001
-    print rmse(target, A_fast_probe.get_data())
-    assert rmse(target, A_fast_probe.get_data()) < .30
-    print rmse(target, A_med_probe.get_data())
-    assert rmse(target, A_med_probe.get_data()) < .025
-    print rmse(target, A_slow_probe.get_data())
-    assert rmse(target, A_slow_probe.get_data()) < 0.1
+        net.run(1.0)
 
-    for speed in 'fast', 'med', 'slow':
-        probe = locals()['A_%s_probe' % speed]
-        data = np.asarray(probe.get_data()).flatten()
-        plt.plot(data, label=speed)
+        target = np.sin(np.arange(0, 1000, 10) / 1000.)
+        target.shape = (100, 1)
 
-    in_data = np.asarray(in_probe.get_data()).flatten()
+        for speed in 'fast', 'med', 'slow':
+            probe = locals()['A_%s_probe' % speed]
+            data = np.asarray(probe.get_data()).flatten()
+            plt.plot(data, label=speed)
 
-    plt.plot(in_data, label='in')
-    plt.legend(loc='upper left')
+        in_data = np.asarray(in_probe.get_data()).flatten()
 
-    if show:
-        plt.show()
+        plt.plot(in_data, label='in')
+        plt.legend(loc='upper left')
 
+        if self.show:
+            plt.show()
+
+
+
+        # target is off-by-one at the sampling frequency of dt=0.001
+        print rmse(target, in_probe.get_data())
+        assert rmse(target, in_probe.get_data()) < .001
+        print rmse(target, A_fast_probe.get_data())
+        assert rmse(target, A_fast_probe.get_data()) < .30
+        print rmse(target, A_med_probe.get_data())
+        assert rmse(target, A_med_probe.get_data()) < .025
+        print rmse(target, A_slow_probe.get_data())
+        assert rmse(target, A_slow_probe.get_data()) < 0.1
 


### PR DESCRIPTION
Making tests into unit tests makes it easier to import them in nengo_ocl,
 swap the `Simulator` class attribute, and re-run all the tests with a
different simulator. I'd like to do more tests this way, rather than
having them be just `test_foo` functions at the module level of test
files.

Thoughts?
