### PR TITLE
Using generic python function to specify learning rule

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ Release History
   `#1077 <https://github.com/nengo/nengo/pull/1077>`_)
 - Tweaked ``rasterplot`` so that spikes from different neurons don't overlap.
   (`#1121 <https://github.com/nengo/nengo/pull/1121>`_)
+- Added ``GenericRule`` to allow for easy implementation of new learning rules.
+  (`#553 <https://github.com/nengo/nengo/pull/553>`_)
 
 **Bug fixes**
 

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -24,7 +24,7 @@ from .node import Node
 from .neurons import (AdaptiveLIF, AdaptiveLIFRate, Direct, Izhikevich, LIF,
                       LIFRate, RectifiedLinear, Sigmoid)
 from .network import Network
-from .learning_rules import PES, BCM, Oja, Voja
+from .learning_rules import PES, BCM, Oja, Voja, GenericRule
 from .params import Default
 from .probe import Probe
 from .rc import rc, RC_DEFAULTS

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -6,7 +6,7 @@ from nengo.builder import Builder, Signal
 from nengo.builder.ensemble import gen_eval_points, get_activities
 from nengo.builder.node import SimPyFunc
 from nengo.builder.operator import (
-    DotInc, ElementwiseInc, PreserveValue, Reset, SlicedCopy)
+    DotInc, ElementwiseInc, Reset, SlicedCopy)
 from nengo.connection import Connection
 from nengo.dists import Distribution
 from nengo.ensemble import Ensemble, Neurons
@@ -279,27 +279,12 @@ def build_connection(model, conn):
         signal, model.sig[conn]['out'], dst_slice=post_slice,
         inc=True, tag="%s.gain" % conn))
 
-    # Build learning rules
+    # Build learning rule connection object
     if conn.learning_rule is not None:
         rule = conn.learning_rule
         rule = [rule] if not is_iterable(rule) else rule
-        targets = []
         for r in itervalues(rule) if isinstance(rule, dict) else rule:
             model.build(r)
