### PR TITLE
Made common signals readonly

### DIFF
--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -35,8 +35,10 @@ def build_network(model, network):
 
     if model.toplevel is None:
         model.toplevel = network
-        model.sig['common'][0] = Signal(0.0, name='Common: Zero')
-        model.sig['common'][1] = Signal(1.0, name='Common: One')
+        model.sig['common'][0] = Signal(
+            npext.array(0.0, readonly=True), name='Common: Zero')
+        model.sig['common'][1] = Signal(
+            npext.array(1.0, readonly=True), name='Common: One')
         model.seeds[network] = get_seed(network, np.random)
 
     # Set config

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -8,6 +8,7 @@ from nengo.builder import Model
 from nengo.builder.ensemble import BuiltEnsemble
 from nengo.builder.operator import DotInc, PreserveValue
 from nengo.builder.signal import Signal, SignalDict
+from nengo.utils.compat import itervalues
 
 
 def test_seeding(RefSimulator):
@@ -223,3 +224,15 @@ def test_signal_reshape():
     assert three_d.reshape((-1, 4)).shape == (2, 4)
     assert three_d.reshape((2, -1, 2)).shape == (2, 2, 2)
     assert three_d.reshape((1, 2, 1, 2, 2, 1)).shape == (1, 2, 1, 2, 2, 1)
+
+
+def test_commonsig_readonly(RefSimulator):
+    """Test that the common signals cannot be modified."""
+    net = nengo.Network(label="test_commonsig")
+    sim = RefSimulator(net)
+    for sig in itervalues(sim.model.sig['common']):
+        sim.signals.init(sig, sig.value)
+        with pytest.raises(ValueError):
+            sim.signals[sig] = np.array([-1])
+        with pytest.raises(ValueError):
+            sim.signals[sig][...] = np.array([-1])

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -21,7 +21,7 @@ def broadcast_shape(shape, length):
         return shape
 
 
-def array(x, dims=None, min_dims=0, **kwargs):
+def array(x, dims=None, min_dims=0, readonly=False, **kwargs):
     y = np.array(x, **kwargs)
     dims = max(min_dims, y.ndim) if dims is None else dims
 
@@ -32,6 +32,9 @@ def array(x, dims=None, min_dims=0, **kwargs):
     elif y.ndim > dims:
         raise ValueError(
             "Input cannot be cast to array with %d dimensions" % dims)
+
+    if readonly:
+        y.flags.writeable = False
 
     return y
 


### PR DESCRIPTION
I looked over all the signals we make to see if any made sense to be readonly. Right now, it seems like the only critical ones are the `'common'` signals, so this ensures that they are not writeable. I added `test_builder.test_commonsig_readonly` to test that they can't be modified.