### PR TITLE
WIP: List slicing of objects is more intuitive

### DIFF
--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -593,7 +593,8 @@ class Connection(NengoObject):
 
     def _pad_transform(self, transform):
         """Pads the transform with zeros according to the pre/post slices."""
-        if self._preslice == slice(None) and self._postslice == slice(None):
+        if (self._preslice == slice(None) and self._postslice == slice(None)
+                and transform.ndim != 1):
             # Default case when unsliced objects are passed to __init__
             return transform
 
@@ -607,20 +608,27 @@ class Connection(NengoObject):
         # Check that the given transform matches the pre/post slices sizes
         self._check_transform(transform, (post_sliced_size, pre_sliced_size))
 
-        # Cast scalar transforms to the identity
-        if transform.ndim == 0:
-            # following assertion should be guaranteed by _check_transform
-            assert pre_sliced_size == post_sliced_size
-            transform = transform*np.eye(pre_sliced_size)
-
         # Create the new transform matching the pre/post dimensions
         new_transform = np.zeros((out_dims, in_dims))
-        rows_transform = np.array(new_transform[self._postslice])
-        rows_transform[:, self._preslice] = transform
-        new_transform[self._postslice] = rows_transform
-        # Note: the above is a little obscure, but we do it so that lists of
-        #  indices can specify selections of rows and columns, rather than
-        #  just individual items
+        if transform.ndim < 2:
+            slice_to_list = lambda s, d: (
+                np.arange(d)[s] if isinstance(s, slice) else s)
+            preslice = slice_to_list(self._preslice, in_dims)
+            postslice = slice_to_list(self._postslice, out_dims)
+            new_transform[postslice, preslice] = transform
+        else:  #if transform.ndim == 2:
+            repeated_inds = lambda x: (
+                not isinstance(x, slice) and np.unique(x).size != len(x))
+            if repeated_inds(self._preslice) or repeated_inds(self._postslice):
+                raise ValueError("%s object selection has repeated indices" %
+                                 ("Input" if repeated_inds(self._preslice)
+                                  else "Output"))
+            rows_transform = np.array(new_transform[self._postslice])
+            rows_transform[:, self._preslice] = transform
+            new_transform[self._postslice] = rows_transform
+            # Note: the above is a little obscure, but we do it so that lists of
+            #  indices can specify selections of rows and columns, rather than
+            #  just individual items
 
         # Note: Calling _check_shapes after this, is (or, should be) redundant
         return new_transform
@@ -646,13 +654,18 @@ class Connection(NengoObject):
         if out_src == "Probe":
             return
         out_dims, in_dims = required_shape
-        if transform.ndim == 0:
+        if transform.ndim < 2:
+            if transform.ndim == 1 and transform.size != out_dims:
+                raise ValueError("Transform length (%d) not equal to "
+                                 "%s output size (%d)" %
+                                 (transform.size, out_src, out_dims))
+
             # check input dimensionality matches output dimensionality
             if in_dims != out_dims:
                 raise ValueError("%s output size (%d) not equal to "
                                  "%s input size (%d)" %
                                  (in_src, in_dims, out_src, out_dims))
