### PR TITLE
Fix usage of `astype` for NumPy 1.6

### DIFF
--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -58,9 +58,8 @@ def build_ensemble(model, ens):
     if isinstance(ens.neuron_type, Direct):
         encoders = np.identity(ens.dimensions)
     elif isinstance(ens.encoders, Distribution):
-        encoders = ens.encoders.sample(
-            ens.n_neurons, ens.dimensions, rng=rng).astype(
-            np.float64, copy=False)
+        encoders = ens.encoders.sample(ens.n_neurons, ens.dimensions, rng=rng)
+        encoders = np.asarray(encoders, dtype=np.float64)
     else:
         encoders = npext.array(ens.encoders, min_dims=2, dtype=np.float64)
     encoders /= npext.norm(encoders, axis=1, keepdims=True)


### PR DESCRIPTION
The `copy` kwarg was added to NumPy in 1.7. Since we depend on `numpy>=1.6`, we shouldn't use it. This uses `asarray` instead.