### PR TITLE
Enforce Node output is callable when size_in!=0

### DIFF
--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -434,7 +434,7 @@ def test_dimensionality_errors(nl_nodirect):
         m.config[nengo.Ensemble].neuron_type = nl_nodirect()
         n01 = nengo.Node(output=[1])
         n02 = nengo.Node(output=[1, 1])
-        n21 = nengo.Node(output=[1], size_in=2)
+        n21 = nengo.Node(output=lambda t, x: [1], size_in=2)
         e1 = nengo.Ensemble(N, 1)
         e2 = nengo.Ensemble(N, 2)
 
@@ -457,6 +457,8 @@ def test_dimensionality_errors(nl_nodirect):
             nengo.Connection(e2.neurons, e1, transform=np.random.randn(2, N))
         with pytest.raises(ValueError):
             nengo.Connection(e2, e1, function=lambda x: x, transform=[[1]])
+        with pytest.raises(TypeError):
+            nengo.Connection(e2, e1, function=lambda: 0, transform=[[1]])
         with pytest.raises(ValueError):
             nengo.Connection(n21, e2, transform=np.ones((2, 2)))
 

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -162,10 +162,15 @@ def test_function_args_error(Simulator):
     with nengo.Network(label="test_function_args_error", seed=0):
         with pytest.raises(TypeError):
             nengo.Node(output=lambda t, x: x+1)
+        nengo.Node(output=lambda t, x=[0]: t+1, size_in=1)
         with pytest.raises(TypeError):
             nengo.Node(output=lambda t: t+1, size_in=1)
         with pytest.raises(TypeError):
             nengo.Node(output=lambda t, x, y: t+1, size_in=2)
+        with pytest.raises(TypeError):
+            nengo.Node(output=[0], size_in=1)
+        with pytest.raises(TypeError):
+            nengo.Node(output=0, size_in=1)
 
 
 def test_output_shape_error(Simulator):

--- a/nengo/utils/inspect.py
+++ b/nengo/utils/inspect.py
@@ -1,0 +1,27 @@
+"""Utility functions related to the inspect module."""
+
+from __future__ import absolute_import
+
+from collections import namedtuple
+import inspect
+
+CheckedCall = namedtuple('CheckedCall', ('value', 'invoked'))
+
+
+def checked_call(func, *args, **kwargs):
+    """Calls func(*args, **kwargs) and checks that invocation was successful.
+
+    The namedtuple ``(value=func(*args, **kwargs), invoked=True)`` is returned
+    if the call is successful. If an exception occurs inside of ``func``, then
+    that exception will be raised. Otherwise, if the exception occurs as a
+    result of invocation, then ``(value=None, invoked=False)`` is returned.
+
+    Assumes that func is callable.
+    """
+    try:
+        return CheckedCall(func(*args, **kwargs), True)
+    except:
+        tb = inspect.trace()
+        if not len(tb) or tb[-1][0] is not inspect.currentframe():
+            raise  # exception occurred inside func
+    return CheckedCall(None, False)

--- a/nengo/utils/tests/test_inspect.py
+++ b/nengo/utils/tests/test_inspect.py
@@ -1,0 +1,75 @@
+import logging
+
+import numpy as np
+import pytest
+
+import nengo
+from nengo.utils.inspect import checked_call
+
+logger = logging.getLogger(__name__)
+
+
+def test_checked_call():
+    def func1(a):
+        return a
+
+    def func2(a, b=0, **kwargs):
+        return a+b
+
+    def func3(a, b=0, c=0, *args, **kwargs):
+        return a+b+c+sum(args)
+
+    func4 = lambda x=[0]: sum(x)
+
+    class A(object):
+        def __call__(self, a, b):
+            return a + b
+
+    assert checked_call(func1) == (None, False)
+    assert checked_call(func1, 1) == (1, True)
+    assert checked_call(func1, 1, 2) == (None, False)
+    assert checked_call(func1, 1, two=2) == (None, False)
+
+    assert checked_call(func2) == (None, False)
+    assert checked_call(func2, 1) == (1, True)
+    assert checked_call(func2, 1, 2) == (3, True)
+    assert checked_call(func2, 1, 2, three=3) == (3, True)
+    assert checked_call(func2, 1, 2, 3) == (None, False)
+
+    assert checked_call(func3) == (None, False)
+    assert checked_call(func3, 1) == (1, True)
+    assert checked_call(func3, 1, 2) == (3, True)
+    assert checked_call(func3, 1, 2, 3) == (6, True)
+    assert checked_call(func3, 1, 2, 3, 4, 5, 6) == (21, True)
+
+    assert checked_call(func4) == (0, True)
+    assert checked_call(func4, [1, 2]) == (3, True)
+    assert checked_call(func4, [1], 2) == (None, False)
+
+    assert checked_call(A(), 1) == (None, False)
+    assert checked_call(A(), 1, 2) == (3, True)
+    assert checked_call(A(), 1, 2, 3) == (None, False)
+
+    assert checked_call(np.sin) == (None, False)
+    assert checked_call(np.sin, 0) == (0, True)
+    assert checked_call(np.sin, 0, np.array([1])) == (np.array([0]), True)
+    assert checked_call(np.sin, 0, np.array([1]), 1) == (None, False)
+
+
+def test_checked_call_errors():
+    class A(object):
+        def __call__(self, a):
+            raise NotImplementedError()
+
+    assert checked_call(A()) == (None, False)
+    with pytest.raises(NotImplementedError):
+        checked_call(A(), 1)
+
+    assert checked_call(np.sin, 1, 2, 3) == (None, False)
+    with pytest.raises(ValueError):
+        checked_call(lambda x: np.sin(1, 2, 3), 1)
+
+
+if __name__ == "__main__":
+    nengo.log(debug=True)
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
Fixes #305.

Also added a fix for a problem where if the `output` callable happens to raise a `TypeError`, then you get a confusing error message that says ".. takes _X_ argument(s), ... expected to take _X_ argument(s)". This happened to me more than once. In general, the practice of handling a general exception from an unknown function should be avoided unless the assumption is self-evident (e.g. catching a `SyntaxError` from within an `eval`). This is much safer.
