### PR TITLE
Fixed circular convolution routing

### DIFF
--- a/nengo/spa/thalamus.py
+++ b/nengo/spa/thalamus.py
@@ -240,7 +240,7 @@ class Thalamus(nengo.networks.Thalamus, Module):
 
             # inhibit the channel when the action is not chosen
             inhibit = [[-self.route_inhibit]] * (self.neurons_cconv)
-            for e in channel.product.ensembles:
+            for e in channel.product.all_ensembles:
                 nengo.Connection(gate, e.neurons, transform=inhibit,
                                  synapse=self.synapse_inhibit)
 


### PR DESCRIPTION
I screwed up the routing logic in thalamus.py such that it wasn't inhibiting any action rule of the form "a = b*c".  

I've fixed this and added a test for it in test_thalamus.py
