### PR TITLE
Fixed erroneous uses of `nengo.Simulator` in tests.

### DIFF
--- a/nengo/spa/tests/test_thalamus.py
+++ b/nengo/spa/tests/test_thalamus.py
@@ -93,7 +93,7 @@ def test_routing(Simulator):
         buff3_probe = nengo.Probe(model.buff3.state.output, synapse=0.03)
         thal_probe = nengo.Probe(model.thal.output, synapse=0.03)
 
-    sim = nengo.Simulator(model)
+    sim = Simulator(model)
     sim.run(0.5)
 
     data1 = sim.data[buff1_probe]

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -7,7 +7,7 @@ import nengo
 import nengo.builder
 
 
-def test_seeding():
+def test_seeding(RefSimulator):
     """Test that setting the model seed fixes everything"""
 
     #  TODO: this really just checks random parameters in ensembles.
@@ -23,10 +23,10 @@ def test_seeding():
         C = nengo.Connection(A, B, function=lambda x: x ** 2)
 
     m.seed = 872
-    m1 = nengo.Simulator(m).model.params
-    m2 = nengo.Simulator(m).model.params
+    m1 = RefSimulator(m).model.params
+    m2 = RefSimulator(m).model.params
     m.seed = 873
-    m3 = nengo.Simulator(m).model.params
+    m3 = RefSimulator(m).model.params
 
     def compare_objs(obj1, obj2, attrs, equal=True):
         for attr in attrs:
@@ -51,7 +51,7 @@ def test_seeding():
     compare_objs(Cs[0], Cs[2], conn_attrs, equal=False)
 
 
-def test_hierarchical_seeding():
+def test_hierarchical_seeding(RefSimulator):
     """Changes to subnetworks shouldn't affect seeds in top-level network"""
 
     def create(make_extra, seed):
@@ -70,9 +70,9 @@ def test_hierarchical_seeding():
     same2, same2objs = create(True, 9)
     diff, diffobjs = create(True, 10)
 
-    same1seeds = nengo.Simulator(same1).model.seeds
-    same2seeds = nengo.Simulator(same2).model.seeds
-    diffseeds = nengo.Simulator(diff).model.seeds
+    same1seeds = RefSimulator(same1).model.seeds
+    same2seeds = RefSimulator(same2).model.seeds
+    diffseeds = RefSimulator(diff).model.seeds
 
     for diffobj, same2obj in zip(diffobjs, same2objs):
         # These seeds should all be different

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -234,7 +234,7 @@ def test_function_and_transform(Simulator, nl, plt):
         ap = nengo.Probe(a, synapse=0.03)
         bp = nengo.Probe(b, synapse=0.03)
 
-    sim = nengo.Simulator(model)
+    sim = Simulator(model)
     sim.run(1.0)
     x0, x1 = np.dot(sim.data[ap]**2, [[1., -1]]).T
     y0, y1 = sim.data[bp].T
@@ -404,7 +404,7 @@ def test_slicing(Simulator, nl, plt):
             nengo.Connection(a[sa], b[sb], transform=T)
             probes.append(nengo.Probe(b, synapse=0.03))
 
-    sim = nengo.Simulator(m)
+    sim = Simulator(m)
     sim.run(0.2)
     t = sim.trange()
 
@@ -629,18 +629,18 @@ def test_nonexistant_prepost(Simulator):
         e1 = nengo.Ensemble(100, 1)
         nengo.Connection(a, e1)
     with pytest.raises(ValueError):
-        nengo.Simulator(model1)
+        Simulator(model1)
 
     with nengo.Network() as model2:
         e2 = nengo.Ensemble(100, 1)
         nengo.Connection(e2, a)
     with pytest.raises(ValueError):
-        nengo.Simulator(model2)
+        Simulator(model2)
 
     with nengo.Network() as model3:
         nengo.Probe(a)
     with pytest.raises(ValueError):
-        nengo.Simulator(model3)
+        Simulator(model3)
 
 
 def test_directneurons(Simulator, nl_nodirect):

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -20,7 +20,7 @@ def test_missing_attribute():
 
 
 @pytest.mark.parametrize("n_dimensions", [1, 200])
-def test_encoders(n_dimensions, n_neurons=10, encoders=None):
+def test_encoders(RefSimulator, n_dimensions, n_neurons=10, encoders=None):
     if encoders is None:
         encoders = np.random.normal(size=(n_neurons, n_dimensions))
         encoders = npext.array(encoders, min_dims=2, dtype=np.float64)
