### PR TITLE
Test seeds are now machine-independent.

### DIFF
--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -250,7 +250,7 @@ def test_dt_dependence(Simulator, plt, learning_rule, seed, rng):
     plt.saveas = "test_learning_rules.test_dt_dependence_%s.pdf" % (
         learning_rule.__name__)
 
-    assert np.allclose(trans_data[0], trans_data[1], atol=1e-3)
+    assert np.allclose(trans_data[0], trans_data[1], atol=2e-3)
     assert not np.all(sim.data[trans_p][0] == sim.data[trans_p][-1])
 
 

--- a/nengo/tests/test_pytest.py
+++ b/nengo/tests/test_pytest.py
@@ -1,0 +1,8 @@
+import nengo.utils.numpy as npext
+from nengo.tests.conftest import test_seed
+
+
+def test_seed_fixture(seed):
+    """The seed should be the same on all machines"""
+    i = (seed - test_seed) % npext.maxint
+    assert i == 1832276344


### PR DESCRIPTION
Test seeds are generated by hashing the test function name
and filename. Previously, test seeds were using the full
filename, meaning that test results were very machine dependent.
We now use the relative filename (i.e. the name within the
Nengo directory), making things machine independent.

Fixes #586.

WIP: this change of seed has caused some tests to fail,
so we need to revisit tolerances on those tests.
