### PR TITLE
Move probability distributions to utils/distributions.py

### DIFF
--- a/nengo/builder.py
+++ b/nengo/builder.py
@@ -7,6 +7,7 @@ import numpy as np
 import nengo
 import nengo.decoders
 import nengo.nonlinearities
+from nengo.utils.distributions import UniformHypersphere
 
 logger = logging.getLogger(__name__)
 
@@ -761,8 +762,8 @@ class Builder(object):
 
         # Generate eval points
         if ens.eval_points is None:
-            ens.eval_points = nengo.decoders.sample_hypersphere(
-                ens.dimensions, ens.EVAL_POINTS, rng) * ens.radius
+            ens.eval_points = UniformHypersphere(ens.dimensions).sample(
+                ens.EVAL_POINTS, rng=rng) * ens.radius
         else:
             ens.eval_points = np.array(ens.eval_points, dtype=np.float64)
             if ens.eval_points.ndim == 1:

--- a/nengo/decoders.py
+++ b/nengo/decoders.py
@@ -9,30 +9,6 @@ the associated functions will be placed here.
 
 import numpy as np
 
-
-def sample_hypersphere(dimensions, n_samples, rng, surface=False):
-    """Generate sample points from a hypersphere.
-
-    Returns float array of sample points: dimensions x n_samples
-
-    """
-    samples = rng.randn(n_samples, dimensions)
-
-    # normalize magnitude of sampled points to be of unit length
-    norm = np.sum(samples * samples, axis=1)
-    samples /= np.sqrt(norm)[:, np.newaxis]
-
-    if surface:
-        return samples
-
-    # generate magnitudes for vectors from uniform distribution
-    scale = rng.rand(n_samples, 1) ** (1.0 / dimensions)
-
-    # scale sample points
-    samples *= scale
-
-    return samples
-
 DEFAULT_RCOND = 0.01
 
 

--- a/nengo/nonlinearities.py
+++ b/nengo/nonlinearities.py
@@ -3,8 +3,8 @@ import logging
 
 import numpy as np
 
-import nengo.decoders
 from nengo.objects import Neurons
+from nengo.utils.distributions import UniformHypersphere
 
 logger = logging.getLogger(__name__)
 
@@ -75,8 +75,8 @@ class _LIFBase(Neurons):
         return self.n_neurons
 
     def default_encoders(self, dimensions, rng):
-        return nengo.decoders.sample_hypersphere(
-            dimensions, self.n_neurons, rng, surface=True)
+        sphere = UniformHypersphere(dimensions, surface=True)
+        return sphere.sample(self.n_neurons, rng=rng)
 
     def rates_from_current(self, J):
         """LIF firing rates in Hz for input current (incl. bias)"""

--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import nengo
 import nengo.decoders
+from nengo.utils.distributions import Uniform
 
 logger = logging.getLogger(__name__)
 
@@ -14,34 +15,6 @@ def _in_stack(function):
     import inspect
     codes = [record[0].f_code for record in inspect.stack()]
     return function.__code__ in codes
-
-
-class Uniform(object):
-
-    def __init__(self, low, high):
-        self.low = low
-        self.high = high
-
-    def __eq__(self, other):
-        return self.low == other.low and self.high == other.high
-
-    def sample(self, n, rng=None):
-        rng = np.random if rng is None else rng
-        return rng.uniform(low=self.low, high=self.high, size=n)
-
-
-class Gaussian(object):
-
-    def __init__(self, mean, std):
-        self.mean = mean
-        self.std = std
-
-    def __eq__(self, other):
-        return self.mean == other.mean and self.std == other.std
-
-    def sample(self, n, rng=None):
-        rng = np.random if rng is None else rng
-        return rng.normal(loc=self.mean, scale=self.std, size=n)
 
 
 class Neurons(object):