-            targets.append(r.modifies)
-
-        if 'encoders' in targets:
-            encoder_sig = model.sig[conn.post_obj]['encoders']
-            if not any(isinstance(op, PreserveValue) and op.dst is encoder_sig
-                       for op in model.operators):
-                encoder_sig.readonly = False
-                model.add_op(PreserveValue(encoder_sig))
-        if 'decoders' in targets or 'weights' in targets:
-            if weights.ndim < 2:
-                raise BuildError(
-                    "'transform' must be a 2-dimensional array for learning")
-            model.sig[conn]['weights'].readonly = False
-            model.add_op(PreserveValue(model.sig[conn]['weights']))
 
     model.params[conn] = BuiltConnection(eval_points=eval_points,
                                          solver_info=solver_info,

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from nengo.builder import Builder, Operator, Signal
 from nengo.builder.operator import DotInc, ElementwiseInc, Reset
-from nengo.connection import LearningRule
+from nengo.learning_rules import LearningRule
 from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError
 from nengo.learning_rules import BCM, Oja, PES, Voja

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -35,7 +35,7 @@ def signal_probe(model, key, probe):
 
     try:
         sig = model.sig[probe.obj][key]
-    except IndexError:
+    except KeyError:
         raise BuildError(
             "Attribute %r is not probeable on %s." % (key, probe.obj))
 
@@ -103,7 +103,7 @@ def build_probe(model, probe):
     if probe.attr == 'params':
         # don't add this probe to the model probe lists
         model.params[probe] = model.params[probe.obj]
-        return
+        return model.params[probe]
 
     key = probeables[probe.attr] if probe.attr in probeables else probe.attr
     if key is None:
@@ -115,3 +115,5 @@ def build_probe(model, probe):
 
     # Simulator will fill this list with probe data during simulation
     model.params[probe] = []
+    
+    return model.sig[probe]['in']

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -115,5 +115,5 @@ def build_probe(model, probe):
 
     # Simulator will fill this list with probe data during simulation
     model.params[probe] = []
-    
+
     return model.sig[probe]['in']

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -100,6 +100,11 @@ def build_probe(model, probe):
         raise BuildError(
             "Type %r is not probeable" % type(probe.obj).__name__)
 
+    if probe.attr == 'params':
+        # don't add this probe to the model probe lists
+        model.params[probe] = model.params[probe.obj]
+        return
+
     key = probeables[probe.attr] if probe.attr in probeables else probe.attr
     if key is None:
         conn_probe(model, probe)

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -354,7 +354,7 @@ class Connection(NengoObject):
         Linear transform mapping the pre function output to the post input.
     """
 
-    probeable = ('output', 'input', 'weights')
+    probeable = ('output', 'input', 'weights', 'params')
 
     pre = PrePostParam('pre', nonzero_size_out=True)
     post = PrePostParam('post', nonzero_size_in=True)

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -512,6 +512,14 @@ class LearningRule(object):
         self._connection = weakref.ref(connection)
         self.learning_rule_type = learning_rule_type
 
+        if learning_rule_type.size_in is not None:
+            self.size_in = learning_rule_type.size_in
+        else:
+            # infer size_in from post
+            self.size_in = (self.connection.post_obj.ensemble.size_in
+                            if isinstance(self.connection.post_obj, Neurons)
+                            else self.connection.size_out)
+
     def __repr__(self):
         return "<LearningRule at 0x%x modifying %r with type %r>" % (
             id(self), self.connection, self.learning_rule_type)
@@ -526,11 +534,6 @@ class LearningRule(object):
         return self._connection()
 
     @property
-    def error_type(self):
-        """(str) The type of information expected by the learning rule."""
-        return self.learning_rule_type.error_type
-
-    @property
     def modifies(self):
         """(str) The variable modified by the learning rule."""
         return self.learning_rule_type.modifies
@@ -539,24 +542,6 @@ class LearningRule(object):
     def probeable(self):
         """(tuple) Signals that can be probed in the learning rule."""
         return self.learning_rule_type.probeable
-
-    @property
-    def size_in(self):
-        """(int) Dimensionality of the signal expected by the learning rule."""
-        if self.error_type == 'none':
-            return 0
-        elif self.error_type == 'scalar':
-            return 1
-        elif self.error_type == 'decoded':
-            return (self.connection.post_obj.ensemble.size_in
-                    if isinstance(self.connection.post_obj, Neurons) else
-                    self.connection.size_out)
-        elif self.error_type == 'neuron':
-            raise NotImplementedError()
-        else:
-            raise ValidationError(
-                "Unrecognized error type %r" % self.error_type,
-                attr='error_type', obj=self)
 
     @property
     def size_out(self):

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -74,16 +74,17 @@ class ConnectionLearningRuleTypeParam(LearningRuleTypeParam):
                     attr=self.name, obj=conn)
 
             # transform matrix must be 2D
-            pre_size = (
-                conn.pre_obj.n_neurons if isinstance(conn.pre_obj, Ensemble)
-                else conn.pre.size_out)
-            post_size = conn.post.size_in
-            if (not conn.solver.weights and
-                    conn.transform.shape != (post_size, pre_size)):
-                raise ValidationError(
-                    "Transform must be 2D array with shape post_neurons x "
-                    "pre_neurons (%d, %d)" % (pre_size, post_size),
-                    attr=self.name, obj=conn)
+            if not isinstance(conn.transform, Distribution):
+                pre_size = (conn.pre_obj.n_neurons
+                            if isinstance(conn.pre_obj, Ensemble)
+                            else conn.pre.size_out)
+                post_size = conn.post.size_in
+                if (not conn.solver.weights and
+                        conn.transform.shape != (post_size, pre_size)):
+                    raise ValidationError(
+                        "Transform must be 2D array with shape post_neurons x "
+                        "pre_neurons (%d, %d)" % (pre_size, post_size),
+                        attr=self.name, obj=conn)
 
 
 class ConnectionSolverParam(SolverParam):

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -106,7 +106,7 @@ class Ensemble(NengoObject):
         The seed used for random number generation.
     """
 
-    probeable = ('decoded_output', 'input', 'params')
+    probeable = ('decoded_output', 'input', 'encoders', 'params')
 
     n_neurons = IntParam('n_neurons', default=None, low=1)
     dimensions = IntParam('dimensions', default=None, low=1)

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -106,7 +106,7 @@ class Ensemble(NengoObject):
         The seed used for random number generation.
     """
 
-    probeable = ('decoded_output', 'input')
+    probeable = ('decoded_output', 'input', 'params')
 
     n_neurons = IntParam('n_neurons', default=None, low=1)
     dimensions = IntParam('dimensions', default=None, low=1)

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -5,7 +5,7 @@ from nengo.base import ObjView
 from nengo.ensemble import Neurons
 from nengo.exceptions import ValidationError
 from nengo.params import (FrozenObject, NumberParam, Parameter, IntParam,
-                          BoolParam)
+                          TupleParam)
 from nengo.utils.compat import is_iterable, itervalues
 
 
@@ -343,18 +343,18 @@ class GenericRule(LearningRuleType):
         to the learning rule function
     """
 
-    probeable = ('target', 'data', 'delta')
+    probeable = ('delta',)
 
-    pass_model_params = BoolParam('pass_model_params')
+    data_sources = TupleParam("data_sources")
 
-    def __init__(self, function, learning_rate=1.0, size_in=0,
-                 modifies="decoders", pass_model_params=False):
+    def __init__(self, function, data_sources=None, learning_rate=1.0,
+                 modifies="decoders"):
         self.modifies = modifies
         self.function = function
-        self.pass_model_params = pass_model_params
+        self.data_sources = data_sources
 
         super(GenericRule, self).__init__(learning_rate=learning_rate,
-                                          size_in=size_in)
+                                          size_in=0)
 
 
 class LearningRuleTypeParam(Parameter):

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -1,8 +1,63 @@
 import warnings
