### PR TITLE
Simplified network code

### DIFF
--- a/nengo/networks/basalganglia.py
+++ b/nengo/networks/basalganglia.py
@@ -35,63 +35,62 @@ class BasalGanglia(nengo.Network):
             'encoders': encoders,
         }
 
-        with self:
-            strD1 = EnsembleArray(label='Striatal D1 neurons',
-                                  intercepts=Uniform(self.e, 1), **ea_params)
+        strD1 = EnsembleArray(label='Striatal D1 neurons',
+                              intercepts=Uniform(self.e, 1), **ea_params)
 
-            strD2 = EnsembleArray(label='Striatal D2 neurons',
-                                  intercepts=Uniform(self.e, 1), **ea_params)
+        strD2 = EnsembleArray(label='Striatal D2 neurons',
+                              intercepts=Uniform(self.e, 1), **ea_params)
 
-            stn = EnsembleArray(label='Subthalamic nucleus',
-                                intercepts=Uniform(self.ep, 1), **ea_params)
+        stn = EnsembleArray(label='Subthalamic nucleus',
+                            intercepts=Uniform(self.ep, 1), **ea_params)
 
-            gpi = EnsembleArray(label='Globus pallidus internus',
-                                intercepts=Uniform(self.eg, 1), **ea_params)
+        gpi = EnsembleArray(label='Globus pallidus internus',
+                            intercepts=Uniform(self.eg, 1), **ea_params)
 
-            gpe = EnsembleArray(label='Globus pallidus externus',
-                                intercepts=Uniform(self.ee, 1), **ea_params)
+        gpe = EnsembleArray(label='Globus pallidus externus',
+                            intercepts=Uniform(self.ee, 1), **ea_params)
 
-            self.input = nengo.Node(label="input", size_in=dimensions)
-            self.output = nengo.Node(label="output", size_in=dimensions)
+        self.input = nengo.Node(label="input", size_in=dimensions)
+        self.output = nengo.Node(label="output", size_in=dimensions)
 
-            # spread the input to StrD1, StrD2, and STN
-            nengo.Connection(
-                self.input, strD1.input, filter=None,
-                transform=np.eye(dimensions) * self.ws * (1 + self.lg))
-            nengo.Connection(
-                self.input, strD2.input, filter=None,
-                transform=np.eye(dimensions) * self.ws * (1 - self.le))
-            nengo.Connection(
-                self.input, stn.input, filter=None,
-                transform=np.eye(dimensions) * self.wt)
+        # spread the input to StrD1, StrD2, and STN
+        nengo.Connection(
+            self.input, strD1.input, filter=None,
+            transform=np.eye(dimensions) * self.ws * (1 + self.lg))
+        nengo.Connection(
+            self.input, strD2.input, filter=None,
+            transform=np.eye(dimensions) * self.ws * (1 - self.le))
+        nengo.Connection(
+            self.input, stn.input, filter=None,
+            transform=np.eye(dimensions) * self.wt)
 
-            # connect the striatum to the GPi and GPe (inhibitory)
-            nengo.Connection(strD1.add_output('func_str', self.str()),
-                             gpi.input, filter=tau_gaba,
-                             transform=-np.eye(dimensions) * self.wm)
-            nengo.Connection(strD2.add_output('func_str', self.str()),
-                             gpe.input, filter=tau_gaba,
-                             transform=-np.eye(dimensions) * self.wm)
+        # connect the striatum to the GPi and GPe (inhibitory)
+        nengo.Connection(strD1.add_output('func_str', self.str()),
+                         gpi.input, filter=tau_gaba,
+                         transform=-np.eye(dimensions) * self.wm)
+        nengo.Connection(strD2.add_output('func_str', self.str()),
+                         gpe.input, filter=tau_gaba,
+                         transform=-np.eye(dimensions) * self.wm)
 
