### PR TITLE
Changed sim.trange() to use arange instead of linspace

### DIFF
--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -227,5 +227,5 @@ class Simulator(object):
 
     def trange(self, dt=None):
         dt = self.dt if dt is None else dt
-        n_steps = int(self.n_steps / (dt / self.dt))
+        n_steps = int(np.ceil(self.n_steps * self.dt / dt))
         return dt * np.arange(0, n_steps)

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -66,6 +66,20 @@ def test_time_absolute(Simulator):
     assert np.allclose(sim.trange(), [0.00, .001, .002])
 
 
+def test_trange_with_probes(Simulator):
+    dt = 1e-3
+    m = nengo.Network()
+    periods = dt * np.arange(1, 21)
+    with m:
+        u = nengo.Node(output=np.sin)
+        probes = [nengo.Probe(u, sample_every=p, synapse=5*p) for p in periods]
+
+    sim = Simulator(m, dt=dt)
+    sim.run(0.333)
+    for i, p in enumerate(periods):
+        assert len(sim.trange(p)) == len(sim.data[probes[i]])
+
+
 def test_signal_indexing_1(RefSimulator):
     one = Signal(np.zeros(1), name="a")
     two = Signal(np.zeros(2), name="b")


### PR DESCRIPTION
This more accurately reflects the actual simulation timesteps.  E.g.

``` python
sim = nengo.Simulator(dt=0.5)
sim.run(2.0) # runs at 4 timesteps: 0.0, 0.5, 1.0, 1.5
sim.trange() # returns 0.0, 0.66, 1.33, 2.0
```

Basically linspace tries to space things evenly, whereas arange gives you the actual `dt` intervals.

Not a very critical change, just thought I'd get it in there before I forget.

I'm also sneaking in a small change to the error returned when you get a TypeError from a Node function.  It's helpful to get the actual TypeError, since it is very possible that your Node function throws a TypeError unrelated to argument dimensions.  Seemed silly to make a 4 character change its own PR though.