+import weakref
 
+from nengo.ensemble import Neurons
 from nengo.exceptions import ValidationError
 from nengo.params import FrozenObject, NumberParam, Parameter, IntParam
 from nengo.utils.compat import is_iterable, itervalues
+
+
+class LearningRule(object):
+    """An interface for making connections to a learning rule.
+
+    Connections to a learning rule are to allow elements of the network to
+    affect the learning rule. For example, learning rules that use error
+    information can obtain that information through a connection.
+
+    Learning rule objects should only ever be accessed through the
+    ``learning_rule`` attribute of a connection.
+    """
+
+    def __init__(self, connection, learning_rule_type):
+        self._connection = weakref.ref(connection)
+        self.learning_rule_type = learning_rule_type
+
+        if learning_rule_type.size_in is not None:
+            self.size_in = learning_rule_type.size_in
+        else:
+            # infer size_in from post
+            self.size_in = (self.connection.post_obj.ensemble.size_in
+                            if isinstance(self.connection.post_obj, Neurons)
+                            else self.connection.size_out)
+
+    def __repr__(self):
+        return "<LearningRule at 0x%x modifying %r with type %r>" % (
+            id(self), self.connection, self.learning_rule_type)
+
+    def __str__(self):
+        return "<LearningRule modifying %s with type %s>" % (
+            self.connection, self.learning_rule_type)
+
+    @property
+    def connection(self):
+        """(Connection) The connection modified by the learning rule."""
+        return self._connection()
+
+    @property
+    def modifies(self):
+        """(str) The variable modified by the learning rule."""
+        return self.learning_rule_type.modifies
+
+    @property
+    def probeable(self):
+        """(tuple) Signals that can be probed in the learning rule."""
+        return self.learning_rule_type.probeable
+
+    @property
+    def size_out(self):
+        """(int) Cannot connect from learning rules, so always 0."""
+        return 0  # since a learning rule can't connect to anything
+        # TODO: allow probing individual learning rules
 
 
 class LearningRuleType(FrozenObject):

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -2,7 +2,8 @@ from nengo.base import NengoObject, NengoObjectParam, ObjView
 from nengo.config import Config
 from nengo.connection import Connection, LearningRule
 from nengo.exceptions import ObsoleteError, ValidationError
