### PR TITLE
Parameters outside the config system

### DIFF
--- a/nengo/base.py
+++ b/nengo/base.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from nengo.config import Config
-from nengo.params import Default, is_param, Parameter
+from nengo.params import Default, is_param, Parameter, Unconfigurable
 from nengo.utils.compat import with_metaclass
 
 
@@ -140,7 +140,7 @@ class ObjView(object):
 class NengoObjectParam(Parameter):
     def __init__(self, default=None, optional=False, readonly=True,
                  nonzero_size_in=False, nonzero_size_out=False):
-        assert default is None  # These can't have defaults
+        assert default in [None, Unconfigurable]  # These can't have defaults
         self.nonzero_size_in = nonzero_size_in
         self.nonzero_size_out = nonzero_size_out
         super(NengoObjectParam, self).__init__(default, optional, readonly)

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -138,9 +138,9 @@ class ObjView(object):
 
 
 class NengoObjectParam(Parameter):
-    def __init__(self, default=None, optional=False, readonly=True,
+    def __init__(self, optional=False, readonly=True,
                  nonzero_size_in=False, nonzero_size_out=False):
-        assert default in [None, Unconfigurable]  # These can't have defaults
+        default = Unconfigurable  # These can't have defaults
         self.nonzero_size_in = nonzero_size_in
         self.nonzero_size_out = nonzero_size_out
         super(NengoObjectParam, self).__init__(default, optional, readonly)

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -53,7 +53,7 @@ class ClassParams(object):
             super(ClassParams, self).__setattr__(key, value)
         else:
             param = self.get_param(key)
-            if not param.is_configurable:
+            if not param.configurable:
                 raise ValueError("Parameter '%s' is not configurable" % key)
 
             param.validate(self, value)
@@ -249,6 +249,11 @@ class Config(object):
 
         # Get the descriptor
         desc = getattr(nengo_cls, param)
+        if not desc.configurable:
+            raise ValueError("Unconfigurable parameters have no defaults. "
+                             "Please ensure you are not using the 'Default' "
+                             "keyword with an unconfigurable parameter.")
+
         for config in reversed(Config.context):
 
             # If a default has been set for this config, return it
@@ -283,7 +288,8 @@ class Config(object):
         else:
             lines.append("Current defaults for %s:" % nengo_cls.__name__)
             for attr in dir(nengo_cls):
-                if is_param(getattr(nengo_cls, attr)):
+                desc = getattr(nengo_cls, attr)
+                if is_param(desc) and desc.configurable:
                     val = Config.default(nengo_cls, attr)
                     lines.append("  %s: %s" % (attr, val))
         return "\n".join(lines)

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -52,8 +52,12 @@ class ClassParams(object):
         if key.startswith("_"):
             super(ClassParams, self).__setattr__(key, value)
         else:
-            self.get_param(key).validate(self, value)
-            self.get_param(key).defaults[self] = value
+            param = self.get_param(key)
+            if not param.is_configurable:
+                raise ValueError("Parameter '%s' is not configurable" % key)
+
+            param.validate(self, value)
+            param.defaults[self] = value
 
     def __delattr__(self, key):
         if key.startswith("_"):

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -1,7 +1,16 @@
 import warnings
 
-from nengo.params import Parameter
+from nengo.base import NengoObjectParam
+from nengo.params import Parameter, NumberParam, Unconfigurable
 from nengo.utils.compat import is_iterable, itervalues
+
+
+class ConnectionParam(NengoObjectParam):
+    def validate(self, instance, conn):
+        from nengo.connection import Connection
+        if not isinstance(conn, Connection):
+            raise ValueError("'%s' is not a Connection" % conn)
+        super(ConnectionParam, self).validate(instance, conn)
 
 
 class LearningRuleType(object):
@@ -11,6 +20,7 @@ class LearningRuleType(object):
     the Connection on which you want to do learning.
     """
 
+    learning_rate = NumberParam(default=Unconfigurable, low=0, low_open=True)
     probeable = []
 
     def __init__(self, learning_rate=1e-6):
@@ -46,6 +56,7 @@ class PES(LearningRuleType):
         The modulatory connection created to project the error signal.
     """
 
+    error_connection = ConnectionParam(default=Unconfigurable)
     modifies = ['Ensemble', 'Neurons']
     probeable = ['scaled_error', 'activities']
 
@@ -76,6 +87,9 @@ class BCM(LearningRuleType):
     TODO
     """
 
+    pre_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
+    post_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
+    theta_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
     modifies = ['Neurons']
     probeable = ['theta', 'pre_filtered', 'post_filtered']
 
@@ -109,6 +123,9 @@ class Oja(LearningRuleType):
     TODO
     """
 
+    pre_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
+    post_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
+    beta = NumberParam(default=Unconfigurable, low=0)
     modifies = ['Neurons']
     probeable = ['pre_filtered', 'post_filtered']
 

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -1,7 +1,7 @@
 import warnings
 
 from nengo.base import NengoObjectParam
-from nengo.params import Parameter, NumberParam, Unconfigurable
+from nengo.params import Parameter, NumberParam
 from nengo.utils.compat import is_iterable, itervalues
 
 
@@ -20,7 +20,7 @@ class LearningRuleType(object):
     the Connection on which you want to do learning.
     """
 
-    learning_rate = NumberParam(default=Unconfigurable, low=0, low_open=True)
+    learning_rate = NumberParam(low=0, low_open=True)
     probeable = []
 
     def __init__(self, learning_rate=1e-6):
@@ -56,7 +56,7 @@ class PES(LearningRuleType):
         The modulatory connection created to project the error signal.
     """
 
-    error_connection = ConnectionParam(default=Unconfigurable)
+    error_connection = ConnectionParam()
     modifies = ['Ensemble', 'Neurons']
     probeable = ['scaled_error', 'activities']
 
@@ -87,9 +87,9 @@ class BCM(LearningRuleType):
     TODO
     """
 
-    pre_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
-    post_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
-    theta_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
+    pre_tau = NumberParam(low=0, low_open=True)
+    post_tau = NumberParam(low=0, low_open=True)
+    theta_tau = NumberParam(low=0, low_open=True)
     modifies = ['Neurons']
     probeable = ['theta', 'pre_filtered', 'post_filtered']
 
@@ -123,9 +123,9 @@ class Oja(LearningRuleType):
     TODO
     """
 
-    pre_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
-    post_tau = NumberParam(default=Unconfigurable, low=0, low_open=True)
-    beta = NumberParam(default=Unconfigurable, low=0)
+    pre_tau = NumberParam(low=0, low_open=True)
+    post_tau = NumberParam(low=0, low_open=True)
+    beta = NumberParam(low=0)
     modifies = ['Neurons']
     probeable = ['pre_filtered', 'post_filtered']
 

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -4,7 +4,7 @@ import logging
 
 import numpy as np
 
-from nengo.params import Parameter, NumberParam, Unconfigurable
+from nengo.params import Parameter, NumberParam
 from nengo.utils.compat import range
 from nengo.utils.neurons import settled_firingrate
 
@@ -136,7 +136,7 @@ class RectifiedLinear(NeuronType):
 class Sigmoid(NeuronType):
     """Neuron whose response curve is a sigmoid."""
 
-    tau_ref = NumberParam(default=Unconfigurable, low=0)
+    tau_ref = NumberParam(low=0)
     probeable = ['rates']
 
     def __init__(self, tau_ref=0.002):
@@ -162,8 +162,8 @@ class Sigmoid(NeuronType):
 class LIFRate(NeuronType):
     """Rate version of the leaky integrate-and-fire (LIF) neuron model."""
 
-    tau_rc = NumberParam(default=Unconfigurable, low=0, low_open=True)
-    tau_ref = NumberParam(default=Unconfigurable, low=0)
+    tau_rc = NumberParam(low=0, low_open=True)
+    tau_ref = NumberParam(low=0)
     probeable = ['rates']
 
     def __init__(self, tau_rc=0.02, tau_ref=0.002):
@@ -254,8 +254,8 @@ class LIF(LIFRate):
 class AdaptiveLIFRate(LIFRate):
     """Adaptive rate version of the LIF neuron model."""
 
-    tau_n = NumberParam(default=Unconfigurable, low=0, low_open=True)
-    inc_n = NumberParam(default=Unconfigurable, low=0)
+    tau_n = NumberParam(low=0, low_open=True)
+    inc_n = NumberParam(low=0)
     probeable = ['rates', 'adaptation']
 
     def __init__(self, tau_n=1, inc_n=0.01, **lif_args):
@@ -331,10 +331,10 @@ class Izhikevich(NeuronType):
        (http://www.izhikevich.org/publications/spikes.pdf)
     """
 
-    tau_recovery = NumberParam(default=Unconfigurable, low=0, low_open=True)
-    coupling = NumberParam(default=Unconfigurable, low=0)
-    reset_voltage = NumberParam(default=Unconfigurable)
-    reset_recovery = NumberParam(default=Unconfigurable)
+    tau_recovery = NumberParam(low=0, low_open=True)
+    coupling = NumberParam(low=0)
+    reset_voltage = NumberParam()
+    reset_recovery = NumberParam()
     probeable = ['spikes', 'voltage', 'recovery']
 
     def __init__(self, tau_recovery=0.02, coupling=0.2,

--- a/nengo/tests/test_base.py
+++ b/nengo/tests/test_base.py
@@ -8,15 +8,17 @@ def test_nengoobjectparam():
     """NengoObjectParam must be a Nengo object and is readonly by default."""
     class Test(object):
         nop = NengoObjectParam()
-
     inst = Test()
-    assert inst.nop is None
+
     # Must be a Nengo object
     with pytest.raises(ValueError):
         inst.nop = 'a'
+
+    # Can set it once
     a = nengo.Ensemble(10, dimensions=2, add_to_container=False)
     inst.nop = a.neurons
     assert inst.nop is a.neurons
+
     # Can't set it twice
     with pytest.raises(ValueError):
         inst.nop = a

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -317,13 +317,13 @@ def test_learningrule_attr(seed):
 
     with nengo.Network(seed=seed):
         a, b, e = [nengo.Ensemble(10, 2) for i in range(3)]
-        r1, r2, r3 = PES(e), BCM(), Oja()
+        c = nengo.Connection(a, b, modulatory=True)  # dummy error connection
 
-        r1 = PES(e)
+        r1 = PES(c)
         c1 = nengo.Connection(a.neurons, b.neurons, learning_rule_type=r1)
         check_rule(c1.learning_rule, c1, r1)
 
-        r2 = [PES(e), BCM()]
+        r2 = [PES(c), BCM()]
         c2 = nengo.Connection(a.neurons, b.neurons, learning_rule_type=r2)
         assert isinstance(c2.learning_rule, list)
         for rule, rule_type in zip(c2.learning_rule, r2):

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -62,14 +62,6 @@ def test_readonly():
     assert inst.r == 'set'
 
 
-def test_readonly_assert():
-    """Readonly Parameters must default to None."""
-
-    with pytest.raises(AssertionError):
-        class Test(object):
-            p = params.Parameter(default=1, readonly=True)
-
-
 def test_boolparam():
     """BoolParams can only be booleans."""
 

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -8,6 +8,10 @@ import numpy as np
 maxint = np.iinfo(np.int32).max
 
 
+def compare(a, b):
+    return 0 if a == b else 1 if a > b else -1 if a < b else None
+
+
 def broadcast_shape(shape, length):
     """Pad a shape with ones following standard Numpy broadcasting."""
     n = len(shape)


### PR DESCRIPTION
This build fixes up Parameters so they can be used outside the config system, and puts them to work in NeuronType and LearningRuleType so that we can validate the parameters on these objects.

The central part of this PR is the `Unconfigurable` type, which is used as a value for the Parameter default to indicate that the Parameter has no default and cannot be set with the config system. If you try to use the parameter before it's been set, you get an error. The second commit makes `Unconfigurable` the default value for Parameter defaults, which doesn't break any existing code since any parameter that is configurable needs a default.