### PR TITLE
Probes now have default attributes

### DIFF
--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -508,10 +508,25 @@ class Probe(object):
     ----------
     sample_rate
     """
+    DEFAULTS = {
+        Ensemble: 'decoded_output',
+        Node: 'output',
+    }
 
-    def __init__(self, target, attr,
+    def __init__(self, target, attr=None,
                  sample_every=0.001, filter=None, dimensions=None):
         self.target = target
+        if attr is None:
+            try:
+                attr = self.DEFAULTS[target.__class__]
+            except KeyError:
+                for k in self.DEFAULTS:
+                    if issubclass(target.__class__, k):
+                        attr = self.DEFAULTS[k]
+                        break
+                else:
+                    raise TypeError("Type " + target.__class__.__name__
+                                    + " has no default probe.")
         self.attr = attr
         self.label = "Probe(" + target.label + "." + attr + ")"
         self.sample_every = sample_every

--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -115,6 +115,23 @@ def test_large(Simulator):
         assert np.allclose(y[1:], x[:-1])  # 1-step delay
 
 
+def test_defaults(Simulator):
+    """Tests that probing with no attr sets the right attr."""
+    model = nengo.Model('test_defaults')
+    node = nengo.Node(output=0.5)
+    ens = nengo.Ensemble(nengo.LIF(20), 1)
+    conn = nengo.Connection(node, ens)
+    node_p = nengo.Probe(node)
+    assert node_p.attr == 'output'
+    ens_p = nengo.Probe(ens)
+    assert ens_p.attr == 'decoded_output'
+    with pytest.raises(TypeError):
+        nengo.Probe(conn)
+    # Let's just make sure it runs too...
+    sim = Simulator(model)
+    sim.run(0.01)
+
+
 if __name__ == "__main__":
     nengo.log(debug=True)
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
`decoded_output` for ensembles, `output` for nodes.

Fixes #255.