-from nengo.params import Default, ConnectionDefault, NumberParam, StringParam
+from nengo.params import (Default, ConnectionDefault, NumberParam, StringParam,
+                          BoolParam)
 from nengo.solvers import SolverParam
 from nengo.synapses import SynapseParam
 
@@ -83,6 +84,9 @@ class Probe(NengoObject):
     solver : Solver, optional (Default: ``ConnectionDefault``)
         `~nengo.solvers.Solver` to compute decoders
         for probes that require them.
+    keep_history: bool (Default: True)
+        If True then the simulation will store the probed value from every
+        timestep; if False, the simulation will only store the last timestep.
     label : str, optional (Default: None)
         A name for the probe. Used for debugging and visualization.
     seed : int, optional (Default: None)
@@ -107,19 +111,22 @@ class Probe(NengoObject):
 
     target = TargetParam('target', nonzero_size_out=True)
     attr = AttributeParam('attr', default=None)
+    keep_history = BoolParam('keep_history', default=True)
     sample_every = NumberParam(
         'sample_every', default=None, optional=True, low=1e-10)
     synapse = SynapseParam('synapse', default=None)
     solver = ProbeSolverParam('solver', default=ConnectionDefault)
 
     def __init__(self, target, attr=None, sample_every=Default,
-                 synapse=Default, solver=Default, label=Default, seed=Default):
+                 synapse=Default, solver=Default, keep_history=Default,
+                 label=Default, seed=Default):
         super(Probe, self).__init__(label=label, seed=seed)
         self.target = target
         self.attr = attr if attr is not None else self.obj.probeable[0]
         self.sample_every = sample_every
         self.synapse = synapse
         self.solver = solver
+        self.keep_history = keep_history
 
     def __repr__(self):
         return "<Probe%s at 0x%x of '%s' of %s>" % (

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -201,7 +201,10 @@ class Simulator(object):
                       probe.sample_every / self.dt)
             if self.n_steps % period < 1:
                 tmp = self.signals[self.model.sig[probe]['in']].copy()
-                self._probe_outputs[probe].append(tmp)
+                if probe.keep_history:
+                    self._probe_outputs[probe].append(tmp)
+                else:
+                    self._probe_outputs[probe] = tmp
 
     def _probe_step_time(self):
         self._n_steps = self.signals[self.model.step].copy()

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -3,7 +3,8 @@ import pytest
 
 import nengo
 from nengo.dists import UniformHypersphere
-from nengo.learning_rules import LearningRuleTypeParam, PES, BCM, Oja, Voja
+from nengo.learning_rules import (LearningRuleTypeParam, PES, BCM, Oja, Voja,
+                                  GenericRule)
 from nengo.processes import WhiteSignal
 
 
@@ -466,3 +467,113 @@ def test_frozen():
 
     with pytest.raises((ValueError, RuntimeError)):
         a.learning_rate = 1e-1
