### PR TITLE
Use warnings module for warnings

### DIFF
--- a/nengo/builder.py
+++ b/nengo/builder.py
@@ -2,6 +2,7 @@
 
 import collections
 import logging
+import warnings
 
 import numpy as np
 
@@ -662,8 +663,7 @@ class Builder(object):
             # two different Ensembles, which is unlikely to be desired.
 
             # TODO: Prevent this at pre-build validation time.
-            logger.warning("Object '%s' has already been built in model "
-                           "'%s'." % (str(obj), model.label))
+            warnings.warn("Object '%s' has already been built." % obj)
             return
 
         for obj_cls in obj.__class__.__mro__:

--- a/nengo/utils/logging.py
+++ b/nengo/utils/logging.py
@@ -47,3 +47,4 @@ def log(debug=False, path=None):
             handler.setFormatter(file_formatter)
             logging.root.addHandler(handler)
     handler.setLevel(level)
+    logging.captureWarnings(True)


### PR DESCRIPTION
Previously we used logging.warning. However, by default, there is no logger installed, so they were never being shown. Warnings are probably worth showing, so we'll use the warnings module instead. This sends warning to `stderr`, so its probably not intrusive in any way.

There was only one warning, it turns out! But still, this came up in #318 so we should show it.
