### PR TITLE
Removed some of the slow examples from tests

### DIFF
--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -23,7 +23,9 @@ def pytest_generate_tests(metafunc):
 
     # if `--optional` is not set, filter out optional notebooks
     ignores = [] if metafunc.config.option.optional else [
-        'lorenz_attractor.ipynb']
+        'lorenz_attractor.ipynb', 'spa_sequence_routed.ipynb',
+        'spa_sequence-Class.ipynb', 'spa_sequence-Context.ipynb',
+        'spa_parser.ipynb', 'question_control.ipynb']
     examples = [path for path in examples
                 if os.path.split(path)[1] not in ignores]
 


### PR DESCRIPTION
Some of the SPA examples are pretty slow to run, so I took them out of the tests (the functionality is still being tested in `nengo/spa/tests`).
