### PR TITLE
Custom replacement connection function for pass through nodes.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -18,6 +18,7 @@ to the file like so::
 Please keep this list sorted alphabetically.
 
 - Aaron Voelker <arvoelke@gmail.com>
+- Andrew Mundy <andrew.mundy@ieee.org>
 - Brent Komer <brent.komer@gmail.com>
 - Bryan Tripp <bptripp@uwaterloo.ca>
 - Chris Eliasmith <celiasmith@uwaterloo.ca>


### PR DESCRIPTION
Allow backends to provide custom functions to replace connections when replacing pass through nodes.

Motivation: in Nengo for SpiNNaker we provide some additional data for connections which needs to be merged correctly.  Providing the replacement connection function as an argument removes the need to rewrite the entire `remove_passthrough_nodes` function.
