### PR TITLE
Added check for invalid firing rates

### DIFF
--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -78,6 +78,12 @@ class _LIFBase(NeuronType):
         """
         max_rates = np.asarray(max_rates)
         intercepts = np.asarray(intercepts)
+        inv_tau_ref = 1. / self.tau_ref
+        if (max_rates > inv_tau_ref).any():
+            raise ValueError(
+                "Max rates must be below the inverse refractory period (%0.3f)"
+                % (inv_tau_ref))
+
         x = 1.0 / (1 - np.exp(
             (self.tau_ref - (1.0 / max_rates)) / self.tau_rc))
         gain = (1 - x) / (intercepts - 1.0)

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -264,6 +264,15 @@ def test_len():
     assert len(ens5.neurons[90:]) == 10
 
 
+def test_invalid_rates(Simulator):
+    with nengo.Network() as model:
+        nengo.Ensemble(1, 1, max_rates=[200],
+                       neuron_type=nengo.LIF(tau_ref=0.01))
+
+    with pytest.raises(ValueError):
+        Simulator(model)
+
+
 if __name__ == "__main__":
     nengo.log(debug=True)
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
- rates above the inverse refractory period are invalid
- @studywolf and I decided that clipping the invalid rates and having a warning would be best, since an error may only occur sometimes if the rates are generated from a distribution. However, there's currently no way to clip the rates inside the `gain_bias` function and then pass the clipped rates back out, and if we did the warning I'd want to make sure that the user gets the clipped rates if they do something like `sim.data[ens].max_rates`. So I went with the easy error solution. This is an improvement over the current solution, which leads to a strange error in the decoder solver due to invalid values in the activities matrix.
