### PR TITLE
Removed extra filter on integrator input

### DIFF
--- a/nengo/networks/integrator.py
+++ b/nengo/networks/integrator.py
@@ -7,4 +7,5 @@ class Integrator(nengo.Network):
         self.input = nengo.Node(size_in=dimensions)
         self.ensemble = nengo.Ensemble(**ens_args)
         nengo.Connection(self.ensemble, self.ensemble, synapse=recurrent_tau)
-        nengo.Connection(self.input, self.ensemble, transform=recurrent_tau)
+        nengo.Connection(self.input, self.ensemble, transform=recurrent_tau,
+                         synapse=None)

--- a/nengo/networks/oscillator.py
+++ b/nengo/networks/oscillator.py
@@ -10,4 +10,4 @@ class Oscillator(nengo.Network):
               [frequency * recurrent_tau, 1]]
         nengo.Connection(self.ensemble, self.ensemble,
                          synapse=recurrent_tau, transform=tA)
-        nengo.Connection(self.input, self.ensemble)
+        nengo.Connection(self.input, self.ensemble, synapse=None)

--- a/nengo/networks/workingmemory.py
+++ b/nengo/networks/workingmemory.py
@@ -31,12 +31,14 @@ class InputGatedMemory(nengo.Network):
         neuron_trans = np.ones((n_neurons * dimensions, 1))
         self.gate = nengo.Node(size_in=1)
         nengo.Connection(self.gate, self.diff.neuron_input,
-                         transform=neuron_trans * -gate_gain)
+                         transform=neuron_trans * -gate_gain,
+                         synapse=None)
 
         # reset input (if reset=1, remove all values stored, and set values=0)
         self.reset = nengo.Node(size_in=1)
         nengo.Connection(self.reset, self.mem.neuron_input,
-                         transform=neuron_trans * -reset_gain)
+                         transform=neuron_trans * -reset_gain,
+                         synapse=None)
 
         self.input = self.diff.input
         self.output = self.mem.output


### PR DESCRIPTION
Since Connection objects have a default synapse of 0.005s, there's an easy mistake that can be made when defining the input and output passthrough Nodes inside a network.  We should always make sure that those input and output passthrough Nodes have `synapse=None`, since otherwise they'll have an extra lowpass filter added on to their behaviour in addition to whatever the user specifies when connecting them up to something.
