### PR TITLE
Make Config work for non-Nengo objects

### DIFF
--- a/nengo/config.py
+++ b/nengo/config.py
@@ -124,7 +124,8 @@ class ClassParams(object):
 
     @property
     def default_params(self):
-        return self._configures.param_list()
+        return (attr for attr in dir(self._configures)
+                if is_param(getattr(self._configures, attr)))
 
     @property
     def extra_params(self):
@@ -207,7 +208,7 @@ class Config(object):
     >>> inst = A()
     >>> config = Config()
     >>> config.configures(A)
-    >>> config[A].set_parameter('amount', Parameter(default=1))
+    >>> config[A].set_param('amount', Parameter(default=1))
     >>> print(config[inst].amount)
     1
     >>> config[inst].amount = 3

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -198,6 +198,24 @@ def test_config_str():
                     "  extra: 50")
 
 
+def test_external_class():
+    class A(object):
+        thing = Parameter(default='hey')
+
+    inst = A()
+    config = nengo.Config()
+    config.configures(A)
+    config[A].set_param('amount', Parameter(default=1))
+
+    # Extra param
+    assert config[inst].amount == 1
+
+    # Default still works like Nengo object
+    assert inst.thing == 'hey'
+    with pytest.raises(AttributeError):
+        config[inst].thing
+
+
 if __name__ == '__main__':
     nengo.log(debug=True)
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
The config system was assuming that the item it configures has a `params_list` attribute, which is true for all NengoObjects, but not in general. This PR removes that erroneous assumption.

Fixes #379.
