### PR TITLE
Fix trange and probe sampling rates.

### DIFF
--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -159,9 +159,9 @@ class Simulator(object):
     def _probe(self):
         """Copy all probed signals to buffers"""
         for probe in self.model.probes:
-            period = (1 if probe.sample_every is None
-                      else int(probe.sample_every / self.dt))
-            if self.n_steps % period == 0:
+            period = (1 if probe.sample_every is None else
+                      probe.sample_every / self.dt)
+            if self.n_steps % period < 1:
                 tmp = self.signals[self.model.sig[probe]['in']].copy()
                 self._probe_outputs[probe].append(tmp)
 


### PR DESCRIPTION
The first commit fixes #497, making sure that trange matches the length of the probe data for normal probe sampling rates. This is straightforward, we were just doing some operations in the wrong order.

The second commit makes sure that trange and the probe data length match for sampling periods that are not multiples of the simulator dt. Currently with this fix, the times in trange don't exactly match the times of the probe data, since the trange times are just linearly interpolated, which won't work for sampling periods that are not multiples of dt (since the samples always comes from times that _are_ multiples of dt). Should we look at changing this so that trange gives the exact times that probe data came from? The pros are we'd be exact (though we currently won't be off by more than one dt), the cons are that the trange times won't be evenly spaced (some code might assume they are), and that trange would be a more complicated function.
