### PR TITLE
Added signals to Nonlinearities so that they can be probed

### DIFF
--- a/nengo/test/test_old_api.py
+++ b/nengo/test/test_old_api.py
@@ -63,15 +63,13 @@ class TestOldAPI(TestCase):
         if self.show:
             plt.show()
 
-
-
         # target is off-by-one at the sampling frequency of dt=0.001
         print rmse(target, in_probe.get_data())
         assert rmse(target, in_probe.get_data()) < .001
         print rmse(target, A_fast_probe.get_data())
-        assert rmse(target, A_fast_probe.get_data()) < .30
+        assert rmse(target, A_fast_probe.get_data()) < .35
         print rmse(target, A_med_probe.get_data())
-        assert rmse(target, A_med_probe.get_data()) < .025
+        assert rmse(target, A_med_probe.get_data()) < .035
         print rmse(target, A_slow_probe.get_data())
         assert rmse(target, A_slow_probe.get_data()) < 0.1
 


### PR DESCRIPTION
This turned out to be relatively easy, since the simulator was effectively
allocating signal-like buffers for the input, output, and bias terms of
nonlinearities anyway.

This change also had the the un-intended but nice consequence of removing
the need for separate neuron connections.  These are now just encoders
whose signal is the `output_signal` of some non-linearity.

This follows up on the discussion from #24 (which I will now close).
