### PR TITLE
Checks to see if a list was passed in for indices

### DIFF
--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -391,10 +391,12 @@ class Connection(object):
 
         # Create the new transform matching the pre/post dimensions
         new_transform = np.zeros((out_dims, in_dims))
-        if type(self._postslice) is list and type(self._preslice) is list:
-            new_transform[self._postslice, self._preslice] = np.diag(transform)
-        else:
-            new_transform[self._postslice, self._preslice] = transform
+        rows_transform = np.array(new_transform[self._postslice])
+        rows_transform[:, self._preslice] = transform
+        new_transform[self._postslice] = rows_transform
+        # Note: the above is a little obscure, but we do it so that lists of
+        #  indices can specify selections of rows and columns, rather than
+        #  just individual items
 
         # Note: Calling _check_shapes after this, is (or, should be) redundant
         return new_transform

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -265,7 +265,7 @@ def test_dimensionality_errors(nl_nodirect):
         nengo.Connection(e2[0], e2, transform=[[1, 2]])
 
 
-def test_connection_slicing(Simulator, nl_nodirect):
+def test_slicing(Simulator, nl_nodirect):
     name = 'connection_slicing'
     N = 30
 
@@ -332,6 +332,14 @@ def test_connection_slicing(Simulator, nl_nodirect):
     assert np.all(conn.transform_full == np.array([[6, 5, 4],
                                                    [0, 0, 0],
                                                    [3, 2, 1]]))
+
+    # Both slices using lists
+    conn = nengo.Connection(neurons3[[1, 0, 2]], neurons3[[2, 1]],
+                            transform=[[1, 2, 3], [4, 5, 6]])
+    assert np.all(conn.transform == np.array([[1, 2, 3], [4, 5, 6]]))
+    assert np.all(conn.transform_full == np.array([[0, 0, 0],
+                                                   [5, 4, 6],
+                                                   [2, 1, 3]]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Takes care of the error encountered when doing something like: 

```
nengo.Connection(a[[0,2,3]], b[[0,3,4]])
```

Here's a test script:

```
import numpy as np

import nengo

N = 10
model = nengo.Model('test')
with model: 
    # input relays
    input0 = nengo.Node(output=[.5])

    a = nengo.Ensemble(neurons=N, dimensions=4)
    b = nengo.Ensemble(neurons=N, dimensions=5)

    # connect up 
    nengo.Connection(a[[0,2,3]], b[[0,3,4]])
    nengo.Connection(a[[0,2,3]], b[0:3])
    nengo.Connection(a[0:3], b[0:3])

    # probes
    in0_probe = nengo.Probe(input0, 'output')
    b = nengo.Probe(b, 'decoded_output', filter=.1)

sim = nengo.Simulator(model, dt=.001)
```
