### PR TITLE
Minor progress bar tweaks

### DIFF
--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -187,42 +187,52 @@ class Simulator(object):
 
         self._probe()
 
-    def run(self, time_in_seconds, progress_bar=None):
+    def run(self, time_in_seconds, progress_bar=True):
         """Simulate for the given length of time.
-
-        If the simulation is expected to exceed a run time of one second, a
-        progress bar will appear by default. Usually, this will be an ASCII
-        command line version, but it can be an HTML version in recent IPython
-        notebook versions. To disable the progress bar use
-        :class:`nengo.utils.progress.NoProgressBar`.
-
-        If the `progress_bar` argument is not an
-        :class:`nengo.utils.progress.ProgressUpdater`, it will be wrapped by a
-        default ``ProgressUpdater`` depending on the execution environment.
 
         Parameters
         ----------
         steps : int
             Number of steps to run the simulation for.
-        progress_bar : :class:`nengo.utils.progress.ProgressBar` or
+        progress_bar : bool or :class:`nengo.utils.progress.ProgressBar` or
                        :class:`nengo.utils.progress.ProgressUpdater`, optional
             Progress bar for displaying the progress.
+
+            By default, ``progress_bar=True``, which uses the default progress
+            bar (text in most situations, or an HTML version in recent IPython
+            notebooks).
+
+            To disable the progress bar, use ``progress_bar=False``.
+
+            For more control over the progress bar, pass in a
+            :class:`nengo.utils.progress.ProgressBar`,
+            or :class:`nengo.utils.progress.ProgressUpdater` instance.
         """
         steps = int(np.round(float(time_in_seconds) / self.dt))
         logger.debug("Running %s for %f seconds, or %d steps",
                      self.model.label, time_in_seconds, steps)
         self.run_steps(steps, progress_bar=progress_bar)
 
-    def run_steps(self, steps, progress_bar=None):
+    def run_steps(self, steps, progress_bar=True):
         """Simulate for the given number of `dt` steps.
 
         Parameters
         ----------
         steps : int
             Number of steps to run the simulation for.
-        progress_bar : :class:`nengo.utils.progress.ProgressBar` or
-                        :class:`nengo.utils.progress.ProgressUpdater`, optional
+        progress_bar : bool or :class:`nengo.utils.progress.ProgressBar` or
+                       :class:`nengo.utils.progress.ProgressUpdater`, optional
             Progress bar for displaying the progress.
+
+            By default, ``progress_bar=True``, which uses the default progress
+            bar (text in most situations, or an HTML version in recent IPython
+            notebooks).
+
+            To disable the progress bar, use ``progress_bar=False``.
+
+            For more control over the progress bar, pass in a
+            :class:`nengo.utils.progress.ProgressBar`,
+            or :class:`nengo.utils.progress.ProgressUpdater` instance.
         """
         with ProgressTracker(steps, progress_bar) as progress:
             for i in range(steps):

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -67,6 +67,7 @@ class TestAutoProgressBar(object):
         def __init__(self, eta, start_time=1234.5):
             self.eta = lambda: eta
             self.start_time = start_time
+            self.finished = False
 
     def test_progress_not_shown_if_eta_below_threshold(self):
         progress_mock = self.ProgressMock(0.2)
@@ -87,6 +88,17 @@ class TestAutoProgressBar(object):
             auto_progress.update(progress_mock)
 
         assert progress_bar.n_update_calls >= 10
+
+    def test_progress_shown_when_finished(self):
+        progress_mock = self.ProgressMock(0.2)
+        progress_bar = ProgressBarMock()
+        auto_progress = AutoProgressBar(progress_bar, min_eta=10.)
+
+        auto_progress.update(progress_mock)
+        assert progress_bar.n_update_calls == 0
+        progress_mock.finished = True
+        auto_progress.update(progress_mock)
+        assert progress_bar.n_update_calls >= 1
 
 
 class TestUpdateN(object):


### PR DESCRIPTION
As discussed in the now closed #493:
- The default progress bar is only used if `True` is passed in to the `ProgressTracker` (or the `wrap_with_progressupdater` function).
- If `False` is passed to `wrap_with_progressupdate`, `NoProgressBar` is used.
- `ProgressBar`s now accept a string which represents the task being tracked. It selfishly defaults to "Simulation", as that's what we use it for, but it'll be handy to be changeable if we ever track the build process also. The default message when a progress bar finishes is now "{task} finished in {time}" rather than "Done in {time}".
- The `AutoProgressBar` now updates as usual if the task is finished. This is so that, even if the bar isn't initially shown and updated, there's still a handy message that the simulation finished.
