### PR TITLE
Node functions get t as float, x as readonly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,20 +7,27 @@ Release History
    version (release date)
    ======================
 
-   ** section **
+   **section**
 
    - One-line description of change (link to Github issue/PR)
 
 .. Changes should be organized in one of several sections:
 
-   - API Changes
+   - API changes
    - Improvements
-   - Behavioural Changes
+   - Behavioural changes
    - Bugfixes
    - Documentation
 
 2.0.1 (unreleased)
 ==================
+
+**Behavioural changes**
+
+- Node functions receive ``t`` as a float (instead of a NumPy scalar)
+  and ``x`` as a readonly NumPy array (instead of a writeable array).
+  (`#626 <https://github.com/nengo/nengo/issues/626>`_,
+  `#628 <https://github.com/nengo/nengo/pull/628>`_)
 
 2.0.0 (January 15, 2015)
 ========================

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -40,7 +40,7 @@ class OutputParam(Parameter):
         self.data[node] = output
 
     def validate_callable(self, node, output):
-        t, x = np.asarray(0.0), np.zeros(node.size_in)
+        t, x = 0.0, np.zeros(node.size_in)
         args = (t, x) if node.size_in > 0 else (t,)
         result, invoked = checked_call(output, *args)
         if not invoked:

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -316,6 +316,22 @@ def test_delay(Simulator, plt):
     plt.plot(sim.trange(), -sim.data[bp])
 
 
+def test_args(Simulator, plt):
+    def fn(t, x):
+        assert isinstance(t, float)
+        assert isinstance(x, np.ndarray)
+        assert x.flags.writeable is False
+        assert x[0] == t
+
+    with nengo.Network() as model:
+        u = nengo.Node(lambda t: t)
+        v = nengo.Node(fn, size_in=1, size_out=0)
+        nengo.Connection(u, v, synapse=None)
+
+    sim = Simulator(model)
+    sim.run(0.01)
+
+
 if __name__ == "__main__":
     nengo.log(debug=True)
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
Node functions now receive `t` as a float (as opposed to a
zero-dimensional array), and `x` as a readonly view onto the
simulator data. This addresses #626.