### PR TITLE
Add Sigmoid neuron type

### DIFF
--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -20,8 +20,8 @@ from .config import Config
 from .connection import Connection
 from .ensemble import Ensemble
 from .node import Node
-from .neurons import (
-    AdaptiveLIF, AdaptiveLIFRate, Direct, LIF, LIFRate, RectifiedLinear)
+from .neurons import (AdaptiveLIF, AdaptiveLIFRate, Direct, LIF, LIFRate,
+                      RectifiedLinear, Sigmoid)
 from .network import Network
 from .learning_rules import PES, BCM, Oja
 from .params import Default

--- a/nengo/builder/neurons.py
+++ b/nengo/builder/neurons.py
@@ -4,7 +4,7 @@ from nengo.builder.builder import Builder
 from nengo.builder.signal import Signal
 from nengo.builder.operator import Operator
 from nengo.neurons import (
-    AdaptiveLIF, AdaptiveLIFRate, LIF, LIFRate, RectifiedLinear)
+    AdaptiveLIF, AdaptiveLIFRate, LIF, LIFRate, RectifiedLinear, Sigmoid)
 
 
 class SimNeurons(Operator):
@@ -34,6 +34,13 @@ class SimNeurons(Operator):
 @Builder.register(RectifiedLinear)
 def build_rectifiedlinear(model, reclinear, neurons):
     model.add_op(SimNeurons(neurons=reclinear,
+                            J=model.sig[neurons]['in'],
+                            output=model.sig[neurons]['out']))
+
+
+@Builder.register(Sigmoid)
+def build_sigmoid(model, sigmoid, neurons):
+    model.add_op(SimNeurons(neurons=sigmoid,
                             J=model.sig[neurons]['in'],
                             output=model.sig[neurons]['out']))
 

--- a/nengo/networks/tests/test_ensemblearray.py
+++ b/nengo/networks/tests/test_ensemblearray.py
@@ -177,7 +177,8 @@ def test_neuronconnection(Simulator, nl, seed):
     s = Simulator(net)
     s.run(0.1)
 
-    assert np.all(s.data[p][-1] == 0.0)
+    # Some nls (e.g. Sigmoid) never go all the way to 0
+    assert np.all(s.data[p][-1] < 1e-2)
 
     if nl == nengo.Direct:
         assert (len(catcher.record) == 1 and

--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import nengo.utils.numpy as npext
-from nengo.neurons import Direct, LIF, LIFRate, RectifiedLinear
+from nengo.neurons import Direct, LIF, LIFRate, RectifiedLinear, Sigmoid
 from nengo.rc import rc
 from nengo.simulator import Simulator as ReferenceSimulator
 from nengo.utils.compat import ensure_bytes
@@ -95,9 +95,11 @@ def seed(request):
 
 def pytest_generate_tests(metafunc):
     if "nl" in metafunc.funcargnames:
-        metafunc.parametrize("nl", [Direct, LIF, LIFRate, RectifiedLinear])
+        metafunc.parametrize(
+            "nl", [Direct, LIF, LIFRate, RectifiedLinear, Sigmoid])
     if "nl_nodirect" in metafunc.funcargnames:
-        metafunc.parametrize("nl_nodirect", [LIF, LIFRate, RectifiedLinear])
+        metafunc.parametrize(
+            "nl_nodirect", [LIF, LIFRate, RectifiedLinear, Sigmoid])
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Includes the testing commits from #569, and includes (part of) the generic `gain_bias` calculation from [`nengo_brainstorm`](https://github.com/ctn-waterloo/nef-chip-hardware/blob/master/nengo_brainstorm/neuron_tuning.py#L60).

Still a WIP to look at Monday morning; in this case, the issue is that the sigmoid is between 0 and 1, but really we should be scaling it to be from 0 to max_rates; not entirely sure the best way to do that, since `step_math` doesn't have access to gains and biases (they're incorporated into `J`).
