### PR TITLE
Rename thalamus.thalamus to .actions

### DIFF
--- a/nengo/networks/actionselection.py
+++ b/nengo/networks/actionselection.py
@@ -147,17 +147,17 @@ class Thalamus(nengo.Network):
 
     def __init__(self, dimensions, n_neurons_per_ensemble=50, mutual_inhib=1,
                  threshold=0):
-        self.thalamus = EnsembleArray(n_neurons_per_ensemble, dimensions,
-                                      intercepts=Uniform(threshold, 1),
-                                      encoders=[[1]] * n_neurons_per_ensemble,
-                                      label="thalamus")
+        self.actions = EnsembleArray(n_neurons_per_ensemble, dimensions,
+                                     intercepts=Uniform(threshold, 1),
+                                     encoders=[[1]] * n_neurons_per_ensemble,
+                                     label="actions")
 
-        self.input = self.thalamus.input
-        self.output = self.thalamus.output
+        self.input = self.actions.input
+        self.output = self.actions.output
 
-        nengo.Connection(self.thalamus.output, self.thalamus.input,
+        nengo.Connection(self.actions.output, self.actions.input,
                          transform=(np.eye(dimensions) - 1) * mutual_inhib)
 
         self.bias = nengo.Node([1])
-        nengo.Connection(self.bias, self.thalamus.input,
+        nengo.Connection(self.bias, self.actions.input,
                          transform=[[1]]*dimensions)

--- a/nengo/spa/thalamus.py
+++ b/nengo/spa/thalamus.py
@@ -79,7 +79,7 @@ class Thalamus(nengo.networks.Thalamus, Module):
 
         with spa:
             # connect basal ganglia to thalamus
-            nengo.Connection(self.bg.output, self.thalamus.input,
+            nengo.Connection(self.bg.output, self.actions.input,
                              synapse=self.synapse_bg)
 
         # implement the various effects
@@ -118,7 +118,7 @@ class Thalamus(nengo.networks.Thalamus, Module):
         transform = np.array([vocab.parse(value).v]).T
 
         with self.spa:
-            nengo.Connection(self.thalamus.ensembles[index],
+            nengo.Connection(self.actions.ensembles[index],
                              sink, transform=transform,
                              synapse=self.synapse_direct)
 
@@ -139,7 +139,7 @@ class Thalamus(nengo.networks.Thalamus, Module):
                                       intercepts=intercepts,
                                       label='gate[%d]' % index,
                                       encoders=[[1]] * self.neurons_gate)
-                nengo.Connection(self.thalamus.ensembles[index], gate,
+                nengo.Connection(self.actions.ensembles[index], gate,
                                  synapse=self.synapse_to_gate, transform=-1)
                 nengo.Connection(self.bias, gate, synapse=None)
                 self.gates[index] = gate


### PR DESCRIPTION
Some of @tcstewar's SPA examples probe `thalamus.actions`, which seems like a nicer name for this `EnsembleArray` anyway.
