### PR TITLE
Removed EnsembleNeuronTypeParam.

### DIFF
--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -5,32 +5,6 @@ from nengo.params import (
 from nengo.utils.distributions import Uniform, UniformHypersphere
 
 
-class EnsembleNeuronTypeParam(NeuronTypeParam):
-    def __set__(self, ens, neurons):
-        orig_probeable = list(ens.probeable)
-        self.update_probeable(ens, neurons)
-        try:
-            super(EnsembleNeuronTypeParam, self).__set__(ens, neurons)
-        except:
-            ens.probeable = orig_probeable
-            raise
-
-    def update_probeable(self, ens, neurons):
-        """Update the probeable list."""
-        # We could use a set instead and this would be easier, but we use
-        # the first member of the list as the default probeable, so that
-        # doesn't work.
-        if ens in self.data and self.data[ens] is not None:
-            for attr in self.data[ens].probeable:
-                if attr in ens.probeable:
-                    ens.probeable.remove(attr)
-
-        if neurons is not None:
-            for attr in neurons.probeable:
-                if attr not in ens.probeable:
-                    ens.probeable.append(attr)
-
-
 class Ensemble(NengoObject):
     """A group of neurons that collectively represent a vector.
 
@@ -70,7 +44,7 @@ class Ensemble(NengoObject):
     n_neurons = IntParam(default=None, low=1)
     dimensions = IntParam(default=None, low=1)
     radius = NumberParam(default=1.0, low=1e-10)
-    neuron_type = EnsembleNeuronTypeParam(default=LIF())
+    neuron_type = NeuronTypeParam(default=LIF())
     encoders = DistributionParam(default=UniformHypersphere(surface=True),
                                  sample_shape=('n_neurons', 'dimensions'))
     intercepts = DistributionParam(default=Uniform(-1.0, 1.0),

--- a/nengo/spa/tests/test_assoc_mem.py
+++ b/nengo/spa/tests/test_assoc_mem.py
@@ -112,7 +112,7 @@ def test_am_default_output_inhibit_utilities(Simulator):
     def inhib_func(t):
         return int(t > 0.75)
 
-    m = nengo.Network('model', seed=123)
+    m = nengo.Network('model', seed=1234)
     with m:
         am = AssociativeMemory(vocab2,
                                default_output_vector=vocab.parse("F").v,
@@ -146,7 +146,7 @@ def test_am_default_output_inhibit_utilities(Simulator):
     assert np.allclose(sim.data[in_p][t2], vocab.parse("0.8*A+B").v, atol=0.1)
     assert np.allclose(sim.data[in_p][t3], vocab.parse("E").v, atol=0.1)
     assert np.allclose(sim.data[in_p][t4], vocab.parse("E").v, atol=0.1)
-    assert np.allclose(sim.data[out_p][t1], vocab.parse("A+B").v, atol=0.11)
+    assert np.allclose(sim.data[out_p][t1], vocab.parse("A+B").v, atol=0.1)
     assert np.allclose(sim.data[out_p][t2], vocab.parse("A+B").v, atol=0.1)
     assert np.allclose(sim.data[out_p][t3], vocab.parse("F").v, atol=0.1)
     assert np.allclose(sim.data[out_p][t4], vocab.parse("0").v, atol=0.1)

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -1,4 +1,3 @@
-from collections import Counter
 import logging
 
 import numpy as np
@@ -6,7 +5,6 @@ import pytest
 
 import nengo
 import nengo.utils.numpy as npext
-from nengo.ensemble import EnsembleNeuronTypeParam
 from nengo.utils.distributions import Choice
 from nengo.utils.testing import Plotter, warns
 
@@ -303,27 +301,6 @@ def test_gain_bias(Simulator, nl_nodirect):
     sim = Simulator(model)
     assert np.array_equal(gain, sim.data[a].gain)
     assert np.array_equal(bias, sim.data[a].bias)
-
-
-def test_neurontypeparam_probeable():
-    """NeuronTypeParam can update a probeable list."""
-    class Test(object):
-        ntp = EnsembleNeuronTypeParam(default=None, optional=True)
-        probeable = ['output']
-
-    inst = Test()
-    assert inst.probeable == ['output']
-    inst.ntp = nengo.LIF()
-    assert Counter(inst.probeable) == Counter(inst.ntp.probeable + ['output'])
-    # The first element is important,  as it's the default
-    assert inst.probeable[0] == 'output'
-    # Setting it again should result in the same list
-    inst.ntp = nengo.LIF()
-    assert Counter(inst.probeable) == Counter(inst.ntp.probeable + ['output'])
-    assert inst.probeable[0] == 'output'
-    # Unsetting it should clear the list appropriately
-    inst.ntp = None
-    assert inst.probeable == ['output']
 
 
 if __name__ == "__main__":

--- a/nengo/utils/tests/test_probe.py
+++ b/nengo/utils/tests/test_probe.py
@@ -53,11 +53,11 @@ def test_probe_all_options():
             nengo.Node(output=[0])
 
     probe_all(model, recursive=True, probe_options={
-        nengo.Ensemble: ['decoded_output', 'spikes']})
+        nengo.Ensemble: ['decoded_output']})
 
     # only probes spikes and decoded output of the ensembles
-    assert(len(model.probes) == 2)
-    assert(len(subnet.probes) == 2)
+    assert(len(model.probes) == 1)
+    assert(len(subnet.probes) == 1)
 
 
 def test_probe_all_kwargs():


### PR DESCRIPTION
This was only necessary when we wanted to probe neuron stuff on the
ensemble. Now that we use the neurons object, this is unnecessary.
