### PR TITLE
SignalDict can set readonly items

### DIFF
--- a/nengo/builder.py
+++ b/nengo/builder.py
@@ -321,58 +321,76 @@ class SignalDict(dict):
     these arrays never get copied, which wastes time and space.
 
     Use ``init`` to set the ndarray initially.
-    """
 
-    def __getitem__(self, obj):
+    Attributes
+    ----------
+    readonly : list of Signals
+        A list of Signals that are marked as readonly.
+       Their associated ndarrays cannot be modified.
+    """
+    def __init__(self, *args, **kwargs):
+        self.readonly = []
+        super(SignalDict, self).__init__(*args, **kwargs)
+
+    def __getitem__(self, sig):
         """SignalDict overrides __getitem__ for two reasons.
 
         1. so that scalars are returned as 0-d ndarrays
         2. so that a SignalView lookup returns a views of its base
         """
-        if obj in self:
-            return dict.__getitem__(self, obj)
-        elif obj.base in self:
+        if sig in self:
+            return dict.__getitem__(self, sig)
+        elif sig.base in self:
             # look up views as a fallback
             # --work around numpy's special case behaviour for scalars
-            base_array = self[obj.base]
-            try:
-                # for some installations, this works
-                itemsize = int(obj.dtype.itemsize)
-            except TypeError:
-                # other installations, this...
-                itemsize = int(obj.dtype().itemsize)
-            byteoffset = itemsize * obj.offset
-            bytestrides = [itemsize * s for s in obj.elemstrides]
-            view = np.ndarray(shape=obj.shape,
-                              dtype=obj.dtype,
+            base_array = self[sig.base]
+            itemsize = int(sig.dtype.itemsize)
+            byteoffset = itemsize * sig.offset
+            bytestrides = [itemsize * s for s in sig.elemstrides]
+            view = np.ndarray(shape=sig.shape,
+                              dtype=sig.dtype,
                               buffer=base_array.data,
                               offset=byteoffset,
                               strides=bytestrides)
+            if not base_array.flags.writeable:
+                # Ensure readonly ndarrays have readonly views
+                view.flags.writeable = False
             return view
         else:
             raise KeyError("%s has not been initialized. Please call "
-                           "SignalDict.init first." % (str(obj)))
+                           "SignalDict.init first." % (str(sig)))
 
-    def __setitem__(self, key, val):
+    def __setitem__(self, sig, ndarray):
         """Ensures that ndarrays stay in the same place in memory.
 
-        Unlike normal dicts, this means that you cannot add a new key
+        Unlike normal dicts, this means that you cannot add a new signal
         to a SignalDict using __setitem__. This is by design, to avoid
-        silent typos when debugging Simulator. Every key must instead
+        silent typos when debugging Simulator. Every signal must instead
         be explicitly initialized with SignalDict.init.
         """
-        self.__getitem__(key)[...] = val
+        if sig in self.readonly:
+            # Using mostly the same error message as numpy for consistency
+            raise ValueError("assignment destination is read-only: %s" % sig)
+        self.__getitem__(sig)[...] = ndarray
 
     def __str__(self):
         """Pretty-print the signals and current values."""
         sio = StringIO()
-        for k in self:
-            sio.write("%s %s\n" % (repr(k), repr(self[k])))
+        for sig in self:
+            sio.write("%s %s\n" % (repr(sig), repr(self[sig])))
         return sio.getvalue()
 
-    def init(self, signal, ndarray):
-        """Set up a permanent mapping from signal -> ndarray."""
-        dict.__setitem__(self, signal, ndarray)
+    def init(self, sig, ndarray, readonly=False):
+        """Set up a permanent mapping from sig -> ndarray.
+
+        If readonly is set, then it will be added to self.readonly in order
+        to raise an error in __setitem__. We will also set that ndarray's
+        writeable flag to false to ensure that it is indeed a readonly signal.
+        """
+        if readonly:
+            self.readonly.append(sig)
+            ndarray.flags.writeable = False
+        dict.__setitem__(self, sig, ndarray)
 
 
 class Operator(object):


### PR DESCRIPTION
It came up in #85 that some backends (e.g. nengo_ocl) make the SignalDict available, but the ndarrays are not actually modifiable despite seeming that way. This makes it possible to init signals with readonly ndarrays. Their readonly status is tracked and ensured by the SignalDict.

Other changes
- Changed all key, value names to sig, ndarray to make the SignalDict easier to read/understand
- Added tests to ensure readonly status
