### PR TITLE
Allow scalar arrays as input to NumberParam

### DIFF
--- a/nengo/params.py
+++ b/nengo/params.py
@@ -94,6 +94,11 @@ class NumberParam(Parameter):
         self.high = high
         super(NumberParam, self).__init__(default, optional, readonly)
 
+    def __set__(self, instance, value):
+        if isinstance(value, np.ndarray) and value.shape == ():
+            value = value.item()  # convert scalar array to Python object
+        super(NumberParam, self).__set__(instance, value)
+
     def validate(self, instance, num):
         if num is not None:
             if not is_number(num):

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -132,6 +132,10 @@ def test_numberparam():
     inst.np_lh = 1.0
     assert inst.np_lh == 1.0
 
+    # ensure scalar array works
+    inst.np = np.array(2.0)
+    assert inst.np == 2.0
+
     # must be a number!
     with pytest.raises(ValueError):
         inst.np = 'a'


### PR DESCRIPTION
I added this because I saved some stuff to a `.npz` file, and when I loaded it back I couldn't use the scalars as input to parameters like `radius`, since they had all been converted to scalar `ndarray`s.

So what I've done is to convert scalar arrays to Python objects in the `NumberParam` setter. The other option would be to convert all `NumberParam` inputs to arrays, then check if the array is a scalar in the validator, but I think this is more work.
