### PR TITLE
Connections can take dists for eval_points

### DIFF
--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -6,8 +6,8 @@ from nengo.base import NengoObject, NengoObjectParam, ObjView
 from nengo.ensemble import Ensemble
 from nengo.learning_rules import LearningRuleType, LearningRuleTypeParam
 from nengo.node import Node
-from nengo.params import (
-    Default, BoolParam, FunctionParam, IntParam, ListParam, NdarrayParam)
+from nengo.params import (Default, BoolParam, DistributionParam, FunctionParam,
+                          IntParam, ListParam, NdarrayParam)
 from nengo.solvers import LstsqL2, SolverParam
 from nengo.synapses import Lowpass, SynapseParam
 from nengo.utils.compat import is_iterable, iteritems
@@ -47,7 +47,7 @@ class ConnectionSolverParam(SolverParam):
                     "(got '%s')" % conn.post.__class__.__name__)
 
 
-class EvalPointsParam(NdarrayParam):
+class EvalPointsParam(DistributionParam):
     def validate(self, conn, ndarray):
         """Eval points are only valid when pre is an ensemble."""
         if not isinstance(conn.pre, Ensemble):
@@ -208,7 +208,7 @@ class Connection(NengoObject):
     learning_rule_type = ConnectionLearningRuleTypeParam(
         default=None, optional=True)
     eval_points = EvalPointsParam(
-        default=None, optional=True, shape=('*', 'size_in'))
+        default=None, optional=True, sample_shape=('*', 'size_in'))
     seed = IntParam(default=None, optional=True)
     probeable = ListParam(default=['output', 'input', 'transform', 'decoders'])
 

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -605,6 +605,7 @@ def test_set_eval_points(Simulator):
         b = nengo.Ensemble(10, 2)
         # ConnEvalPoints parameter checks that pre is an ensemble
         nengo.Connection(a, b, eval_points=[[0, 0], [0.5, 1]])
+        nengo.Connection(a, b, eval_points=nengo.dists.Uniform(0, 1))
         with pytest.raises(ValueError):
             nengo.Connection(a.neurons, b, eval_points=[[0, 0], [0.5, 1]])
 


### PR DESCRIPTION
As has been requested a number of times in the past while :rainbow: I only tested that it builds (in `test_connection.test_set_eval_points`); other PRs are in the queue that will test it functionally.