### PR TITLE
Node vs. PythonFunction and a hidden bug

### DIFF
--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -98,7 +98,7 @@ class TestSimulator(unittest.TestCase):
 
         time = Signal(np.zeros(1), name='time')
         sig = Signal(np.zeros(1), name='sig')
-        pop = nengo.PythonFunction(fn=lambda x: np.sin(x), n_in=1)
+        pop = nengo.PythonFunction(fn=lambda t, x: np.sin(x), n_in=1)
         m.operators = []
         b = Builder()
         b.model = m


### PR DESCRIPTION
I ran into a bit of a snag with NengoOCL and turns out it is a bug in master. The commit below triggers it.

I think the trouble is that Nengo is currently assuming that all PythonFunctions take time as the first input. This wasn't noticed because the PythonFunctions in the unit tests all use numpy ufuncs, which _do_ run on double-arguments, but they don't behave as expected: they use time as the input and write the result _to_ the second argument (which was suppose to be the input).

After the recent discussion in #224 I don't know what to suggest as a fix. But I think there is a problem that needs some attention here.
