### PR TITLE
Fixed bug in helpers.tuning_curves

### DIFF
--- a/nengo/helpers.py
+++ b/nengo/helpers.py
@@ -10,7 +10,7 @@ def tuning_curves(sim_ens):
     eval_points = np.array(sim_ens.eval_points)
     eval_points.sort(axis=0)
     activities = sim_ens.activities(eval_points)
-    return sim_ens.eval_points, activities
+    return eval_points, activities
 
 
 def encoders():


### PR DESCRIPTION
Was returning unsorted eval_points.

If people are finding this function useful, then we probably also need to add unit tests for this, though if people are finding them REALLY useful, then we should make it something that can probe in the ensemble, rather than just a helper.