-        else:
+        elif transform.ndim == 2:
             # check input dimensionality matches transform
             if in_dims != transform.shape[1]:
                 raise ValueError("%s output size (%d) not equal to "
@@ -664,6 +677,9 @@ class Connection(NengoObject):
                 raise ValueError("Transform output size (%d) not equal to "
                                  "%s input size (%d)" %
                                  (transform.shape[0], out_src, out_dims))
+        else:
+            raise ValueError("Cannot handle transform tensors "
+                             "with dimensions > 2")
 
     @property
     def label(self):

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -390,6 +390,39 @@ def test_unsupervised_learning_rule(Simulator, nl_nodirect, learning_rule):
     sim.run(1.)
 
 
+def test_vector(Simulator, nl):
+    name = 'vector'
+    N1, N2 = 50, 50
+    transform = [-1, 0.5]
+
+    m = nengo.Network(label=name, seed=123)
+    with m:
+        u = nengo.Node(output=[0.5, 0.5])
+        a = nengo.Ensemble(nl(N1), dimensions=2)
+        b = nengo.Ensemble(nl(N2), dimensions=2)
+        nengo.Connection(u, a)
+        nengo.Connection(a, b, transform=transform)
+
+        up = nengo.Probe(u, 'output')
+        ap = nengo.Probe(a, synapse=0.03)
+        bp = nengo.Probe(b, synapse=0.03)
+
+    sim = Simulator(m)
+    sim.run(1.0)
+    t = sim.trange()
+    x = sim.data[up]
+    y = x * transform
+    yhat = sim.data[bp]
+
+    with Plotter(Simulator, nl) as plt:
+        plt.plot(t, y, '--')
+        plt.plot(t, yhat)
+        plt.savefig('test_connection.test_' + name + '.pdf')
+        plt.close()
+
+    assert np.allclose(y[-10:], yhat[-10:], atol=.1, rtol=.01)
+
+
 def test_dimensionality_errors(nl_nodirect):
     N = 10
     with nengo.Network(label="test_dimensionality_error") as m:
@@ -407,6 +440,7 @@ def test_dimensionality_errors(nl_nodirect):
         nengo.Connection(n21, e1)
         nengo.Connection(e1.neurons, n21, transform=np.random.randn(2, N))
         nengo.Connection(e2, e1, function=lambda x: x[0])
+        nengo.Connection(e2, e2, transform=np.ones(2))
 
         # these should not work
         with pytest.raises(ValueError):
@@ -421,6 +455,10 @@ def test_dimensionality_errors(nl_nodirect):
             nengo.Connection(e2, e1, function=lambda x: x, transform=[[1]])
         with pytest.raises(ValueError):
             nengo.Connection(n21, e2, transform=np.ones((2, 2)))
+        with pytest.raises(ValueError):
+            nengo.Connection(e2, e2, transform=np.ones((2, 2, 2)))
+        with pytest.raises(ValueError):
+            nengo.Connection(e2, e2, transform=np.ones(3))
 
         # these should not work because of indexing mismatches
         with pytest.raises(ValueError):
@@ -511,6 +549,27 @@ def test_slicing(Simulator, nl_nodirect):
         assert np.all(conn.transform_full == np.array([[0, 0, 0],
                                                        [5, 4, 6],
                                                        [2, 1, 3]]))
+
+        # using vector
+        conn = nengo.Connection(ens3[[1, 0, 2]], ens3[[2, 0, 1]],
+                                transform=[1, 2, 3])
+        assert np.all(conn.transform == np.array([1, 2, 3]))
+        assert np.all(conn.transform_full == np.array([[2, 0, 0],
+                                                       [0, 0, 3],
+                                                       [0, 1, 0]]))
+
+        # using vector and lists
+        conn = nengo.Connection(ens3[[1, 0, 2]], ens3[[2, 0, 1]],
+                                transform=[1, 2, 3])
+        assert np.all(conn.transform == np.array([1, 2, 3]))
+        assert np.all(conn.transform_full == np.array([[2, 0, 0],
+                                                       [0, 0, 3],
+                                                       [0, 1, 0]]))
+
+        # using multi-index lists
+        conn = nengo.Connection(ens3, ens2[[0, 1, 0]])
+        assert np.all(conn.transform_full == np.array([[1, 0, 1],
+                                                       [0, 1, 0]]))
 
 
 def test_shortfilter(Simulator, nl):


### PR DESCRIPTION
This is a fix for #343, which I think makes slicing more intuitive. You can do things like @studywolf wanted in #343, and you can also pass vectors as transforms (see `test_connection:test_vector`).

My only hesitation is that passing a vector versus a matrix significantly changes the way the indexing works. We previously had something like this in the case of scalars, with scalars being transformed into the identity matrix. So I don't think it's really a problem, but I'm interested to hear what everyone thinks.

I've labelled this WIP since some of the code is a bit hacky right now, and I plan on refactoring it a bit before merging.
