### PR TITLE
Can do len on sliceables

### DIFF
--- a/nengo/objects.py
+++ b/nengo/objects.py
@@ -266,6 +266,9 @@ class Neurons(object):
     def __getitem__(self, key):
         return ObjView(self, key)
 
+    def __len__(self):
+        return self.ensemble.n_neurons
+
     @property
     def label(self):
         return "%s.neurons" % self.ensemble.label
@@ -356,6 +359,9 @@ class Ensemble(NengoObject):
 
     def __getitem__(self, key):
         return ObjView(self, key)
+
+    def __len__(self):
+        return self.dimensions
 
     @property
     def neurons(self):
@@ -466,6 +472,9 @@ class Node(NengoObject):
 
     def __getitem__(self, key):
         return ObjView(self, key)
+
+    def __len__(self):
+        return self.size_out
 
 
 class Connection(NengoObject):
@@ -812,3 +821,6 @@ class ObjView(object):
             else:
                 key = slice(key, key+1)
         self.slice = key
+
+    def __len__(self):
+        return len(np.arange(len(self.obj))[self.slice])

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -246,6 +246,24 @@ def test_eval_points_heuristic(Simulator, nl_nodirect, neurons, dims):
     assert points.shape == (heuristic(neurons, dims), dims)
 
 
+def test_len():
+    """Make sure we can do len(ens) or len(ens.neurons)."""
+    with nengo.Network():
+        ens1 = nengo.Ensemble(10, dimensions=1)
+        ens5 = nengo.Ensemble(100, dimensions=5)
+    # Ensemble.__len__
+    assert len(ens1) == 1
+    assert len(ens5) == 5
+    assert len(ens1[0]) == 1
+    assert len(ens5[:3]) == 3
+
+    # Neurons.__len__
+    assert len(ens1.neurons) == 10
+    assert len(ens5.neurons) == 100
+    assert len(ens1.neurons[0]) == 1
+    assert len(ens5.neurons[90:]) == 10
+
+
 if __name__ == "__main__":
     nengo.log(debug=True)
     pytest.main([__file__, '-v'])

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -252,6 +252,19 @@ def test_unconnected_node(Simulator):
     assert hits[0] == 2
 
 
+def test_len():
+    with nengo.Network():
+        n1 = nengo.Node(None, size_in=1)
+        n3 = nengo.Node([1, 2, 3])
+        n4 = nengo.Node(lambda t: np.arange(4) * t)
+
+    assert len(n1) == 1
+    assert len(n3) == 3
+    assert len(n4) == 4
+    assert len(n1[0]) == 1
+    assert len(n4[1:3]) == 2
+
+
 if __name__ == "__main__":
     nengo.log(debug=True)
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
Implemented `__len__` on `Ensemble`, `Node`, `Neurons`, `ObjView`. Makes sense -- we already have this information around. Thanks to @andsoandso for the idea!
