### PR TITLE
Removed hashing, _key from objects

### DIFF
--- a/nengo/builder.py
+++ b/nengo/builder.py
@@ -880,8 +880,6 @@ def build_network(network, model):  # noqa: C901
     """
     if model.toplevel is None:
         model.toplevel = network
-
-    if model.toplevel == network:
         model.sig['common'][0] = Signal(0.0, name='Common: Zero')
         model.sig['common'][1] = Signal(1.0, name='Common: One')
 


### PR DESCRIPTION
`__hash__` and `_key` were an attempt to have consistent hashing that would be useful for tools like GUIs that would like to identify objects as being the same across multiple invocations of the same script. Unfortunately, this hash was never actually consistent, and worse, sometimes had conflicts, so just overall it was not a good idea. Removed the hash functions, so we're back to the default Python behavior of using `id` to do equality.

However, we should try to do this explicitly by doing `is` checks instead of `==` checks when seeing is two objects are the same. I changed this in `builder`, as it's the only place I remember ever doing a `==` check.