-            # connect the STN to GPi and GPe (broad and excitatory)
-            tr = np.ones((dimensions, dimensions)) * self.wp
-            stn_output = stn.add_output('func_stn', self.stn())
-            nengo.Connection(stn_output, gpi.input,
-                             transform=tr, filter=tau_ampa)
-            nengo.Connection(stn_output, gpe.input,
-                             transform=tr, filter=tau_ampa)
+        # connect the STN to GPi and GPe (broad and excitatory)
+        tr = np.ones((dimensions, dimensions)) * self.wp
+        stn_output = stn.add_output('func_stn', self.stn())
+        nengo.Connection(stn_output, gpi.input,
+                         transform=tr, filter=tau_ampa)
+        nengo.Connection(stn_output, gpe.input,
+                         transform=tr, filter=tau_ampa)
 
-            # connect the GPe to GPi and STN (inhibitory)
-            gpe_output = gpe.add_output('func_gpe', self.gpe())
-            nengo.Connection(gpe_output, gpi.input, filter=tau_gaba,
-                             transform=-np.eye(dimensions) * self.we)
-            nengo.Connection(gpe_output, stn.input, filter=tau_gaba,
-                             transform=-np.eye(dimensions) * self.wg)
+        # connect the GPe to GPi and STN (inhibitory)
+        gpe_output = gpe.add_output('func_gpe', self.gpe())
+        nengo.Connection(gpe_output, gpi.input, filter=tau_gaba,
+                         transform=-np.eye(dimensions) * self.we)
+        nengo.Connection(gpe_output, stn.input, filter=tau_gaba,
+                         transform=-np.eye(dimensions) * self.wg)
 
-            #connect GPi to output (inhibitory)
-            nengo.Connection(gpi.add_output('func_gpi', self.gpi()),
-                             self.output, filter=None,
-                             transform=np.eye(dimensions) * output_weight)
+        #connect GPi to output (inhibitory)
+        nengo.Connection(gpi.add_output('func_gpi', self.gpi()),
+                         self.output, filter=None,
+                         transform=np.eye(dimensions) * output_weight)
 
     def str(self):
         def func_str(x):

--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -40,28 +40,27 @@ class CircularConvolution(nengo.Network):
             dimensions, first=False, invert=invert_b)
         self.transformC = self._output_transform(dimensions)
 
-        with self:
-            self.A = nengo.Node(size_in=dimensions)
-            self.B = nengo.Node(size_in=dimensions)
-            self.ensemble = EnsembleArray(neurons,
-                                          self.transformC.shape[1],
-                                          dimensions=2,
-                                          radius=radius)
-            self.output = nengo.Node(size_in=dimensions)
+        self.A = nengo.Node(size_in=dimensions)
+        self.B = nengo.Node(size_in=dimensions)
+        self.ensemble = EnsembleArray(neurons,
+                                      self.transformC.shape[1],
+                                      dimensions=2,
+                                      radius=radius)
+        self.output = nengo.Node(size_in=dimensions)
 
