### PR TITLE
Pytest decorator improvements

### DIFF
--- a/nengo/spa/tests/test_thalamus.py
+++ b/nengo/spa/tests/test_thalamus.py
@@ -6,7 +6,7 @@ from nengo import spa
 import numpy as np
 
 
-@pytest.mark.optional  # Too slow
+@pytest.mark.slow
 def test_thalamus(Simulator, plt, seed):
     model = spa.SPA(seed=seed)
 

--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -113,17 +113,20 @@ def pytest_generate_tests(metafunc):
 def pytest_addoption(parser):
     parser.addoption('--benchmarks', action='store_true', default=False,
                      help='Also run benchmarking tests')
+    parser.addoption('--plots', action='store_true', default=False,
+                     help='Also run plotting tests')
     parser.addoption('--noexamples', action='store_false', default=True,
                      help='Do not run examples')
     parser.addoption(
-        '--optional', action='store_true', default=False,
-        help='Also run optional tests that may use optional packages')
+        '--slow', action='store_true', default=False,
+        help='Also run slow tests.')
 
 
 def pytest_runtest_setup(item):
     for mark, option, message in [
             ('benchmark', 'benchmarks', "benchmarks not requested"),
             ('example', 'noexamples', "examples not requested"),
-            ('optional', 'optional', "optional tests not requested")]:
+            ('plot', 'plots', "plots not requested"),
+            ('slow', 'slow', "slow tests not requested")]:
         if getattr(item.obj, mark, None) and not item.config.getvalue(option):
             pytest.skip(message)

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -21,8 +21,8 @@ from nengo.utils.stdlib import execfile
 def pytest_generate_tests(metafunc):
     examples = glob('%s/*.ipynb' % examples_dir)
 
-    # if `--optional` is not set, filter out time-consuming notebooks
-    ignores = [] if metafunc.config.option.optional else [
+    # if `--slow` is not set, filter out time-consuming notebooks
+    ignores = [] if metafunc.config.option.slow else [
         'inhibitory_gating.ipynb', 'izhikevich.ipynb',
         'learn_communication_channel.ipynb', 'learn_product.ipynb',
         'learn_square.ipynb', 'learn_unsupervised.ipynb',
@@ -32,7 +32,7 @@ def pytest_generate_tests(metafunc):
         'spa_parser.ipynb', 'spa_sequence.ipynb',
         'spa_sequence_routed.ipynb']
     argvalues = [pytest.mark.skipif(os.path.basename(path) in ignores,
-                                    reason="Time-consuming")(path)
+                                    reason="slow")(path)
                  for path in examples]
 
     if "nb_path" in metafunc.funcargnames:

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -43,6 +43,7 @@ def pytest_generate_tests(metafunc):
 def test_noexceptions(nb_path, tmpdir, plt):
     """Ensure that no cells raise an exception."""
     pytest.importorskip("IPython", minversion="1.0")