+
+
+@pytest.mark.parametrize('modifies', ["decoders", "weights"])
+def test_generic_rule(Simulator, nl_nodirect, seed, modifies):
+    n = 100
+    input_vector = np.asarray([0.5, -0.5])
+    dt = 0.001
+    reg = 0.1
+
+    m = nengo.Network(seed=seed)
+    with m:
+        m.config[nengo.Ensemble].neuron_type = nl_nodirect()
+        u = nengo.Node(output=input_vector)
+        a = nengo.Ensemble(n, dimensions=2)
+        b = nengo.Ensemble(n, dimensions=2)
+
+        nengo.Connection(u, a)
+
+        if modifies == "decoders":
+            def regularized_pes(target, data):
+                return -dt / n * np.outer(data[:2], data[2:]) - target * reg
+        else:
+            def regularized_pes(target, data, params):
+                encoders = params[b].encoders
+                gains = params[b].gain
+                return (-dt / n *
+                        np.outer(np.dot(encoders, data[:2]) * gains,
+                                 data[2:]) - target * reg)
+
+        rule = GenericRule(regularized_pes, learning_rate=1e-3,
+                           size_in=2 + n, modifies=modifies,
+                           pass_model_params=modifies == "weights")
+
+        conn = nengo.Connection(
+            a if modifies == "decoders" else a.neurons,
+            b if modifies == "decoders" else b.neurons,
+            transform=1 if modifies == "decoders" else
+            nengo.dists.Gaussian(0, 0.001),
+            learning_rule_type=rule)
+        nengo.Connection(b, conn.learning_rule[:2])
+        nengo.Connection(u, conn.learning_rule[:2])
+        nengo.Connection(a.neurons, conn.learning_rule[2:], synapse=0.005)
+
+        b_p = nengo.Probe(b, synapse=0.1)
+        weights_p = nengo.Probe(conn, attr="weights")
+
+    with Simulator(m, dt=dt) as sim:
+        sim.run(1.)
+
+    tmask = sim.trange() > .9
+    assert (np.sum(np.abs(sim.data[weights_p][:10])) >
+            np.sum(np.abs(sim.data[weights_p][-10:])))
+    assert np.allclose(sim.data[b_p][tmask], -input_vector, atol=0.05)
+
+
+def test_generic_encoders(Simulator, nl_nodirect, rng, seed):
+    """Voja test implemented via generic rule."""
+
+    n = 200
+    learned_vector = np.asarray([0.3, -0.4, 0.6])
+    learned_vector /= np.linalg.norm(learned_vector)
+    n_change = n // 2  # modify first half of the encoders
+    dt = 1e-3
+
+    # Set the first half to always fire with random encoders, and the
+    # remainder to never fire due to their encoder's dot product with the input
+    intercepts = np.asarray([-1] * n_change + [0.99] * (n - n_change))
+    rand_encoders = UniformHypersphere(surface=True).sample(
+        n_change, len(learned_vector), rng=rng)
+    encoders = np.append(
+        rand_encoders, [-learned_vector] * (n - n_change), axis=0)
+
+    m = nengo.Network(seed=seed)
+    with m:
+        m.config[nengo.Ensemble].neuron_type = nl_nodirect()
+        u = nengo.Node(output=learned_vector)
+        x = nengo.Ensemble(n, dimensions=len(learned_vector),
+                           intercepts=intercepts, encoders=encoders,
+                           radius=2.0)  # to test encoder scaling
+
+        def generic_voja(enc, data, params):
+            scale = (params[x].gain / x.radius)[:, None]
+            return (scale * np.outer(data[:n], data[n:]) -
+                    data[:n, None] * enc)
+
+        conn = nengo.Connection(
+            u, x, synapse=None,
+            learning_rule_type=GenericRule(
+                generic_voja, learning_rate=1e-1 * dt, modifies="encoders",
+                size_in=len(learned_vector) + n, pass_model_params=True))
+        nengo.Connection(u, conn.learning_rule[n:], synapse=None)
+        nengo.Connection(x.neurons, conn.learning_rule[:n], synapse=0.005)
+
+    with Simulator(m, dt=dt) as sim:
+        sim.run(1.0)
+
+        scaled_encoders = sim.signals[sim.model.sig[x]['encoders']]
+
+    encoder_scale = (sim.model.params[x].gain / x.radius)[:, np.newaxis]
+
+    # Check that the last half kept the same encoders throughout the simulation
+    assert np.allclose(sim.model.params[x].scaled_encoders[n_change:],
+                       scaled_encoders[n_change:])
+    # and that they are also equal to their originally assigned value
+    assert np.allclose(sim.model.params[x].scaled_encoders[n_change:] /
+                       encoder_scale[n_change:], -learned_vector)
+
+    # Check that the first half converged to the input
+    assert np.allclose(scaled_encoders[:n_change] / encoder_scale[:n_change],
+                       learned_vector, atol=0.01)

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -12,7 +12,6 @@ def _test_pes(Simulator, nl, plt, seed,
               pre_neurons=False, post_neurons=False, weight_solver=False,
               vin=np.array([0.5, -0.5]), vout=None, n=200,
               function=None, transform=np.array(1.), rate=1e-3):
