### PR TITLE
RebuildNode

### DIFF
--- a/nengo/builder.py
+++ b/nengo/builder.py
@@ -1108,12 +1108,14 @@ def build_node(node, model, config):
     elif not is_callable(node.output):
         model.sig[node]['out'] = Signal(node.output, name=node.label)
     else:
-        sig_in, sig_out = build_pyfunc(fn=node.output,
-                                       t_in=True,
-                                       n_in=node.size_in,
-                                       n_out=node.size_out,
-                                       label="%s.pyfn" % node.label,
-                                       model=model)
+        sig_in, sig_out, outOp = build_pyfunc(fn=node.output,
+                                              t_in=True,
+                                              n_in=node.size_in,
+                                              n_out=node.size_out,
+                                              label="%s.pyfn" % node.label,
+                                              model=model)
+        node.outputOp = outOp
+
         if sig_in is not None:
             model.add_op(DotInc(model.sig[node]['in'],
                                 model.sig['common'][1],
@@ -1125,6 +1127,15 @@ def build_node(node, model, config):
     model.params[node] = None
 
 Builder.register_builder(build_node, nengo.objects.Node)
+
+def rebuild_node_output(node, model):
+    # Provide output
+    if is_callable(node.output):
+        #Do we need to create an input signal?
+        node.outputOp = SimPyFunc(output=model.sig['out'][node], fn=node.output, t_in=True, x=None)
+        model.operators.append(node.outputOp)
+    else:
+        model.sig['out'][node].value = np.asarray(node.output, dtype=np.float64)
 
 
 def conn_probe(pre, probe, **conn_args):
@@ -1221,7 +1232,7 @@ def build_connection(conn, model, config):  # noqa: C901
         if conn.function is None:
             signal = model.sig[conn]['in']
         else:
-            sig_in, signal = build_pyfunc(
+            sig_in, signal, _ = build_pyfunc(
                 fn=conn.function,
                 t_in=False,
                 n_in=model.sig[conn]['in'].size,
@@ -1381,9 +1392,10 @@ def build_pyfunc(fn, t_in, n_in, n_out, label, model):
     else:
         sig_out = None
 
-    model.add_op(SimPyFunc(output=sig_out, fn=fn, t_in=t_in, x=sig_in))
+    outOp = SimPyFunc(output=sig_out, fn=fn, t_in=t_in, x=sig_in)
+    model.add_op(outOp)
 
-    return sig_in, sig_out
+    return sig_in, sig_out, outOp
 
 
 def build_discrete_filter_synapse(

--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -447,7 +447,11 @@ class Node(NengoObject):
         self.size_in = size_in
         self.size_out = size_out
         self.probeable = Default
+        self.outputOp = None
 
+        self.init()
+
+    def init(self):
         if self.output is not None and not is_callable(self.output):
             self.output = npext.array(self.output, min_dims=1, copy=False)
 

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy as np
 
-from nengo.builder import Model, Builder, SignalDict
+from nengo.builder import Model, Builder, SignalDict, rebuild_node_output
 from nengo.utils.graphs import toposort
 from nengo.utils.simulator import operator_depencency_graph
 
@@ -161,6 +161,14 @@ class Simulator(object):
             if i % 1000 == 0:
                 logger.debug("Step %d", i)
             self.step()
+
+    def rebuild_node(self, node, output):
+        # Rebuilds a node with a new output source
+        node.output = output
+        node.init()
+        if (node.outputOp):
+            self.model.operators.remove(node.outputOp)
+        rebuild_node_output(node, self.model)
 
     def trange(self, dt=None):
         dt = self.dt if dt is None else dt

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -11,6 +11,46 @@ from nengo.builder import (
 logger = logging.getLogger(__name__)
 
 
+def test_reset(RefSimulator):
+    """Tests the ability to restart the simulator without rebuilding"""
+    m = nengo.Network(label='test_reset')
+    with m:
+        sin = nengo.Node(output=np.sin)
+        sin_p = nengo.Probe(sin, 'output', sample_every=.01)
+    sim = RefSimulator(m)
+    sim.run(1)
+    d1 = sim.data[sin_p]
+    sim.reset()
+    sim.run(1)
+    d2 = sim.data[sin_p]
+    assert np.all(d1 == d2)
+
+
+def test_change_input(RefSimulator):
+    """Tests the ability to reset the simulator and rebuild input nodes without rebuilding everything"""
+    m = nengo.Network(label='test_change_input')
+    with m:
+        m.config[nengo.Ensemble].neuron_type = nengo.Direct()
+        inputNode1 = nengo.Node(output=np.cos, label="TestNode")
+        inputNode2 = nengo.Node(output=0.5, label="TestNode")
+        e1 = nengo.Ensemble(1, 1)
+        e2 = nengo.Ensemble(1, 1)
+        c1 = nengo.Connection(inputNode1, e1)
+        c2 = nengo.Connection(inputNode2, e2)
+        p1 = nengo.Probe(e, 'decoded_output', sample_every=.01)
+        p2 = nengo.Probe(e2, 'decoded_output', sample_every=.01)
+    sim = RefSimulator(m)
+    sim.run(1)
+    d1 = sim.data[p1]
+    print d1[0:10]
+    sim.rebuild_node(inputNode, output=1)
+    sim.reset()
+    sim.run(1)
+    d2 = sim.data[p1]
+    print d2[0:10]
+    assert np.all(d1 != d2)
+
+
 def test_steps(RefSimulator):
     m = nengo.Network(label="test_steps")
     sim = RefSimulator(m)
@@ -87,7 +127,7 @@ def test_simple_pyfunc(RefSimulator):
     time = Signal(np.zeros(1), name="time")
     sig = Signal(np.zeros(1), name="sig")
     m = Model(dt=dt)
-    sig_in, sig_out = build_pyfunc(lambda t, x: np.sin(x), True, 1, 1, None, m)
+    sig_in, sig_out, _ = build_pyfunc(lambda t, x: np.sin(x), True, 1, 1, None, m)
     m.operators += [
         ProdUpdate(Signal(dt), Signal(1), Signal(1), time),
         DotInc(Signal([[1.0]]), time, sig_in),
@@ -110,7 +150,7 @@ def test_encoder_decoder_pathway(RefSimulator):
     decoders = np.asarray([.2, .1])
     decs = Signal(decoders * 0.5)
     m = Model(dt=0.001)
-    sig_in, sig_out = build_pyfunc(lambda t, x: x + 1, True, 2, 2, None, m)
+    sig_in, sig_out, _ = build_pyfunc(lambda t, x: x + 1, True, 2, 2, None, m)
     m.operators += [
         DotInc(Signal([[1.0], [2.0]]), foo, sig_in),
         ProdUpdate(decs, sig_out, Signal(0.2), foo)
@@ -156,7 +196,7 @@ def test_encoder_decoder_with_views(RefSimulator):
     foo = Signal([1.0], name="foo")
     decoders = np.asarray([.2, .1])
     m = Model(dt=0.001)
-    sig_in, sig_out = build_pyfunc(lambda t, x: x + 1, True, 2, 2, None, m)
+    sig_in, sig_out, _ = build_pyfunc(lambda t, x: x + 1, True, 2, 2, None, m)
     m.operators += [
         DotInc(Signal([[1.0], [2.0]]), foo[:], sig_in),
         ProdUpdate(Signal(decoders * 0.5), sig_out, Signal(0.2), foo[:])


### PR DESCRIPTION
Added a rebuild_node() function to the simulator class, a test for it. rebuild_node() allows rebuilding of individual input nodes, specifying a new output value for them without rebuilding the whole model.

Usage is something like:
m = nengo.Network()
with m:
n = nengo.Node(output=x)
sim.run(...)
sim.rebuild_node(n, output=y)
sim.reset()
sim.run(...)