-            for ens in self.ensemble.ensembles:
-                if not isinstance(neurons, nengo.Direct):
-                    ens.encoders = np.tile(
-                        [[1, 1], [-1, 1], [1, -1], [-1, -1]],
-                        (ens.n_neurons // 4, 1))
-            nengo.Connection(
-                self.A, self.ensemble.input, transform=self.transformA)
-            nengo.Connection(
-                self.B, self.ensemble.input, transform=self.transformB)
-            nengo.Connection(self.ensemble.add_output('product', self.product),
-                             self.output,
-                             filter=0.02,
-                             transform=self.transformC)
+        for ens in self.ensemble.ensembles:
+            if not isinstance(neurons, nengo.Direct):
+                ens.encoders = np.tile(
+                    [[1, 1], [-1, 1], [1, -1], [-1, -1]],
+                    (ens.n_neurons // 4, 1))
+        nengo.Connection(
+            self.A, self.ensemble.input, transform=self.transformA)
+        nengo.Connection(
+            self.B, self.ensemble.input, transform=self.transformB)
+        nengo.Connection(self.ensemble.add_output('product', self.product),
+                         self.output,
+                         filter=0.02,
+                         transform=self.transformC)
 
     @staticmethod
     def _input_transform(dims, first, invert=False):

--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -12,19 +12,18 @@ class EnsembleArray(nengo.Network):
         self.ensembles = []
         transform = np.eye(self.dimensions)
 
-        with self:
-            self.input = nengo.Node(size_in=self.dimensions)
+        self.input = nengo.Node(size_in=self.dimensions)
 
-            for i in range(n_ensembles):
-                e = nengo.Ensemble(copy.deepcopy(neurons),
-                                   self.dimensions_per_ensemble,
-                                   **ens_args)
-                trans = transform[i * self.dimensions_per_ensemble:
-                                  (i + 1) * self.dimensions_per_ensemble, :]
-                nengo.Connection(self.input, e, transform=trans, filter=None)
-                self.ensembles.append(e)
+        for i in range(n_ensembles):
+            e = nengo.Ensemble(copy.deepcopy(neurons),
+                               self.dimensions_per_ensemble,
+                               **ens_args)
+            trans = transform[i * self.dimensions_per_ensemble:
+                              (i + 1) * self.dimensions_per_ensemble, :]
+            nengo.Connection(self.input, e, transform=trans, filter=None)
+            self.ensembles.append(e)
 
-            self.add_output('output', function=None)
+        self.add_output('output', function=None)
 
     def add_output(self, name, function):
         if function is None:

--- a/nengo/networks/integrator.py
+++ b/nengo/networks/integrator.py
@@ -4,10 +4,7 @@ import nengo
 class Integrator(nengo.Network):
     def make(self, recurrent_tau, **ens_args):
         dimensions = ens_args.get('dimensions', 1)
-        with self:
-            self.input = nengo.Node(size_in=dimensions)
-            self.ensemble = nengo.Ensemble(**ens_args)
-            nengo.Connection(
-                self.ensemble, self.ensemble, filter=recurrent_tau)
-            nengo.Connection(
-                self.input, self.ensemble, transform=recurrent_tau)
+        self.input = nengo.Node(size_in=dimensions)
+        self.ensemble = nengo.Ensemble(**ens_args)
+        nengo.Connection(self.ensemble, self.ensemble, filter=recurrent_tau)
+        nengo.Connection(self.input, self.ensemble, transform=recurrent_tau)

--- a/nengo/networks/oscillator.py
+++ b/nengo/networks/oscillator.py
@@ -3,12 +3,11 @@ import nengo
 
 class Oscillator(nengo.Network):
     def make(self, recurrent_tau, frequency, **ens_args):
-        with self:
-            self.input = nengo.Node(label='In', size_in=2)
-            self.ensemble = nengo.Ensemble(
-                label='Oscillator', dimensions=2, **ens_args)
-            tA = [[1, -frequency * recurrent_tau],
-                  [frequency * recurrent_tau, 1]]
-            nengo.Connection(self.ensemble, self.ensemble,
-                             filter=recurrent_tau, transform=tA)
-            nengo.Connection(self.input, self.ensemble)
+        self.input = nengo.Node(label='In', size_in=2)
+        self.ensemble = nengo.Ensemble(
+            label='Oscillator', dimensions=2, **ens_args)
+        tA = [[1, -frequency * recurrent_tau],
+              [frequency * recurrent_tau, 1]]
+        nengo.Connection(self.ensemble, self.ensemble,
+                         filter=recurrent_tau, transform=tA)
+        nengo.Connection(self.input, self.ensemble)

--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -537,7 +537,8 @@ class Network(object):
     def __init__(self, *args, **kwargs):
         self.label = kwargs.pop("label", "Network")
         self.objects = []
-        self.make(*args, **kwargs)
+        with self:
+            self.make(*args, **kwargs)
 
         # add self to current context
         nengo.context.add_to_current(self)


### PR DESCRIPTION
Now, networks don't have to explicitly do `with self:`; everything inside `make` is in the context of the network. Note that if you do do `with self:`, it's fine, just unnecessary.

Also removed `with self:` from all networks.

This is from discussion in #253.
