### PR TITLE
Fixed neuron model under Windows

### DIFF
--- a/nengo/nonlinearities.py
+++ b/nengo/nonlinearities.py
@@ -126,8 +126,11 @@ class _LIFBase(Neurons):
         """LIF firing rates in Hz for input current (incl. bias)"""
         old = np.seterr(divide='ignore')
         try:
-            j = np.maximum(J - 1, 0.)
+            j = J - 1    # because we're using log1p instead of log
             r = 1. / (self.tau_ref + self.tau_rc * np.log1p(1. / j))
+            # NOTE: There is a known bug in numpy that np.log1p(inf) returns
+            #   NaN instead of inf: https://github.com/numpy/numpy/issues/4225
+            r[j <= 0] = 0
         finally:
             np.seterr(**old)
         return r


### PR DESCRIPTION
All decoder computations are broken in (some versions of) Windows right now.  For example:

``` python
import nengo

model = nengo.Model('test')
with model:
    a = nengo.Ensemble(50, 1)
    b = nengo.Ensemble(50, 1)
    nengo.Connection(a, b, filter=0.01) 
sim = nengo.Simulator(model)
```

gives this:

```
C:\Users\Terry\Documents\GitHub\nengo\nengo\decoders.pyc in _cholesky1(A, b, sigma)
     67     b = np.dot(A.T, b)
     68
---> 69     L = np.linalg.cholesky(G)
     70     L = np.linalg.inv(L.T)
     71     return np.dot(L, np.dot(L.T, b))

C:\Python27\lib\site-packages\numpy\linalg\linalg.pyc in cholesky(a)
    529     results = lapack_routine(_L, n, a, m, 0)
    530     if results['info'] > 0:
--> 531         raise LinAlgError('Matrix is not positive definite - '
    532                 'Cholesky decomposition cannot be computed')
    533     s = triu(a, k=0).transpose()

LinAlgError: Matrix is not positive definite - Cholesky decomposition cannot be computed
```

The problem is that the rate-mode approximation of the neurons is giving NaN instead of 0 when the neuron doesn't fire.  This kills the A matrix rather badly.

The NaN is a known bug in numpy:

https://github.com/numpy/numpy/issues/4225

To fix this, we just add `r[j <= 0] = 0` to the rate calculation.