+    pytest.importorskip("jinja2")
     from nengo.utils.ipython import export_py, load_notebook
     nb = load_notebook(nb_path)
     pyfile = "%s.py" % (
@@ -57,6 +58,7 @@ def test_noexceptions(nb_path, tmpdir, plt):
 def test_nooutput(nb_path):
     """Ensure that no cells have output."""
     pytest.importorskip("IPython", minversion="1.0")
+    pytest.importorskip("jinja2")
     from nengo.utils.ipython import load_notebook
     nb = load_notebook(nb_path)
 

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -2,6 +2,10 @@ from glob import glob
 import os
 
 import pytest
+import _pytest.capture
+
+from nengo.utils.paths import examples_dir
+from nengo.utils.stdlib import execfile
 
 # Monkeypatch _pytest.capture.DontReadFromInput
 #  If we don't do this, importing IPython will choke as it reads the current
@@ -9,13 +13,9 @@ import pytest
 #  DontReadFromInput as sys.stdin to capture output.
 #  Running with -s option doesn't have this issue, but this monkeypatch
 #  doesn't have any side effects, so it's fine.
-import _pytest.capture
 _pytest.capture.DontReadFromInput.encoding = "utf-8"
 _pytest.capture.DontReadFromInput.write = lambda: None
 _pytest.capture.DontReadFromInput.flush = lambda: None
-
-from nengo.utils.paths import examples_dir
-from nengo.utils.stdlib import execfile
 
 
 def pytest_generate_tests(metafunc):

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -120,9 +120,9 @@ def test_subsolvers(Solver, seed, rng, tol=1e-2):
         # in-situ. They are tested more robustly elsewhere.
 
 
-@pytest.mark.optional
 @pytest.mark.parametrize('Solver', [LstsqL1])
 def test_decoder_solver_extra(Solver, plt, rng):
+    pytest.importorskip('sklearn')
     test_decoder_solver(Solver, plt, rng)
 
 
@@ -158,8 +158,9 @@ def test_weight_solver(Solver, rng):
     assert np.allclose(W1, W2)
 
 
-@pytest.mark.optional  # uses scipy
 def test_scipy_solvers(rng):
+    pytest.importorskip('scipy')
+
     A, b = get_system(1000, 100, 2, rng=rng)
     sigma = 0.1 * A.max()
 
@@ -170,9 +171,10 @@ def test_scipy_solvers(rng):
     assert np.allclose(x0, x2, atol=2e-5, rtol=1e-3)
 
 
-@pytest.mark.optional  # uses scipy
 @pytest.mark.parametrize('Solver', [Nnls, NnlsL2, NnlsL2nz])
 def test_nnls(Solver, plt, rng):
+    pytest.importorskip('scipy')
+
     A, x = get_system(500, 100, 1, rng=rng, sort=True)
     y = x**2
 
@@ -195,6 +197,8 @@ def test_nnls(Solver, plt, rng):
 
 @pytest.mark.benchmark
 def test_subsolvers_L2(rng):
+    pytest.importorskip('scipy')
+
     ref_solver = cholesky
     solvers = [conjgrad, block_conjgrad, conjgrad_scipy, lsmr_scipy]
 
@@ -219,6 +223,8 @@ def test_subsolvers_L2(rng):
 
 @pytest.mark.benchmark
 def test_subsolvers_L1(rng):
+    pytest.importorskip('sklearn')
+
     A, B = get_system(m=2000, n=1000, d=10, rng=rng)
 
     l1 = 1e-4
@@ -229,6 +235,7 @@ def test_subsolvers_L1(rng):
 
 @pytest.mark.benchmark
 def test_compare_solvers(Simulator, plt, seed):
+    pytest.importorskip('sklearn')
 
     N = 70
     decoder_solvers = [

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import numpy as np
-from mpl_toolkits.mplot3d import Axes3D  # noqa
+import mpl_toolkits.mplot3d  # noqa  Make 3d projection available.
 import pytest
 
 import nengo

--- a/nengo/utils/tests/test_filter_design.py
+++ b/nengo/utils/tests/test_filter_design.py
@@ -9,8 +9,8 @@ from nengo.utils.filter_design import expm, cont2discrete
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.optional
 def test_expm(rng):
+    pytest.importorskip('scipy')
     import scipy.linalg as linalg
     for a in [np.eye(3), rng.randn(10, 10)]:
         assert np.allclose(linalg.expm(a), expm(a))

--- a/nengo/utils/tests/test_matplotlib.py
+++ b/nengo/utils/tests/test_matplotlib.py
@@ -8,7 +8,7 @@ import nengo
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.optional
+@pytest.mark.plot
 @pytest.mark.parametrize('use_eventplot', [True, False])
 def test_rasterplot(use_eventplot, Simulator, seed, plt):
     from nengo.utils.matplotlib import rasterplot

--- a/nengo/utils/tests/test_neurons.py
+++ b/nengo/utils/tests/test_neurons.py
@@ -66,8 +66,8 @@ def _test_rates(Simulator, rates, plt, seed, name=None):
     return relative_rmse
 
 
-@pytest.mark.optional  # requires Scipy
 def test_rates_isi(Simulator, plt, seed):
+    pytest.importorskip('scipy')
     rel_rmse = _test_rates(Simulator, rates_isi, plt, seed)
     assert rel_rmse < 0.3
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,5 @@ commands = flake8 -v nengo
 
 [flake8]
 exclude = __init__.py
+ignore = E123,E133,E226,E241,E242,E731
 max-complexity = 10


### PR DESCRIPTION
This addresses #603. With this PR there shouldn't be any test failures because of uninstalled dependencies anymore, instead those tests are automatically skipped. The reason for the skip can be displayed (including the missing module name) with the `-rs` option to pytest. I think, this approach is preferrable as a failing test should always indicate "something is wrong" and not "maybe something is wrong, but we don't know because of a missing dependency". Because skipped tests are indicated in it's own category, it is still clear that not all tests ran and some of those might fail.

With this the `optional` mark should not be used for tests with special dependencies anymore. I think, at the moment it is only used for slow tests and it seems the same is true for `benchmark`. Maybe we should get rid of one of those? Maybe the remaining mark should be renamed to `slow` as it is more descriptive? (I might want to use `benchmark` for some other benchmarking related pytest functionality I am planning to try to implement.)

Note: I assume `matplotlib` to be a depency for running the test and did not mark all the tests which fail without it.