### PR TITLE
Fix for bug where using unitary semantic pointers would crash builder.

### DIFF
--- a/nengo/spa/pointer.py
+++ b/nengo/spa/pointer.py
@@ -54,7 +54,7 @@ class SemanticPointer:
         fft_real = fft_val.real
         fft_norms = np.sqrt(fft_imag ** 2 + fft_real ** 2)
         fft_unit = fft_val / fft_norms
-        self.v = (np.fft.ifft(fft_unit)).real
+        self.v = np.array((np.fft.ifft(fft_unit)).real)
 
     def __add__(self, other):
         return SemanticPointer(data=self.v + other.v)


### PR DESCRIPTION
- Made the unitary function return a copy of the vector instead of just the .real view.
