### PR TITLE
Fixing typo in objects.py

### DIFF
--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -179,7 +179,7 @@ class Ensemble(object):
         if isinstance(_neurons, int):
             logger.warning(("neurons should be an instance of a nonlinearity, "
                             "not an int. Defaulting to LIF."))
-            _neurons = core.LIF(neurons)
+            _neurons = core.LIF(_neurons)
 
         # Give a better name if name is default
         if _neurons.name.startswith("<LIF"):


### PR DESCRIPTION
When making an ensemble like this:
model.make_ensemble( 'bla', 10, dimensions=1 )
instead of
model.make_ensemble( 'bla', nengo.LIF(10), dimensions=1 )
a NameError would occur in objects.py 
