### PR TITLE
Fixed matrix exponential for filter design.

### DIFF
--- a/nengo/utils/filter_design.py
+++ b/nengo/utils/filter_design.py
@@ -44,6 +44,7 @@ from numpy import (product, zeros, array, dot, r_, eye,
                    atleast_1d, atleast_2d, poly, roots, asarray, allclose)
 
 from .compat import range
+from .numpy import expm
 
 
 class BadCoefficients(UserWarning):
@@ -380,18 +381,6 @@ def ss2zpk(A, B, C, D, input=0):
 
     """
     return tf2zpk(*ss2tf(A, B, C, D, input=input))
-
-
-def expm(A):
-    """Simple matrix exponential to replace Scipy's matrix exponential"""
-    w, V = np.linalg.eig(A)
-    E = np.dot(V * np.exp(w), np.linalg.inv(V))
-
-    if np.allclose(np.abs(E), np.abs(E.real), rtol=1e-20, atol=0):
-        # negligible imaginary part
-        return E.real
-    else:
-        return E
 
 
 def cont2discrete(sys, dt, method="zoh", alpha=None):  # noqa: C901

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -32,6 +32,40 @@ def array(x, dims=None, min_dims=0, **kwargs):
     return y
 
 
+def expm(A, n_factors=None, normalize=False):
+    """Simple matrix exponential to replace Scipy's matrix exponential
+
+    This just uses a recursive (factored) version of the Taylor series,
+    and is not as good as Scipy (which uses Pade approximants). The hard
+    part with this implementation is choosing the length of the Taylor
+    series. A longer series is generally needed for a matrix with a larger
+    eigenvalues, but I'm not exactly sure how these relate. I'm using
+    a heuristic based on the matrix norm, since this is kind-of related
+    to the size of eigenvalues, though for larger norms the function
+    becomes inaccurate no matter the length of the series.
+
+    This function is mostly intended for use in `filter_design`, where
+    the matrices should be small, both in dimensions and norm.
+    """
+    if A.ndim != 2 or A.shape[0] != A.shape[1]:
+        raise ValueError("Argument must be a square matrix")
+
+    a = np.linalg.norm(A)
+    if normalize:
+        a = int(a)
+        A = A / float(a)
+
+    if n_factors is None:
+        n_factors = 20 if normalize else max(20, int(a))
+
+    Y = np.zeros_like(A)
+    for i in range(n_factors, 0, -1):
+        Y = np.dot(A / float(i), Y)
+        np.fill_diagonal(Y, Y.diagonal() + 1)  # add identity matrix
+
+    return np.linalg.matrix_power(Y, a) if normalize else Y
+
+
 def norm(x, axis=None, keepdims=False):
     """Euclidean norm
 

--- a/nengo/utils/tests/test_filter_design.py
+++ b/nengo/utils/tests/test_filter_design.py
@@ -16,14 +16,33 @@ def test_expm(rng):
         assert np.allclose(linalg.expm(a), expm(a))
 
 
-@pytest.mark.optional
-def test_cont2discrete():
-    import scipy.signal
+@pytest.mark.parametrize('dt', [1e-3, 1e-2, 1e-1])
+def test_cont2discrete_zoh(dt):
+    taus = np.logspace(-np.log10(dt) - 1, np.log10(dt) + 3, 30)
 
-    dt = 1e-3
-    tau = 0.03
-    num, den = [1], [tau**2, 2*tau, 1]
-    num0, den0, _ = scipy.signal.cont2discrete((num, den), dt)
+    # test with lowpass filter, using analytic solution
+    for tau in taus:
+        num, den = [1], [tau, 1]
+        d = -np.expm1(-dt / tau)
+        num0, den0 = [0, d], [1, d - 1]
+        num1, den1, _ = cont2discrete((num, den), dt)
+        assert np.allclose(num0, num1)
+        assert np.allclose(den0, den1)
+
+    # test with alpha filter, using analytic solution
+    for tau in taus:
+        num, den = [1], [tau**2, 2*tau, 1]
+        a = dt / tau
+        ea = np.exp(-a)
+        num0 = [0, -a*ea + (1 - ea), ea*(a + ea - 1)]
+        den0 = [1, -2 * ea, ea**2]
+        num1, den1, _ = cont2discrete((num, den), dt)
+        assert np.allclose(num0, num1)
+        assert np.allclose(den0, den1)
+
+    # test integrative filter, using analytic solution
+    num, den = [1], [1, 0]
+    num0, den0 = [0, dt], [1, -1]
     num1, den1, _ = cont2discrete((num, den), dt)
     assert np.allclose(num0, num1)
     assert np.allclose(den0, den1)


### PR DESCRIPTION
- The previous implementation did not work on
  non-diagonalizable matrices; the new one does.
- Also expanded the test of `cont2discrete`,
  and made it not require Scipy.