### PR TITLE
Moved the location of the function check

### DIFF
--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -401,10 +401,6 @@ class Connection(object):
         self._postslice = post.slice
         self.probes = {'signal': []}
 
-        self.filter = filter
-        self.transform = transform
-        self.modulatory = modulatory
-
         if isinstance(self.pre, Ensemble):
             if isinstance(self.post, Ensemble):
                 self.weight_solver = kwargs.pop('weight_solver', None)
@@ -416,6 +412,10 @@ class Connection(object):
         elif not isinstance(self.pre, (Neurons, Node)):
             raise ValueError("Objects of type '%s' cannot serve as 'pre'" %
                              (self.pre.__class__.__name__))
+
+        self.filter = filter
+        self.transform = transform
+        self.modulatory = modulatory
 
         if not isinstance(self.post, (Ensemble, Neurons, Node, Probe)):
             raise ValueError("Objects of type '%s' cannot serve as 'post'" %


### PR DESCRIPTION
Moved the check for a function to _before_ the transform
matrix is made with slicing. Resolves the following error.

When I tried to connect two ensembles using the indexing with a function I get an error 

```
ValueError: Ensemble output size (2) not equal to Ensemble input size (1)
```

Here's the code I was running.

```
import numpy as np

import nengo

N = 10
model = nengo.Model('test')
with model: 
    # input relays
    input0 = nengo.Node(output=[.5])

    a = nengo.Ensemble(neurons=N, dimensions=2)
    b = nengo.Ensemble(neurons=N, dimensions=2)

    # connect up 
    def func(x):
        return [-x[0]]
    nengo.Connection(a, b[0], function=func)

    # probes
    in0_probe = nengo.Probe(input0, 'output')
    b = nengo.Probe(b, 'decoded_output', filter=.1)

sim = nengo.Simulator(model, dt=.001)
```
