### PR TITLE
Fix setup.py not installing NumPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,11 @@ setup(
     license="See LICENSE.rst",
     description=description,
     long_description=long_description,
+    # Without this, `setup.py install` fails to install NumPy.
+    # See https://github.com/nengo/nengo/issues/508 for details.
+    setup_requires=[
+        "numpy>=1.6",
+    ],
     install_requires=[
         "numpy>=1.6",
     ],


### PR DESCRIPTION
It seems to install just fine if NumPy is in `setup_requires` rather than `install_requires`. I'm not sure if NumPy should be removed from `install_requires`, but I feel like best not to touch it in case something reads `install_requires` but not `setup_requires`.

Tested on Mac OS X 10.10 and setuptools 2.2. Doesn't install NumPy twice, but leaves an annoying `.egg` folder in the Nengo directory (which can be removed with no ill-effects).
