### PR TITLE
Handle function arguments on Node->* Connections

### DIFF
--- a/nengo/builder.py
+++ b/nengo/builder.py
@@ -1182,9 +1182,10 @@ def build_connection(conn, model, config):  # noqa: C901
     transform = np.array(conn.transform_full, dtype=np.float64)
 
     # Figure out the signal going across this connection
-    if (isinstance(conn.pre, nengo.objects.Ensemble)
-            and isinstance(conn.pre.neuron_type, nengo.neurons.Direct)):
-        # Decoded connection in directmode
+    if (isinstance(conn.pre, nengo.objects.Node) or
+            (isinstance(conn.pre, nengo.Ensemble) and
+             isinstance(conn.pre.neuron_type, nengo.neurons.Direct))):
+        # Node or Decoded connection in directmode
         if conn.function is None:
             signal = model.sig[conn]['in']
         else:


### PR DESCRIPTION
### Original Issue in nengo-sprint

**@tcstewar commented on 2 May**
Right now, if you do a connection where the `pre` object is a Node, Nengo silently ignores the function argument. This should either be handled or throw an error saying we don't support that.

**@e2crawfo commented on 4 May**
We'll handle this.
