### PR TITLE
Use eval_points in function if given

### DIFF
--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -523,7 +523,11 @@ class DecodedConnection(SignalConnection):
         if self.function is None:
             return self.pre.dimensions
         else:
-            return np.array(self.function(np.ones(self.pre.dimensions,))).size
+            if self._eval_points is not None:
+                val = self._eval_points[0]
+            else:
+                val = np.ones(self.pre.dimensions)
+            return np.array(self.function(val)).size
 
     @property
     def eval_points(self):


### PR DESCRIPTION
- when finding dimensions check for eval_points,
  use eval_points[0] if it exists, otherwise
  go on and use an array of ones.

I ran into the case where I had a function that was just a 
lookup table that didn't specify a value for 1, and then when 
the builder was trying to figure out the dimensions of the 
connection it passed in an array of 1, throwing an error. 

This just changes to check to see if any eval_points 
have been specified to use, and use 
those first, and use the array of 1s otherwise.
