### PR TITLE
Play nicer with nengo_ocl

### DIFF
--- a/nengo/model.py
+++ b/nengo/model.py
@@ -227,7 +227,7 @@ class Model(object):
         modelcopy = copy.deepcopy(self, memo)
         modelcopy.memo = memo
         self.prep_for_simulation(modelcopy, dt)
-        return sim_class(modelcopy, **sim_args)
+        return sim_class(model=modelcopy, **sim_args)
 
     ### Model manipulation
 


### PR DESCRIPTION
It's possible to pass in **sim_args now. Necessary for some nengo_ocl stuff
