### PR TITLE
NeuronType functions handle array_like

### DIFF
--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -249,6 +249,10 @@ class array_like(object):
             callargs = inspect.getcallargs(_wrapped, *args, **kwargs)
             for arg in self.arguments:
                 callargs[arg] = np.array(callargs[arg], **self.array_kwargs)
-            return wrapped(**callargs)
+
+            args = tuple(callargs[arg] for arg in argspec.args)
+            varargs = callargs.get(argspec.varargs, ())
+            keywords = callargs.get(argspec.keywords, {})
+            return wrapped(*(args + varargs), **kwargs)
 
         return FunctionWrapper(wrapped, wrapper)

--- a/nengo/utils/tests/test_numpy.py
+++ b/nengo/utils/tests/test_numpy.py
@@ -2,7 +2,29 @@ from __future__ import absolute_import
 
 import numpy as np
 
-from nengo.utils.numpy import meshgrid_nd
+from nengo.utils.numpy import array_like, meshgrid_nd
+
+
+def test_array_like():
+    # test complex function signature
+    @array_like('a', 'b')
+    def fn1(a, b=[1, 2], *args, **kwargs):
+        assert isinstance(a, np.ndarray)
+        assert isinstance(b, np.ndarray)
+        assert kwargs['c'] == 'hi'
+
+    fn1([1, 3], c='hi')
+
+    # test multiple decorators
+    @array_like('a', ndmin=1)
+    @array_like('b', ndmin=2)
+    def fn2(a, b):
+        assert isinstance(a, np.ndarray)
+        assert isinstance(b, np.ndarray)
+        assert a.ndim >= 1
+        assert b.ndim >= 2
+
+    fn2(3, 5)
 
 
 def test_meshgrid_nd():


### PR DESCRIPTION
- Allow `NeuronType.rates` and `NeuronType.gain_bias` to handle
  all array_like arguments, including single numbers, lists, and
  arrays.
- To facilitate this, I added the `array_like` decorator that marks
  function arguments to be passed through `np.array` (with
  `copy=False` by default).