-
     vout = np.array(vin) if vout is None else vout
 
     model = nengo.Network(seed=seed)
@@ -83,7 +82,7 @@ def test_pes_weight_solver(Simulator, plt, seed):
 
 def test_pes_ens_slice(Simulator, plt, seed):
     vin = [0.5, -0.5]
-    vout = [vin[0]**2 + vin[1]**2]
+    vout = [vin[0] ** 2 + vin[1] ** 2]
     function = lambda x: [x[0] - x[1]]
     _test_pes(Simulator, nengo.LIF, plt, seed, vin=vin, vout=vout,
               function=function)
@@ -186,7 +185,7 @@ def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt):
     with m:
         u = nengo.Node(WhiteSignal(0.5, high=10), size_out=2)
         a = nengo.Ensemble(n, dimensions=2)
-        b = nengo.Ensemble(n+1, dimensions=2)
+        b = nengo.Ensemble(n + 1, dimensions=2)
         nengo.Connection(u, a)
 
         if solver:
@@ -205,7 +204,7 @@ def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt):
         ap = nengo.Probe(a, synapse=0.03)
         up = nengo.Probe(b, synapse=0.03)
 
-    with Simulator(m, seed=seed+1) as sim:
+    with Simulator(m, seed=seed + 1) as sim:
         sim.run(0.5)
     t = sim.trange()
 
@@ -313,6 +312,7 @@ def test_reset(Simulator, learning_rule, plt, seed, rng):
 
 def test_learningruletypeparam():
     """LearningRuleTypeParam must be one or many learning rules."""
+
     class Test(object):
         lrp = LearningRuleTypeParam('lrp', default=None)
 
@@ -333,6 +333,7 @@ def test_learningruletypeparam():
 
 def test_learningrule_attr(seed):
     """Test learning_rule attribute on Connection"""
+
     def check_rule(rule, conn, rule_type):
         assert rule.connection is conn and rule.learning_rule_type is rule_type
 
@@ -369,7 +370,7 @@ def test_voja_encoders(Simulator, nl_nodirect, rng, seed):
 
     # Set the first half to always fire with random encoders, and the
     # remainder to never fire due to their encoder's dot product with the input