@@ -32,26 +32,26 @@ def test_encoders(n_dimensions, n_neurons=10, encoders=None):
                              dimensions=n_dimensions,
                              encoders=encoders,
                              label="A")
-    sim = nengo.Simulator(model)
+    sim = RefSimulator(model)
 
     assert np.allclose(encoders, sim.data[ens].encoders)
 
 
-def test_encoders_wrong_shape():
+def test_encoders_wrong_shape(RefSimulator):
     n_dimensions = 3
     encoders = np.random.normal(size=n_dimensions)
     with pytest.raises(ValueError):
-        test_encoders(n_dimensions, encoders=encoders)
+        test_encoders(RefSimulator, n_dimensions, encoders=encoders)
 
 
-def test_encoders_negative_neurons():
+def test_encoders_negative_neurons(RefSimulator):
     with pytest.raises(ValueError):
-        test_encoders(1, n_neurons=-1)
+        test_encoders(RefSimulator, 1, n_neurons=-1)
 
 
-def test_encoders_no_dimensions():
+def test_encoders_no_dimensions(RefSimulator):
     with pytest.raises(ValueError):
-        test_encoders(0)
+        test_encoders(RefSimulator, 0)
 
 
 def test_constant_scalar(Simulator, nl, plt):

--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -48,7 +48,7 @@ def test_dts(Simulator):
             a = nengo.Node(output=0)
             ap = nengo.Probe(a, sample_every=dt2)
 
-        sim = nengo.Simulator(model, dt=dt)
+        sim = Simulator(model, dt=dt)
         sim.run(tend)
         t = sim.trange(dt2)
         x = sim.data[ap]
@@ -114,7 +114,7 @@ def test_simulator_dt(Simulator):
         nengo.Connection(a, b)
         bp = nengo.Probe(b)
 
-    sim = nengo.Simulator(model, dt=0.01)
+    sim = Simulator(model, dt=0.01)
     sim.run(1.)
     assert sim.data[bp].shape == (100, 1)
 
@@ -130,7 +130,7 @@ def test_multiple_probes(Simulator):
         p_01 = nengo.Probe(ens, sample_every=f * dt)
         p_1 = nengo.Probe(ens, sample_every=f**2 * dt)
 
-    sim = nengo.Simulator(model, dt=dt)
+    sim = Simulator(model, dt=dt)
     sim.run(1.)
     assert np.allclose(sim.data[p_001][f - 1::f], sim.data[p_01])
     assert np.allclose(sim.data[p_01][f - 1::f], sim.data[p_1])
@@ -147,7 +147,7 @@ def test_input_probe(Simulator):
         nengo.Connection(n2, ens, synapse=None)
         input_probe = nengo.Probe(ens, 'input')
 
-        sim = nengo.Simulator(model)
+        sim = Simulator(model)
         sim.run(1.)
         t = sim.trange()
         assert np.allclose(sim.data[input_probe][:, 0], np.sin(t) + 0.5)
@@ -165,7 +165,7 @@ def test_slice(Simulator, nl):
         bp1a = nengo.Probe(b[1], synapse=0.03)
         bp1b = nengo.Probe(b[1:], synapse=0.03)
 
-    sim = nengo.Simulator(model)
+    sim = Simulator(model)
     sim.run(1.0)
     assert np.allclose(sim.data[bp][:, 0], sim.data[bp0a][:, 0])
     assert np.allclose(sim.data[bp][:, 0], sim.data[bp0b][:, 0])

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -26,7 +26,7 @@ def run_synapse(Simulator, synapse, dt=1e-3, runtime=1., n_neurons=None):
         ref = nengo.Probe(target)
         filtered = nengo.Probe(target, synapse=synapse)
 
-    sim = nengo.Simulator(model, dt=dt)
+    sim = Simulator(model, dt=dt)
     sim.run(runtime)
 
     return sim.trange(), sim.data[ref], sim.data[filtered]

--- a/nengo/utils/tests/test_connection.py
+++ b/nengo/utils/tests/test_connection.py
@@ -35,7 +35,7 @@ def test_target_function(Simulator, nl_nodirect, plt, dimension):
         probe1 = nengo.Probe(ens2, synapse=0.03)
         probe2 = nengo.Probe(ens3, synapse=0.03)
 
-    sim = nengo.Simulator(model)
+    sim = Simulator(model)
     sim.run(1)
 
     plt.plot(sim.trange(), sim.data[probe1])


### PR DESCRIPTION
- Should always use `Simulator` or `RefSimulator` pytest args.
