### PR TITLE
Fixing scaling target function

### DIFF
--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -29,7 +29,8 @@ def build_linear_system(model, conn, rng):
         eval_points = npext.array(
             model.params[conn.pre_obj].eval_points, min_dims=2)
     else:
-        eval_points = gen_eval_points(conn.pre_obj, conn.eval_points, rng)
+        eval_points = gen_eval_points(
+            conn.pre_obj, conn.eval_points, rng, conn.scale_eval_points)
 
     x = np.dot(eval_points, encoders.T / conn.pre_obj.radius)
     activities = conn.pre_obj.neuron_type.rates(x, gain, bias)

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -24,7 +24,7 @@ def sample(dist, n_samples, rng):
     return np.array(dist)
 
 
-def gen_eval_points(ens, eval_points, rng):
+def gen_eval_points(ens, eval_points, rng, scale_eval_points=True):
     if isinstance(eval_points, Distribution):
         n_points = ens.n_eval_points
         if n_points is None:
@@ -37,7 +37,8 @@ def gen_eval_points(ens, eval_points, rng):
                           "n_eval_points. Ignoring n_eval_points.")
         eval_points = np.array(eval_points, dtype=np.float64)
 
-    eval_points *= ens.radius  # scale by ensemble radius
+    if scale_eval_points:
+        eval_points *= ens.radius  # scale by ensemble radius
     return eval_points
 
 

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -165,6 +165,9 @@ class Connection(NengoObject):
     eval_points : (n_eval_points, pre_size) array_like or int, optional
         Points at which to evaluate `function` when computing decoders,
         spanning the interval (-pre.radius, pre.radius) in each dimension.
+    scale_eval_points : bool
+        Indicates whether the eval_points should be scaled by the radius of
+        the pre Ensemble. Defaults to True.
     learning_rule_type : instance or list or dict of LearningRuleType, optional
         Methods of modifying the connection weights during simulation.
 
@@ -209,12 +212,14 @@ class Connection(NengoObject):
         default=None, optional=True)
     eval_points = EvalPointsParam(
         default=None, optional=True, sample_shape=('*', 'size_in'))
+    scale_eval_points = BoolParam(default=True)
     seed = IntParam(default=None, optional=True)
     probeable = ListParam(default=['output', 'input', 'transform', 'decoders'])
 
     def __init__(self, pre, post, synapse=Default, transform=Default,
                  solver=Default, learning_rule_type=Default, function=Default,
-                 modulatory=Default, eval_points=Default, seed=Default):
+                 modulatory=Default, eval_points=Default,
+                 scale_eval_points=Default, seed=Default):
         self.pre = pre
         self.post = post
 
@@ -224,6 +229,7 @@ class Connection(NengoObject):
         self.modulatory = modulatory
         self.synapse = synapse
         self.transform = transform
+        self.scale_eval_points = scale_eval_points
         self.eval_points = eval_points  # Must be set before function
         self.function_info = function  # Must be set after transform
 

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -615,7 +615,8 @@ def test_set_eval_points(Simulator):
 
 @pytest.mark.parametrize('sample', [False, True])
 @pytest.mark.parametrize('radius', [0.5, 1., 1.5])
-def test_eval_points_scaling(Simulator, sample, radius, seed, rng):
+@pytest.mark.parametrize('scale', [False, True])
+def test_eval_points_scaling(Simulator, sample, radius, seed, rng, scale):
     eval_points = UniformHypersphere()
     if sample:
         eval_points = eval_points.sample(500, 3, rng=rng)
@@ -624,12 +625,14 @@ def test_eval_points_scaling(Simulator, sample, radius, seed, rng):
     with model:
         a = nengo.Ensemble(1, 3, radius=radius)
         b = nengo.Ensemble(1, 3)
-        con = nengo.Connection(a, b, eval_points=eval_points)
+        con = nengo.Connection(a, b, eval_points=eval_points,
+                               scale_eval_points=scale)
 
     sim = Simulator(model)
     dists = np.linalg.norm(sim.data[con].eval_points, axis=1)
-    assert np.all(dists <= radius)
-    assert np.any(dists >= 0.9 * radius)
+    limit = radius if scale else 1.0
+    assert np.all(dists <= limit)
+    assert np.any(dists >= 0.9 * limit)
 
 
 def test_solverparam():

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -54,4 +54,6 @@ def target_function(eval_points, targets):
         x = tuple(x)
         return func_dict[x]
 
-    return {'function': function, 'eval_points': eval_points}
+    return {'function': function,
+            'eval_points': eval_points,
+            'scale_eval_points': False}


### PR DESCRIPTION
Here's a quick fix for #623.  This adds a ```scale_eval_points``` to Connection, as discussed in #564 but at the time we didn't think there was a pressing need to add it, so we were holding off.  However, without this feature I don't see a nice way to use ```nengo.utils.target_function``` on an pre-Ensemble with a radius that isn't 1.0. (issue #623).