### PR TITLE
WIP: Added Gauss' method for convolution.

### DIFF
--- a/nengo/networks/tests/test_circularconv.py
+++ b/nengo/networks/tests/test_circularconv.py
@@ -13,13 +13,13 @@ from nengo.utils.testing import Plotter
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.parametrize('dims', [5, 6, 11, 16])
 @pytest.mark.parametrize('invert_a', [True, False])
 @pytest.mark.parametrize('invert_b', [True, False])
-def test_circularconv_transforms(invert_a, invert_b):
+def test_circularconv_transforms(dims, invert_a, invert_b):
     """Test the circular convolution transforms"""
     rng = np.random.RandomState(43232)
 
-    dims = 100
     x = rng.randn(dims)
     y = rng.randn(dims)
     z0 = circconv(x, y, invert_a=invert_a, invert_b=invert_b)
@@ -47,7 +47,7 @@ def test_circularconv(Simulator, nl, dims=4, neurons_per_product=128):
     assert np.abs(result).max() < radius
 
     # --- model
-    model = nengo.Network(label="circular convolution")
+    model = nengo.Network(seed=283)
     with model:
         model.config[nengo.Ensemble].neuron_type = nl()
         inputA = nengo.Node(a)


### PR DESCRIPTION
This branch implements Gauss' method for complex number multiplication in the circular convolution network, which allows complex multiplication to be done with 3 multiplies instead of four, thus reducing the number of products needed for circular convolution by 25%.

I still need to document in code exactly how the method works (beyond just pointing people [here](http://en.wikipedia.org/wiki/Multiplication_algorithm#Gauss.27s_complex_multiplication_algorithm)), so I've marked it WIP.