--- a/nengo/utils/distributions.py
+++ b/nengo/utils/distributions.py
@@ -1,0 +1,116 @@
+import numpy as np
+
+
+class Distribution(object):
+    """A base class for probability distributions.
+
+    The only thing that a probabilities distribution needs is a
+    ``sample`` function. This base class ensures that all distributions
+    accept the same arguments for the sample function.
+    """
+
+    def sample(self, n, rng=np.random):
+        raise NotImplementedError("Distributions should implement sample.")
+
+
+class Uniform(Distribution):
+    """A uniform distribution.
+
+    It's equally likely to get any scalar between ``low`` and ``high``.
+
+    Note that the order of ``low`` and ``high`` doesn't matter;
+    if ``low < high`` this will still work, and ``low`` will still
+    be a closed interval while ``high`` is open.
+
+    Parameters
+    ----------
+    low : Number
+        The closed lower bound of the uniform distribution; samples >= low
+    high : Number
+        The open upper bound of the uniform distribution; samples < high
+
+    """
+
+    def __init__(self, low, high):
+        self.low = low
+        self.high = high
+
+    def __eq__(self, other):
+        return self.low == other.low and self.high == other.high
+
+    def sample(self, n, rng=np.random):
+        return rng.uniform(low=self.low, high=self.high, size=n)
+
+
+class Gaussian(Distribution):
+    """A Gaussian distribution.
+
+    This represents a bell-curve centred at ``mean`` and with
+    spread represented by the standard deviation, ``std``.
+
+    Parameters
+    ----------
+    mean : Number
+        The mean of the Gaussian.
+    std : Number
+        The standard deviation of the Gaussian.
+
+    Raises
+    ------
+    ValueError if ``std <= 0``
+
+    """
+
+    def __init__(self, mean, std):
+        if std <= 0:
+            raise ValueError("std must be greater than 0; passed %f" % std)
+        self.mean = mean
+        self.std = std
+
+    def __eq__(self, other):
+        return self.mean == other.mean and self.std == other.std
+
+    def sample(self, n, rng=np.random):
+        return rng.normal(loc=self.mean, scale=self.std, size=n)
+
+
+class UniformHypersphere(Distribution):
+    """Distributions over an n-dimensional unit hypersphere.
+
+    Parameters
+    ----------
+    dimensions : Number
+        The dimensionality of the hypersphere; i.e., the length
+        of each sample point vector.
+    surface : bool
+        Whether sample points should be distributed uniformly
+        over the surface of the hyperphere (True),
+        or within the hypersphere (False).
+        Default: False
+
+    """
+
+    def __init__(self, dimensions, surface=False):
+        if dimensions < 1:
+            raise ValueError("Hypersphere must have dimensions > 0")
+        if not isinstance(dimensions, int):
+            raise ValueError("Hyperphere only defined for integer dimensions")
+        self.dimensions = dimensions
+        self.surface = surface
+
+    def sample(self, n, rng=np.random):
+        samples = rng.randn(n, self.dimensions)
+
+        # normalize magnitude of sampled points to be of unit length
+        norm = np.sum(samples * samples, axis=1)
+        samples /= np.sqrt(norm)[:, np.newaxis]
+
+        if self.surface:
+            return samples
+
+        # generate magnitudes for vectors from uniform distribution
+        scale = rng.rand(n, 1) ** (1.0 / self.dimensions)
+
+        # scale sample points
+        samples *= scale
+        return samples

--- a/nengo/utils/tests/test_distributions.py
+++ b/nengo/utils/tests/test_distributions.py
@@ -1,0 +1,66 @@
+import numpy as np
+import numpy.linalg  # noqa: F401
+import pytest
+
+import nengo
+import nengo.utils.distributions as dists
+
+
+@pytest.mark.parametrize("low,high", [(-2, -1), (-1, 1), (1, 2), (1, -1)])
+def test_uniform(low, high):
+    n = 100
+    dist = dists.Uniform(low, high)
+    samples = dist.sample(n, np.random.RandomState(1))
+    if low < high:
+        assert np.all(samples >= low)
+        assert np.all(samples < high)
+    else:
+        assert np.all(samples <= low)
+        assert np.all(samples > high)
+    hist, _ = np.histogram(samples, bins=5)
+    assert np.allclose(hist - np.mean(hist), 0, atol=0.1 * n)
+
+
+@pytest.mark.parametrize("mean,std", [(0, 1), (0, 0), (10, 2)])
+def test_gaussian(mean, std):
+    n = 100
+    if std <= 0:
+        with pytest.raises(ValueError):
+            dist = dists.Gaussian(mean, std)
+    else:
+        dist = dists.Gaussian(mean, std)
+        samples = dist.sample(n, np.random.RandomState(1))
+        assert abs(np.mean(samples) - mean) < std * 0.1
+        assert abs(np.std(samples) - std) < 1
+
+
+@pytest.mark.parametrize("dimensions", [0, 1, 2, 5])
+def test_hypersphere(dimensions):
+    n = 100 * dimensions
+    if dimensions < 1:
+        with pytest.raises(ValueError):
+            dist = dists.UniformHypersphere(dimensions)
+    else:
+        dist = dists.UniformHypersphere(dimensions)
+        samples = dist.sample(n, np.random.RandomState(1))
+        assert samples.shape == (n, dimensions)
+        assert np.allclose(
+            np.mean(samples, axis=0), np.zeros(dimensions), atol=0.1)
+        hist, _ = np.histogramdd(samples, bins=5)
+        assert np.allclose(hist - np.mean(hist), 0, atol=0.1 * n)
+
+
+@pytest.mark.parametrize("dimensions", [1, 2, 5])
+def test_hypersphere_surface(dimensions):
+    n = 100 * dimensions
+    dist = dists.UniformHypersphere(dimensions, surface=True)
+    samples = dist.sample(n, np.random.RandomState(1))
+    assert samples.shape == (n, dimensions)
+    assert np.allclose(np.linalg.norm(samples, axis=1), 1)
+    assert np.allclose(
+        np.mean(samples, axis=0), np.zeros(dimensions), atol=0.1)
+
+
+if __name__ == "__main__":
+    nengo.log(debug=True)
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
The weirdness of `sample_hypersphere` came up in #280. This makes hypersphere sampling have the same interface as Uniform and Gaussian, and organizes all three together in `utils.distributions`.

One discussion point: should these be imported into the `nengo` namespace? Are they going to be used frequently enough by users?
