### PR TITLE
Added filter to direct connections where filter < dt.

### DIFF
--- a/nengo/builder.py
+++ b/nengo/builder.py
@@ -996,8 +996,13 @@ class Builder(object):
             # Direct connection
             signal = self.model.sig_in[conn]
 
-        # Add operator for filtering
-        if decoders is None and conn.filter is not None and conn.filter > dt:
+        # Add operator for filtering (in the case filter wasn't already
+        # added, when pre.neurons is a non-direct Ensemble)
+        if decoders is None and conn.filter is not None:
+            # Note: we add a filter here even if filter < dt,
+            # in order to avoid cycles in the op graph. If the filter
+            # is explicitly set to None (e.g. for a passthrough node)
+            # then cycles can still occur.
             signal = self.filtered_signal(signal, conn.filter)
 
         if conn.modulatory:

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -348,6 +348,28 @@ def test_slicing(Simulator, nl_nodirect):
                                                        [2, 1, 3]]))
 
 
+def test_shortfilter(Simulator, nl):
+    # Testing the case where the connection filter is < dt
+    m = nengo.Network()
+    with m:
+        a = nengo.Ensemble(neurons=nl(10), dimensions=1)
+        nengo.Connection(a, a)
+
+        b = nengo.Ensemble(neurons=nl(10), dimensions=1)
+        nengo.Connection(a, b)
+        nengo.Connection(b, a)
+
+    Simulator(model=m, dt=.01)
+    # This test passes if there are no cycles in the op graph
+
+    # We will still get a cycle if the user explicitly sets the
+    # filter to None
+    with m:
+        d = nengo.Ensemble(neurons=nengo.Direct(10), dimensions=1)
+        nengo.Connection(d, d, filter=None)
+    with pytest.raises(ValueError):
+        Simulator(model=m, dt=.01)
+
 if __name__ == "__main__":
     nengo.log(debug=True)
     pytest.main([__file__, '-v'])

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -88,8 +88,8 @@ def test_alif_rate(Simulator):
                            max_rates=max_rates,
                            intercepts=intercepts,
                            encoders=encoders)
-        nengo.Connection(u, a, filter=0)
-        ap = nengo.Probe(a.neurons, "output", filter=0.001)
+        nengo.Connection(u, a, filter=None)
+        ap = nengo.Probe(a.neurons, "output", filter=None)
 
     dt = 1e-3
     sim = Simulator(model, dt=dt)


### PR DESCRIPTION
Fix for Issue #319.

The problem was that if you had a direct connection with no filter you wound up with cycles in the op graph (generally we use the decoder ProdUpdate or the filter ProdUpdate operation to terminate the operation cycle in a given timestep).  

I went with a compromise in fixing this.  If the user sets filter < dt, in the past we were omitting the filter operation.  I have changed this now so that we leave the filter in (with filter==dt).  This is designed to catch the case where the user does not really intend to omit the filter, so would be pretty surprised at the cycle problem.

If the user sets `filter=None`, I don't add anything.  This means that you don't end up with an extra timestep delay (for things like Passthrough nodes).  In most cases this won't result in any cycles anyway, because there will be some other operations to break the cycle downstream.  I figure since the user has to explicitly choose to set `filter=None`, we can assume that that is really what they want, and leave the consequences (possible cycles) in their hands.
