### PR TITLE
Changed EnsembleArray neurons parameter to be per-ensemble (Issue #242)

### DIFF
--- a/nengo/networks/basalganglia.py
+++ b/nengo/networks/basalganglia.py
@@ -29,7 +29,7 @@ class BasalGanglia(nengo.Network):
 
         encoders = np.ones((n_neurons_per_ensemble, 1))
         ea_params = {
-            'neurons': nengo.LIF(n_neurons_per_ensemble * dimensions),
+            'neurons': nengo.LIF(n_neurons_per_ensemble),
             'n_ensembles': dimensions,
             'radius': radius,
             'encoders': encoders,

--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -45,7 +45,7 @@ class CircularConvolution(nengo.Network):
             self.B = nengo.Node(dimensions=dimensions)
             self.ensemble = EnsembleArray(neurons,
                                           self.transformC.shape[1],
-                                          dimensions_per_ensemble=2,
+                                          dimensions=2,
                                           radius=radius)
             self.output = nengo.Node(dimensions=dimensions)
 

--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -6,28 +6,19 @@ import nengo
 
 
 class EnsembleArray(nengo.Network):
-    def make(self, neurons, n_ensembles, dimensions_per_ensemble=1, **ens_args):
+    def make(self, neurons, n_ensembles, **ens_args):
         self.n_ensembles = n_ensembles
-        self.dimensions_per_ensemble = dimensions_per_ensemble
+        self.dimensions_per_ensemble = ens_args.pop('dimensions', 1)
         self.ensembles = []
         transform = np.eye(self.dimensions)
-        each_neurons = neurons.n_neurons // n_ensembles
-        extra_neurons = neurons.n_neurons % n_ensembles
 
         with self:
             self.input = nengo.Node(dimensions=self.dimensions)
 
             for i in range(n_ensembles):
-                ens_neurons = copy.deepcopy(neurons)
-                if extra_neurons > 0:
-                    ens_neurons.n_neurons = each_neurons + 1
-                    extra_neurons -= 1
-                else:
-                    ens_neurons.n_neurons = each_neurons
-
-                e = nengo.Ensemble(ens_neurons, dimensions_per_ensemble, **ens_args)
-                trans = transform[i * dimensions_per_ensemble:
-                                  (i + 1) * dimensions_per_ensemble, :]
+                e = nengo.Ensemble(copy.deepcopy(neurons), self.dimensions_per_ensemble, **ens_args)
+                trans = transform[i * self.dimensions_per_ensemble:
+                                  (i + 1) * self.dimensions_per_ensemble, :]
                 nengo.Connection(self.input, e, transform=trans, filter=None)
                 self.ensembles.append(e)
 

--- a/nengo/tests/test_circularconv.py
+++ b/nengo/tests/test_circularconv.py
@@ -44,9 +44,8 @@ class TestCircularConv(SimulatorTestCase):
     def _test_circularconv(self, dims=5, neurons_per_product=128):
         rng = np.random.RandomState(42342)
 
-        n_neurons = neurons_per_product * dims
-        n_neurons_d = 2 * neurons_per_product * (
-            2*dims - (2 if dims % 2 == 0 else 1))
+        n_neurons = neurons_per_product
+        n_neurons_d = 2 * neurons_per_product
         radius = 1
 
         a = rng.normal(scale=np.sqrt(1./dims), size=dims)

--- a/nengo/tests/test_ensemble_array.py
+++ b/nengo/tests/test_ensemble_array.py
@@ -10,28 +10,11 @@ from nengo.tests.helpers import Plotter, SimulatorTestCase, unittest
 
 logger = logging.getLogger(__name__)
 
-
-class TestEnsembleArrayCreation(unittest.TestCase):
-    def test_neuron_parititoning(self):
-        nengo.Model()
-        ea_even = EnsembleArray(nengo.LIF(10), 5)
-        for ens in ea_even.ensembles:
-            self.assertEqual(ens.n_neurons, 2)
-
-        ea_odd = EnsembleArray(nengo.LIF(19), 4)
-
-        # Order of the sizes shouldn't matter
-        sizes = [5, 5, 5, 4]
-        for ens in ea_odd.ensembles:
-            sizes.remove(ens.n_neurons)
-        self.assertEqual(len(sizes), 0)
-
-
 class TestEnsembleArray(SimulatorTestCase):
     def test_multidim(self):
         """Test an ensemble array with multiple dimensions per ensemble"""
         dims = 3
-        n_neurons = 3 * 60
+        n_neurons = 60
         radius = 1.5
 
         rng = np.random.RandomState(523887)
@@ -51,7 +34,7 @@ class TestEnsembleArray(SimulatorTestCase):
             A = EnsembleArray(nengo.LIF(n_neurons), dims, radius=radius)
             B = EnsembleArray(nengo.LIF(n_neurons), dims, radius=radius)
             C = EnsembleArray(nengo.LIF(n_neurons * 2), dims,
-                              dimensions_per_ensemble=2,
+                              dimensions=2,
                               radius=radius, label="C")
 
             nengo.Connection(inputA, A.input)
@@ -104,9 +87,9 @@ class TestEnsembleArray(SimulatorTestCase):
 
         model = nengo.Model('Matrix Multiplication', seed=123)
         with model:
-            A = EnsembleArray(nengo.LIF(N * Amat.size),
+            A = EnsembleArray(nengo.LIF(N),
                               Amat.size, radius=radius)
-            B = EnsembleArray(nengo.LIF(N * Bmat.size),
+            B = EnsembleArray(nengo.LIF(N),
                               Bmat.size, radius=radius)
 
             inputA = nengo.Node(output=Amat.ravel())
@@ -118,9 +101,9 @@ class TestEnsembleArray(SimulatorTestCase):
             B_p = nengo.Probe(
                 B.output, 'output', sample_every=0.01, filter=0.01)
 
-            C = EnsembleArray(nengo.LIF(N * Amat.size * Bmat.shape[1] * 2),
+            C = EnsembleArray(nengo.LIF(N),
                               Amat.size * Bmat.shape[1],
-                              dimensions_per_ensemble=2,
+                              dimensions=2,
                               radius=1.5 * radius)
 
             for ens in C.ensembles:
@@ -142,7 +125,7 @@ class TestEnsembleArray(SimulatorTestCase):
             C_p = nengo.Probe(
                 C.output, 'output', sample_every=0.01, filter=0.01)
 
-            D = EnsembleArray(nengo.LIF(N * Amat.shape[0] * Bmat.shape[1]),
+            D = EnsembleArray(nengo.LIF(N),
                               Amat.shape[0] * Bmat.shape[1], radius=radius)
 
             def product(x):


### PR DESCRIPTION
As discussed, now when creating an EnsembleArray, you specify the neurons for one ensemble and then those get duplicated in each element in the array, rather than specifying the total neurons and then splitting them up.  Also note that as part of this I removed the `dimensions_per_ensemble` parameter.  Since all the parameters are per-ensemble now, you just specify `dimension`, like you would for a single ensemble (or if you don't specify anything the default is 1).

Before:

``` python
EnsembleArray(nengo.LIF(N*n_ensembles), n_ensembles, dimensions_per_ensemble=2)
```

Now:

``` python
EnsembleArray(nengo.LIF(N), n_ensembles, dimensions=2)
```
