### PR TITLE
Cracking down on not passing a Neuron type

### DIFF
--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -180,10 +180,8 @@ class Ensemble(object):
 
     @neurons.setter
     def neurons(self, _neurons):
-        if isinstance(_neurons, int):
-            logger.warning(("neurons should be an instance of a Neuron type, "
-                            "not an int. Defaulting to LIF."))
-            _neurons = nengo.LIF(_neurons)
+        if not isinstance(_neurons, Neurons):
+            raise TypeError('neurons must be a subclass of Neurons.')
 
         _neurons.dimensions = self.dimensions
         self._neurons = _neurons


### PR DESCRIPTION
We allowed people to pass ints for neurons for a while now because this was what we did in Nengo 1.4, and we wanted to ease the transition. Well, transition time's over! Sorry! (Also: not sorry.)

@tcstewar wanted to keep this around for representing a "default" neuron type. This PR's also serves as a discussion for how best to do this.

In unit tests, we switch neuron types by doing something like this:

``` python
for n_type in [nengo.LIF, nengo.LIFRate, nengo.Direct]:
    with nengo.Model():
       A = nengo.Ensemble(n_type(100), 1)
       ...
```

So, in user scripts, it would be something like

``` python
neurons = nengo.LIF  # Change to try out rate / direct mode
with nengo.Model():
    A = nengo.Ensemble(neurons(100), 1)
```

But should we do this some other way? One possibility would be to allow people to use `nengo.Neurons` directly, and allow the builder to choose what neuron type that corresponds to at build time.

``` python
with nengo.Model():
    A = nengo.Ensemble(nengo.Neurons(100), 1)
```

Any other possibilities spring to mind?