-    intercepts = np.asarray([-1]*n_change + [0.99]*(n - n_change))
+    intercepts = np.asarray([-1] * n_change + [0.99] * (n - n_change))
     rand_encoders = UniformHypersphere(surface=True).sample(
         n_change, len(learned_vector), rng=rng)
     encoders = np.append(
@@ -480,35 +481,37 @@ def test_generic_rule(Simulator, nl_nodirect, seed, modifies):
     with m:
         m.config[nengo.Ensemble].neuron_type = nl_nodirect()
         u = nengo.Node(output=input_vector)
+        error = nengo.Node(size_in=2)
         a = nengo.Ensemble(n, dimensions=2)
         b = nengo.Ensemble(n, dimensions=2)
 
         nengo.Connection(u, a)
-
-        if modifies == "decoders":
-            def regularized_pes(target, data):
-                return -dt / n * np.outer(data[:2], data[2:]) - target * reg
-        else:
-            def regularized_pes(target, data, params):
-                encoders = params[b].encoders
-                gains = params[b].gain
-                return (-dt / n *
-                        np.outer(np.dot(encoders, data[:2]) * gains,
-                                 data[2:]) - target * reg)
-
-        rule = GenericRule(regularized_pes, learning_rate=1e-3,
-                           size_in=2 + n, modifies=modifies,
-                           pass_model_params=modifies == "weights")
-
+        nengo.Connection(b, error)
+        nengo.Connection(u, error)
         conn = nengo.Connection(
             a if modifies == "decoders" else a.neurons,
             b if modifies == "decoders" else b.neurons,
             transform=1 if modifies == "decoders" else
-            nengo.dists.Gaussian(0, 0.001),
-            learning_rule_type=rule)
-        nengo.Connection(b, conn.learning_rule[:2])
-        nengo.Connection(u, conn.learning_rule[:2])
-        nengo.Connection(a.neurons, conn.learning_rule[2:], synapse=0.005)
+            nengo.dists.Gaussian(0, 0.001))
+
+        if modifies == "decoders":
+            def regularized_pes(target, error, activities):
+                return -dt / n * np.outer(error, activities) - target * reg
+        else:
+            def regularized_pes(target, error, activities, params):
+                return (-dt / n * np.outer(np.dot(params.encoders, error) *
+                                           params.gain, activities) -
+                        target * reg)
+
+        probes = [
+            nengo.Probe(conn, attr="weights"),
+            nengo.Probe(error),
+            nengo.Probe(a.neurons, synapse=0.005)]
+        if modifies == "weights":
+            probes += [nengo.Probe(b, attr='params')]
+
+        conn.learning_rule_type = GenericRule(
+            regularized_pes, probes, learning_rate=1e-3, modifies=modifies)
 
         b_p = nengo.Probe(b, synapse=0.1)
         weights_p = nengo.Probe(conn, attr="weights")
@@ -547,18 +550,19 @@ def test_generic_encoders(Simulator, nl_nodirect, rng, seed):
                            intercepts=intercepts, encoders=encoders,
                            radius=2.0)  # to test encoder scaling
 
-        def generic_voja(enc, data, params):
-            scale = (params[x].gain / x.radius)[:, None]
-            return (scale * np.outer(data[:n], data[n:]) -
-                    data[:n, None] * enc)
+        def generic_voja(enc, input, activities, params):
+            scale = (params.gain / x.radius)[:, None]
+            return (scale * np.outer(activities, input) -
+                    activities[:, None] * enc)
 
-        conn = nengo.Connection(
+        nengo.Connection(
             u, x, synapse=None,
             learning_rule_type=GenericRule(
-                generic_voja, learning_rate=1e-1 * dt, modifies="encoders",
-                size_in=len(learned_vector) + n, pass_model_params=True))
-        nengo.Connection(u, conn.learning_rule[n:], synapse=None)
-        nengo.Connection(x.neurons, conn.learning_rule[:n], synapse=0.005)
+                generic_voja, [nengo.Probe(x, 'encoders'),
+                               nengo.Probe(u),
+                               nengo.Probe(x.neurons, synapse=0.005),
+                               nengo.Probe(x, 'params')],
+                learning_rate=1e-1 * dt, modifies="encoders"))
 
     with Simulator(m, dt=dt) as sim:
         sim.run(1.0)


### PR DESCRIPTION
The idea is that this allows someone to specify an arbitrary Python function for the learning rule.  You need to define a function that accepts the previous decoders and a "data" vector, and outputs a change in the decoders.  The data vector is the output of some node; the idea is that users connect up whatever inputs they want to a passthrough node (although it doesn't have to be a passthrough, could be something more complex), and then we pass the output of that node to the learning rule.

See `test_learning_rule.py` for an example of implementing the PES rule using this syntax.
