### PR TITLE
Add RC setting for dtype

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -140,7 +140,7 @@ travis_yml:
     - stage: basic
       script: static
     - script: test-coverage-scipy
-      test_args: --plots
+      test_args: --memory --plots
     - script: test-coverage
       test_args: --plots
       python: 3.5

--- a/.templates/coverage.sh.template
+++ b/.templates/coverage.sh.template
@@ -2,6 +2,7 @@
 
 {% block script %}
     {# pytest-cov doesn't work well with -p nengo.tests.options #}
-    exe coverage run -m pytest {{ pkg_name }} -v --color=yes --durations 20 "$TEST_ARGS"
+    # shellcheck disable=SC2086
+    exe coverage run -m pytest {{ pkg_name }} -v --color=yes --durations 20 $TEST_ARGS
     exe coverage report -m
 {% endblock %}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
   -
     env:
       SCRIPT="test-coverage-scipy"
-      TEST_ARGS="--plots"
+      TEST_ARGS="--memory --plots"
   -
     env:
       SCRIPT="test-coverage"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Release History
   added to the model. See `configuration options
   <https://www.nengo.ai/nengo/nengorc.html#configuration-options>`__
   for details. (`#1532 <https://github.com/nengo/nengo/pull/1532>`__)
+- Added a ``--memory`` option for pytest that prints the total memory
+  consumed by the tests when they complete (Linux and Mac OS X only).
+  (`#640 <https://github.com/nengo/nengo/pull/640>`__)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ Release History
 - Added a ``--memory`` option for pytest that prints the total memory
   consumed by the tests when they complete (Linux and Mac OS X only).
   (`#640 <https://github.com/nengo/nengo/pull/640>`__)
+- Added a bit precision setting to change the number of bits allocated
+  to each value tracked by Nengo.
+  (`#640 <https://github.com/nengo/nengo/pull/640>`__)
 
 **Changed**
 

--- a/nengo-data/nengorc
+++ b/nengo-data/nengorc
@@ -26,6 +26,12 @@
 
 ### CONFIGURATION BEGINS HERE
 
+# --- Settings for controlling the precision of all calculations
+[precision]
+
+# Default bit precision for all NumPy arrays made by Nengo (e.g., bits: 64
+# would use float64/int64 dtypes). Must be one of '16', '32', or '64'. (string)
+#bits: 64
 
 # --- Settings for the decoder cache
 [decoder_cache]

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -3,11 +3,11 @@ import warnings
 
 import numpy as np
 
-from nengo import rc
 from nengo.builder.signal import Signal, SignalDict
 from nengo.builder.operator import TimeUpdate
 from nengo.cache import NoDecoderCache
 from nengo.exceptions import BuildError
+from nengo.rc import rc
 
 
 class Model:
@@ -21,6 +21,9 @@ class Model:
         A name or description to differentiate models.
     decoder_cache : DecoderCache, optional
         Interface to a cache for expensive parts of the build process.
+    builder : `nengo.builder.Builder`, optional
+        A ``Builder`` instance to use for building. Defaults to a
+        new ``Builder()``.
 
     Attributes
     ----------
@@ -82,11 +85,13 @@ class Model:
         self.seeded = {}
 
         self.sig = collections.defaultdict(dict)
-        self.sig['common'][0] = Signal(0., readonly=True, name='ZERO')
-        self.sig['common'][1] = Signal(1., readonly=True, name='ONE')
+        self.sig['common'][0] = Signal(
+            np.array(0., dtype=rc.float_dtype), readonly=True, name='ZERO')
+        self.sig['common'][1] = Signal(
+            np.array(1., dtype=rc.float_dtype), readonly=True, name='ONE')
 
-        self.step = Signal(np.array(0, dtype=np.int64), name='step')
-        self.time = Signal(np.array(0, dtype=np.float64), name='time')
+        self.step = Signal(np.array(0, dtype=rc.int_dtype), name='step')
+        self.time = Signal(np.array(0, dtype=rc.float_dtype), name='time')
         self.add_op(TimeUpdate(self.step, self.time))
 
         self.builder = Builder() if builder is None else builder

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -12,6 +12,7 @@ from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError, ObsoleteError
 from nengo.neurons import Direct
 from nengo.node import Node
+from nengo.rc import rc
 from nengo.solvers import NoSolver, Solver
 from nengo.utils.numpy import is_iterable
 
@@ -62,19 +63,22 @@ def get_eval_points(model, conn, rng):
     if conn.eval_points is None:
         view = model.params[conn.pre_obj].eval_points.view()
         view.setflags(write=False)
+        assert view.dtype == rc.float_dtype
         return view
     else:
         return gen_eval_points(
-            conn.pre_obj, conn.eval_points, rng, conn.scale_eval_points)
+            conn.pre_obj, conn.eval_points, rng, conn.scale_eval_points,
+            dtype=rc.float_dtype)
 
 
-def get_targets(conn, eval_points):
+def get_targets(conn, eval_points, dtype=None):
+    dtype = rc.float_dtype if dtype is None else dtype
     if conn.function is None:
-        targets = eval_points[:, conn.pre_slice]
+        targets = eval_points[:, conn.pre_slice].astype(dtype)
     elif isinstance(conn.function, np.ndarray):
         targets = conn.function
     else:
-        targets = np.zeros((len(eval_points), conn.size_mid))
+        targets = np.zeros((len(eval_points), conn.size_mid), dtype=dtype)
         for i, ep in enumerate(eval_points[:, conn.pre_slice]):
             out = conn.function(ep)
             if out is None:
@@ -95,7 +99,7 @@ def build_linear_system(model, conn, rng):
             "This is because no evaluation points fall in the firing "
             "ranges of any neurons." % (conn, conn.pre_obj))
 
-    targets = get_targets(conn, eval_points)
+    targets = get_targets(conn, eval_points, dtype=rc.float_dtype)
     return eval_points, activities, targets
 
 
@@ -105,7 +109,7 @@ def build_decoders(model, conn, rng):
     bias = model.params[conn.pre_obj].bias
 
     eval_points = get_eval_points(model, conn, rng)
-    targets = get_targets(conn, eval_points)
+    targets = get_targets(conn, eval_points, dtype=rc.float_dtype)
 
     if conn.solver.weights and not conn.solver.compositional:
         # solver is solving for the whole weight matrix, so apply
@@ -158,8 +162,8 @@ def slice_signal(model, signal, sl):
     if isinstance(sl, slice) and (sl.step is None or sl.step == 1):
         return signal[sl]
     else:
-        size = np.arange(signal.size)[sl].size
-        sliced_signal = Signal(np.zeros(size), name="%s.sliced" % signal.name)
+        size = np.arange(signal.size, dtype=rc.float_dtype)[sl].size
+        sliced_signal = Signal(shape=size, name="%s.sliced" % signal.name)
         model.add_op(Copy(signal, sliced_signal, src_slice=sl))
         return sliced_signal
 
@@ -171,8 +175,8 @@ def build_solver(model, solver, conn, rng):
 
 @Builder.register(NoSolver)
 def build_no_solver(model, solver, conn, rng):
-    activities = np.zeros((1, conn.pre_obj.n_neurons))
-    targets = np.zeros((1, conn.size_mid))
+    activities = np.zeros((1, conn.pre_obj.n_neurons), dtype=rc.float_dtype)
+    targets = np.zeros((1, conn.size_mid), dtype=rc.float_dtype)
     # No need to invoke the cache for NoSolver
     decoders, solver_info = conn.solver(activities, targets, rng=rng)
     weights = decoders.T
@@ -249,7 +253,7 @@ def build_connection(model, conn):
         elif isinstance(conn.function, np.ndarray):
             raise BuildError("Cannot use function points in direct connection")
         else:
-            in_signal = Signal(np.zeros(conn.size_mid), name='%s.func' % conn)
+            in_signal = Signal(shape=conn.size_mid, name='%s.func' % conn)
             model.add_op(SimPyFunc(in_signal, conn.function, None, sliced_in))
     elif isinstance(conn.pre_obj, Ensemble):  # Normal decoded connection
         eval_points, decoders, solver_info = model.build(

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -491,7 +491,7 @@ def build_learning_rule(model, rule):
     else:
         raise BuildError("Unknown target %r" % rule.modifies)
 
-    delta = Signal(np.zeros(target.shape), name='Delta')
+    delta = Signal(shape=target.shape, name='Delta')
 
     model.add_op(Copy(delta, target, inc=True, tag=tag))
     model.sig[rule]['delta'] = delta
@@ -614,7 +614,7 @@ def build_voja(model, voja, rule):
 
     # Learning signal, defaults to 1 in case no connection is made
     # and multiplied by the learning_rate * dt
-    learning = Signal(np.zeros(rule.size_in), name="Voja:learning")
+    learning = Signal(shape=rule.size_in, name="Voja:learning")
     assert rule.size_in == 1
     model.add_op(Reset(learning, value=1.0))
     model.sig[rule]['in'] = learning  # optional connection will attach here
@@ -664,7 +664,7 @@ def build_pes(model, pes, rule):
     conn = rule.connection
 
     # Create input error signal
-    error = Signal(np.zeros(rule.size_in), name="PES:error")
+    error = Signal(shape=rule.size_in, name="PES:error")
     model.add_op(Reset(error))
     model.sig[rule]['in'] = error  # error connection will attach here
 

--- a/nengo/builder/neurons.py
+++ b/nengo/builder/neurons.py
@@ -3,6 +3,7 @@ import numpy as np
 from nengo.builder import Builder, Operator, Signal
 from nengo.neurons import (AdaptiveLIF, AdaptiveLIFRate, Izhikevich, LIF,
                            NeuronType, SpikingRectifiedLinear)
+from nengo.rc import rc
 
 
 class SimNeurons(Operator):
@@ -130,7 +131,7 @@ def build_spikingrectifiedlinear(model, spikingrectifiedlinear, neurons):
     """
 
     model.sig[neurons]['voltage'] = Signal(
-        np.zeros(neurons.size_in), name="%s.voltage" % neurons)
+        shape=neurons.size_in, name="%s.voltage" % neurons)
     model.add_op(SimNeurons(
         neurons=spikingrectifiedlinear,
         J=model.sig[neurons]['in'],
@@ -161,9 +162,9 @@ def build_lif(model, lif, neurons):
     """
 
     model.sig[neurons]['voltage'] = Signal(
-        np.zeros(neurons.size_in), name="%s.voltage" % neurons)
+        shape=neurons.size_in, name="%s.voltage" % neurons)
     model.sig[neurons]['refractory_time'] = Signal(
-        np.zeros(neurons.size_in), name="%s.refractory_time" % neurons)
+        shape=neurons.size_in, name="%s.refractory_time" % neurons)
     model.add_op(SimNeurons(
         neurons=lif,
         J=model.sig[neurons]['in'],
@@ -195,7 +196,7 @@ def build_alifrate(model, alifrate, neurons):
     """
 
     model.sig[neurons]['adaptation'] = Signal(
-        np.zeros(neurons.size_in), name="%s.adaptation" % neurons)
+        shape=neurons.size_in, name="%s.adaptation" % neurons)
     model.add_op(SimNeurons(neurons=alifrate,
                             J=model.sig[neurons]['in'],
                             output=model.sig[neurons]['out'],
@@ -226,11 +227,11 @@ def build_alif(model, alif, neurons):
     """
 
     model.sig[neurons]['voltage'] = Signal(
-        np.zeros(neurons.size_in), name="%s.voltage" % neurons)
+        shape=neurons.size_in, name="%s.voltage" % neurons)
     model.sig[neurons]['refractory_time'] = Signal(
-        np.zeros(neurons.size_in), name="%s.refractory_time" % neurons)
+        shape=neurons.size_in, name="%s.refractory_time" % neurons)
     model.sig[neurons]['adaptation'] = Signal(
-        np.zeros(neurons.size_in), name="%s.adaptation" % neurons)
+        shape=neurons.size_in, name="%s.adaptation" % neurons)
     model.add_op(SimNeurons(neurons=alif,
                             J=model.sig[neurons]['in'],
                             output=model.sig[neurons]['out'],
@@ -262,12 +263,16 @@ def build_izhikevich(model, izhikevich, neurons):
     """
 
     model.sig[neurons]['voltage'] = Signal(
-        np.ones(neurons.size_in) * izhikevich.reset_voltage,
-        name="%s.voltage" % neurons)
+        np.ones(neurons.size_in, dtype=rc.float_dtype)
+        * izhikevich.reset_voltage,
+        name="%s.voltage" % neurons,
+    )
     model.sig[neurons]['recovery'] = Signal(
-        np.ones(neurons.size_in)
+        np.ones(neurons.size_in, dtype=rc.float_dtype)
         * izhikevich.reset_voltage
-        * izhikevich.coupling, name="%s.recovery" % neurons)
+        * izhikevich.coupling,
+        name="%s.recovery" % neurons,
+    )
     model.add_op(SimNeurons(neurons=izhikevich,
                             J=model.sig[neurons]['in'],
                             output=model.sig[neurons]['out'],

--- a/nengo/builder/node.py
+++ b/nengo/builder/node.py
@@ -1,10 +1,9 @@
-import numpy as np
-
 from nengo.builder import Builder, Signal
 from nengo.builder.operator import Reset, SimPyFunc
 from nengo.exceptions import BuildError
 from nengo.node import Node
 from nengo.processes import Process
+from nengo.rc import rc
 from nengo.utils.numpy import is_array_like
 
 
@@ -30,7 +29,7 @@ def build_node(model, node):
 
     # input signal
     if not is_array_like(node.output) and node.size_in > 0:
-        sig_in = Signal(np.zeros(node.size_in), name="%s.in" % node)
+        sig_in = Signal(shape=node.size_in, name="%s.in" % node)
         model.add_op(Reset(sig_in))
     else:
         sig_in = None
@@ -39,15 +38,18 @@ def build_node(model, node):
     if node.output is None:
         sig_out = sig_in
     elif isinstance(node.output, Process):
-        sig_out = Signal(np.zeros(node.size_out), name="%s.out" % node)
+        sig_out = Signal(shape=node.size_out, name="%s.out" % node)
         model.build(node.output, sig_in, sig_out)
     elif callable(node.output):
-        sig_out = (Signal(np.zeros(node.size_out), name="%s.out" % node)
+        sig_out = (Signal(shape=node.size_out, name="%s.out" % node)
                    if node.size_out > 0 else None)
         model.add_op(SimPyFunc(
             output=sig_out, fn=node.output, t=model.time, x=sig_in))
     elif is_array_like(node.output):
-        sig_out = Signal(node.output, name="%s.out" % node)
+        sig_out = Signal(
+            node.output.astype(rc.float_dtype),
+            name="%s.out" % node,
+        )
     else:
         raise BuildError(
             "Invalid node output type %r" % type(node.output).__name__)

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -394,7 +394,8 @@ class Copy(Operator):
         # If there are repeated indices in dst_slice, special handling needed.
         repeats = False
         if npext.is_array_like(dst_slice):
-            dst_slice = np.array(dst_slice)  # copy because we might modify it
+            # copy because we might modify it
+            dst_slice = np.array(dst_slice)
             if dst_slice.dtype.kind != "b":
                 # get canonical, positive indices first
                 dst_slice[dst_slice < 0] += len(dst)
@@ -696,7 +697,7 @@ class BsrDotInc(DotInc):
             mat_A = self.bsr_matrix((A, self.indices, self.indptr))
             inc = mat_A.dot(X)
             if self.reshape:
-                inc = np.asarray(inc).reshape(Y.shape)
+                inc = inc.reshape(Y.shape)
             Y[...] += inc
         return step_dotinc
 

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -11,6 +11,7 @@ from nengo.builder.neurons import SimNeurons
 from nengo.builder import operator
 from nengo.builder.operator import DotInc, ElementwiseInc, Copy
 from nengo.builder.signal import Signal
+from nengo.rc import rc
 from nengo.utils.graphs import BidirectionalDAG, transitive_closure
 from nengo.utils.stdlib import Timer, WeakKeyDefaultDict, WeakSet
 
@@ -226,7 +227,8 @@ class OpMergePass:
         """
 
         # Sort to have sequential memory.
-        offsets = np.array([self.opinfo[op].v_offset for op in subset])
+        offsets = np.array(
+            [self.opinfo[op].v_offset for op in subset], dtype=rc.float_dtype)
         sort_indices = np.argsort(offsets)
         offsets = offsets[sort_indices]
         sorted_subset = [subset[i] for i in sort_indices]
@@ -662,13 +664,13 @@ class DotIncMerger(Merger):
         Y, Y_sigr = SigMerger.merge([o.Y for o in ops])
 
         # Construct sparse A representation
-        data = np.array([o.A.initial_value for o in ops])
+        data = np.array([o.A.initial_value for o in ops], dtype=rc.float_dtype)
         if data.ndim == 1:
             data = data.reshape((data.size, 1, 1))
         elif data.ndim == 2:
             data = data.reshape(data.shape + (1,))
-        indptr = np.arange(len(ops) + 1, dtype=int)
-        indices = np.arange(len(ops), dtype=int)
+        indptr = np.arange(len(ops) + 1, dtype=rc.int_dtype)
+        indices = np.arange(len(ops), dtype=rc.int_dtype)
         name = 'bsr_merged<{first}, ..., {last}>'.format(
             first=ops[0].A.name, last=ops[-1].A.name)
         readonly = all([o.A.readonly for o in ops])

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from nengo.builder import Builder, Signal
 from nengo.builder.operator import Copy, Reset
 from nengo.connection import Connection, LearningRule
@@ -22,7 +20,7 @@ def conn_probe(model, probe):
     model.seeds[conn] = model.seeds[probe]
 
     # Make a sink signal for the connection
-    model.sig[probe]['in'] = Signal(np.zeros(conn.size_out), name=str(probe))
+    model.sig[probe]['in'] = Signal(shape=conn.size_out, name=str(probe))
     model.add_op(Reset(model.sig[probe]['in']))
 
     # Build the connection
@@ -44,7 +42,7 @@ def signal_probe(model, key, probe):
     if probe.synapse is None:
         model.sig[probe]['in'] = sig
     else:
-        model.sig[probe]['in'] = Signal(np.zeros(sig.shape), name=str(probe))
+        model.sig[probe]['in'] = Signal(shape=sig.shape, name=str(probe))
         model.sig[probe]['filtered'] = model.build(probe.synapse, sig)
         model.add_op(Copy(model.sig[probe]['filtered'],
                           model.sig[probe]['in']))

--- a/nengo/builder/processes.py
+++ b/nengo/builder/processes.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from nengo.builder import Builder, Operator, Signal
 from nengo.processes import Process
 from nengo.synapses import Synapse
@@ -159,7 +157,7 @@ def build_synapse(model, synapse, sig_in, sig_out=None):
     """
     if sig_out is None:
         sig_out = Signal(
-            np.zeros(sig_in.shape), name="%s.%s" % (sig_in.name, synapse))
+            shape=sig_in.shape, name="%s.%s" % (sig_in.name, synapse))
 
     model.add_op(SimProcess(
         synapse, sig_in, sig_out, model.time, mode='update'))

--- a/nengo/builder/tests/test_connection.py
+++ b/nengo/builder/tests/test_connection.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+import nengo
+from nengo.builder import Model
+from nengo.builder.connection import build_linear_system
+
+
+def test_build_linear_system(seed, rng, plt):
+    func = lambda x: x**2
+
+    with nengo.Network(seed=seed) as net:
+        conn = nengo.Connection(nengo.Ensemble(60, 1), nengo.Ensemble(50, 1),
+                                function=func)
+
+    model = Model()
+    model.build(net)
+    eval_points, activities, targets = build_linear_system(model, conn, rng)
+    assert eval_points.shape[1] == 1
+    assert targets.shape[1] == 1
+    assert activities.shape[1] == 60
+    assert eval_points.shape[0] == activities.shape[0] == targets.shape[0]
+
+    X = eval_points
+    AA = activities.T.dot(activities)
+    AX = activities.T.dot(eval_points)
+    AY = activities.T.dot(targets)
+    WX = np.linalg.solve(AA, AX)
+    WY = np.linalg.solve(AA, AY)
+
+    Xhat = activities.dot(WX)
+    Yhat = activities.dot(WY)
+
+    i = np.argsort(eval_points.ravel())
+    plt.plot(X[i], Xhat[i])
+    plt.plot(X[i], Yhat[i])
+
+    assert np.allclose(Xhat, X, atol=1e-1)
+    assert np.allclose(Yhat, func(X), atol=1e-1)

--- a/nengo/builder/tests/test_optimizer.py
+++ b/nengo/builder/tests/test_optimizer.py
@@ -126,6 +126,9 @@ def test_sigmerger_merge_views():
 
 @pytest.mark.parametrize("net", (thalamus_net, learning_net))
 def test_optimizer_does_not_change_result(seed, net):
+    dtype_resolution = np.finfo(nengo.rc.float_dtype).resolution
+    dtype_decimal = int(np.floor(-np.log10(dtype_resolution) * 0.5))
+
     model = net()
     model.seed = seed
 
@@ -144,4 +147,5 @@ def test_optimizer_does_not_change_result(seed, net):
         sim_opt.run(0.1)
 
     for probe in probes:
-        assert_almost_equal(sim.data[probe], sim_opt.data[probe])
+        assert_almost_equal(sim.data[probe], sim_opt.data[probe],
+                            decimal=dtype_decimal)

--- a/nengo/builder/tests/test_signal.py
+++ b/nengo/builder/tests/test_signal.py
@@ -352,3 +352,13 @@ def test_signal_init(sig_type):
     signals.init(sig)
     with pytest.raises((ValueError, RuntimeError, TypeError)):
         signals[sig].data[0] = -1
+
+
+def test_signal_shape():
+    shape = (3, 4)
+    sig = Signal(shape=shape)
+    assert sig.shape == shape
+
+    Signal(np.zeros(shape), shape=shape)
+    with pytest.raises(AssertionError):
+        Signal(np.zeros((2, 3)), shape=shape)

--- a/nengo/builder/transforms.py
+++ b/nengo/builder/transforms.py
@@ -3,6 +3,7 @@ import numpy as np
 from nengo.builder import Builder, Operator, Signal
 from nengo.builder.operator import DotInc, ElementwiseInc, Reset, SparseDotInc
 from nengo.exceptions import BuildError
+from nengo.rc import rc
 from nengo.transforms import Convolution, Dense, Sparse
 from nengo._vendor.npconv2d import conv2d
 
@@ -23,17 +24,18 @@ def multiply(x, y):
 @Builder.register(Dense)
 def build_dense(model, transform, sig_in,
                 decoders=None, encoders=None, rng=np.random):
-    weights = transform.sample(rng=rng)
+    weights = transform.sample(rng=rng).astype(rc.float_dtype)
 
     if decoders is not None:
-        weights = multiply(weights, decoders)
+        weights = multiply(weights, decoders.astype(rc.float_dtype))
     if encoders is not None:
-        weights = multiply(encoders.T, weights)
+        weights = multiply(encoders.astype(rc.float_dtype).T, weights)
 
     # Add operator for applying weights
-    weight_sig = Signal(weights, name="%s.weights" % transform, readonly=True)
+    weight_sig = Signal(
+        weights, readonly=True, name="%s.weights" % transform)
     weighted = Signal(
-        np.zeros(transform.size_out if encoders is None else weights.shape[0]),
+        shape=transform.size_out if encoders is None else weights.shape[0],
         name="%s.weighted" % transform)
     model.add_op(Reset(weighted))
 
@@ -57,16 +59,15 @@ def build_sparse(model, transform, sig_in,
     assert encoders is None
 
     # Add output signal
-    weighted = Signal(np.zeros(transform.size_out),
-                      name="%s.weighted" % transform)
+    weighted = Signal(shape=transform.size_out, name="%s.weighted" % transform)
     model.add_op(Reset(weighted))
 
     weights = transform.sample(rng=rng)
     assert weights.ndim == 2
 
     # Add operator for applying weights
-    weight_sig = Signal(weights, name="%s.weights" % transform,
-                        readonly=True)
+    weight_sig = Signal(
+        weights, name="%s.weights" % transform, readonly=True)
     model.add_op(SparseDotInc(weight_sig, sig_in, weighted,
                               tag="%s.apply_weights" % transform))
 
@@ -86,9 +87,8 @@ def build_convolution(model, transform, sig_in,
     assert encoders is None
 
     weights = transform.sample(rng=rng)
-    weight_sig = Signal(weights, name="%s.weights" % transform, readonly=True)
-    weighted = Signal(
-        np.zeros(transform.size_out), name="%s.weighted" % transform)
+    weight_sig = Signal(weights, readonly=True, name="%s.weights" % transform)
+    weighted = Signal(shape=transform.size_out, name="%s.weighted" % transform)
     model.add_op(Reset(weighted))
 
     model.add_op(ConvInc(weight_sig, sig_in, weighted, transform,

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -17,6 +17,7 @@ from nengo.params import (
     Parameter,
     Unconfigurable,
 )
+from nengo.rc import rc
 from nengo.solvers import LstsqL2, SolverParam
 from nengo.synapses import Lowpass, SynapseParam
 from nengo.transforms import Dense, Transform
@@ -180,7 +181,7 @@ class ConnectionFunctionParam(Parameter):
         elif isinstance(function, FunctionInfo):
             function_info = function
         elif is_array_like(function):
-            array = np.array(function, copy=False, dtype=np.float64)
+            array = np.array(function, copy=False, dtype=rc.float_dtype)
             self.check_array(conn, array)
             function_info = FunctionInfo(function=array, size=array.shape[1])
         elif callable(function):

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -8,6 +8,7 @@ from nengo.base import NengoObject, ObjView
 from nengo.exceptions import ValidationError
 from nengo.params import Default, IntParam, Parameter
 from nengo.processes import Process
+from nengo.rc import rc
 from nengo.utils.numpy import is_array_like
 from nengo.utils.stdlib import checked_call
 
@@ -65,7 +66,7 @@ class OutputParam(Parameter):
         elif is_array_like(output):
             # Make into correctly shaped numpy array before validation
             output = npext.array(
-                output, min_dims=1, copy=False, dtype=np.float64)
+                output, min_dims=1, copy=False, dtype=rc.float_dtype)
             self.check_ndarray(node, output)
             if not np.all(np.isfinite(output)):
                 raise ValidationError("Output value must be finite.",

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from nengo.exceptions import (
     ConfigError, ObsoleteError, ReadonlyError, ValidationError)
+from nengo.rc import rc
 from nengo.utils.numpy import (
     array_hash, compare, is_array, is_array_like, is_integer, is_number)
 from nengo.utils.stdlib import WeakKeyIDDictionary, checked_call
@@ -380,12 +381,12 @@ class NdarrayParam(Parameter):
     equatable = True
 
     def __init__(self, name, default=Unconfigurable, shape=None,
-                 dtype=np.float64, optional=False, readonly=None):
+                 dtype=None, optional=False, readonly=None):
         if shape is not None:
             assert shape.count('...') <= 1, (
                 "Cannot have more than one ellipsis")
         self.shape = shape
-        self.dtype = dtype
+        self._dtype = dtype
         super().__init__(name, default, optional, readonly)
 
     @property
@@ -394,6 +395,12 @@ class NdarrayParam(Parameter):
             return True
         return all(is_integer(dim) or dim in ('...', '*')
                    for dim in self.shape)
+
+    @property
+    def dtype(self):
+        if self._dtype is not None:
+            return self._dtype
+        return rc.float_dtype
 
     def hashvalue(self, instance):
         return array_hash(self.__get__(instance, None))

--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -62,6 +62,8 @@ Commented lines show the default values for each setting.
 import configparser
 import logging
 
+import numpy as np
+
 import nengo.utils.paths
 
 logger = logging.getLogger(__name__)
@@ -69,6 +71,9 @@ logger = logging.getLogger(__name__)
 # The default core Nengo RC settings. Access with
 #   nengo.RC_DEFAULTS[section_name][option_name]
 RC_DEFAULTS = {
+    'precision': {
+        'bits': 64,
+    },
     'decoder_cache': {
         'enabled': True,
         'readonly': False,
@@ -120,6 +125,16 @@ class _RC(configparser.SafeConfigParser):
         # configparser uses old-style classes without 'super' support
         configparser.SafeConfigParser.__init__(self)
         self.reload_rc()
+
+    @property
+    def float_dtype(self):
+        bits = self.get('precision', 'bits')
+        return np.dtype("float%s" % bits)
+
+    @property
+    def int_dtype(self):
+        bits = self.get('precision', 'bits')
+        return np.dtype("int%s" % bits)
 
     def _clear(self):
         self.remove_section(configparser.DEFAULTSECT)

--- a/nengo/spa/pointer.py
+++ b/nengo/spa/pointer.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from nengo.exceptions import ValidationError
+from nengo.rc import rc
 from nengo.utils.numpy import is_integer, is_number
 
 
@@ -25,7 +26,7 @@ class SemanticPointer:
                 raise ValidationError(
                     "Must specify either the data or the length for a "
                     "SemanticPointer.", attr='data', obj=self)
-            self.v = np.array(data, dtype=float)
+            self.v = np.array(data, dtype=rc.float_dtype)
             if len(self.v.shape) != 1:
                 raise ValidationError("'data' must be a vector", 'data', self)
 

--- a/nengo/spa/vocab.py
+++ b/nengo/spa/vocab.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from nengo.exceptions import ReadonlyError, SpaParseError, ValidationError
 from nengo.params import Parameter
+from nengo.rc import rc
 from nengo.spa import pointer
 from nengo.utils.numpy import is_iterable, is_number, is_integer
 
@@ -74,7 +75,7 @@ class Vocabulary:
         self.pointers = {}
         self.keys = []
         self.key_pairs = None
-        self.vectors = np.zeros((0, dimensions), dtype=float)
+        self.vectors = np.zeros((0, dimensions), dtype=rc.float_dtype)
         self.vector_pairs = None
         self._include_pairs = None
         self.include_pairs = include_pairs
@@ -193,7 +194,8 @@ class Vocabulary:
         self._include_pairs = value
         if self._include_pairs:
             self.key_pairs = []
-            self.vector_pairs = np.zeros((0, self.dimensions), dtype=float)
+            self.vector_pairs = np.zeros((0, self.dimensions),
+                                         dtype=rc.float_dtype)
             for i in range(1, len(self.keys)):
                 for k in self.keys[:i]:
                     key = self.keys[i]
@@ -276,7 +278,7 @@ class Vocabulary:
         if isinstance(v, pointer.SemanticPointer):
             v = v.v
         else:
-            v = np.array(v, dtype='float')
+            v = np.array(v, dtype=rc.float_dtype)
 
         if normalize:
             nrm = np.linalg.norm(v)
@@ -369,7 +371,8 @@ class Vocabulary:
                     keys = list(self.keys)
                     keys.extend([k for k in other.keys if k not in self.keys])
 
-            t = np.zeros((other.dimensions, self.dimensions), dtype=float)
+            t = np.zeros((other.dimensions, self.dimensions),
+                         dtype=rc.float_dtype)
             for k in keys:
                 a = self[k].v
                 b = other[k].v

--- a/nengo/tests/options.py
+++ b/nengo/tests/options.py
@@ -35,12 +35,15 @@ rather than the two colons ``::`` used by ``nodeid``.
 
 
 def pytest_addoption(parser):
-    parser.addoption('--simulator', nargs=1, type=str, default=None,
-                     help='Specify simulator under test.')
-    parser.addoption('--ref-simulator', nargs=1, type=str, default=None,
-                     help='Specify reference simulator under test.')
-    parser.addoption('--neurons', nargs=1, type=str, default=None,
-                     help='Neuron types under test (comma separated).')
+    parser.addoption(
+        '--simulator', nargs=1, type=str, default=None,
+        help='Specify simulator under test.')
+    parser.addoption(
+        '--ref-simulator', nargs=1, type=str, default=None,
+        help='Specify reference simulator under test.')
+    parser.addoption(
+        '--neurons', nargs=1, type=str, default=None,
+        help='Neuron types under test (comma separated).')
     parser.addoption(
         '--plots', nargs='?', default=False, const=True,
         help='Save plots (can optionally specify a directory for plots).')
@@ -53,18 +56,27 @@ def pytest_addoption(parser):
     parser.addoption(
         '--logs', nargs='?', default=False, const=True,
         help='Save logs (can optionally specify a directory for logs).')
-    parser.addoption('--noexamples', action='store_true', default=False,
-                     help='Do not run examples')
+    parser.addoption(
+        '--noexamples', action='store_true', default=False,
+        help='Do not run examples')
     parser.addoption(
         '--slow', action='store_true', default=False,
         help='Also run slow tests.')
-    parser.addoption('--seed-offset', nargs=1, type=int, default=0,
-                     help="Specify offset of the seed values used in tests.")
-    parser.addoption('--spa', action='store_true', default=False,
-                     help='Run deprecated SPA tests')
+    parser.addoption(
+        '--seed-offset', nargs=1, type=int, default=0,
+        help="Specify offset of the seed values used in tests.")
+    parser.addoption(
+        '--spa', action='store_true', default=False,
+        help='Run deprecated SPA tests')
     parser.addoption(
         '--unsupported', action='store_true', default=False,
         help='Run (with xfail) tests marked as unsupported by this backend.')
     parser.addini("nengo_test_unsupported", type="linelist",
                   help="List of unsupported unit tests with reason for "
                        "exclusion")
+
+    group = parser.getgroup("terminal reporting", "reporting", after="general")
+    group.addoption(
+        '--memory', action='store_true', default=False,
+        help='Show memory consumed by Python after all tests are run '
+        '(not available on Windows)')

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -19,9 +19,10 @@ def test_missing_attribute():
 
 @pytest.mark.parametrize("dimensions", [1, 200])
 def test_encoders(RefSimulator, dimensions, seed, n_neurons=10, encoders=None):
+    dtype = nengo.rc.float_dtype
     if encoders is None:
         encoders = np.random.normal(size=(n_neurons, dimensions))
-        encoders = npext.array(encoders, min_dims=2, dtype=np.float64)
+        encoders = npext.array(encoders, min_dims=2, dtype=dtype)
         encoders /= npext.norm(encoders, axis=1, keepdims=True)
 
     model = nengo.Network(label="_test_encoders", seed=seed)

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -3,6 +3,7 @@ import pytest
 
 import nengo
 from nengo.exceptions import SimulationError, ValidationError
+from nengo.rc import rc
 
 
 def test_time(Simulator):
@@ -266,11 +267,11 @@ def test_set_arraylike_output(Simulator):
         # scalar gets promoted to float vector
         scalar = nengo.Node(2)
         assert scalar.output.shape == (1,)
-        assert str(scalar.output.dtype) == 'float64'
+        assert scalar.output.dtype == rc.float_dtype
         # vector stays 1D
         vector = nengo.Node(np.arange(3))
         assert vector.output.shape == (3,)
-        assert str(vector.output.dtype) == 'float64'
+        assert vector.output.dtype == rc.float_dtype
 
     with Simulator(model):  # Ensure it all builds
         pass

--- a/nengo/transforms.py
+++ b/nengo/transforms.py
@@ -14,6 +14,7 @@ from nengo.params import (
     Parameter,
     ShapeParam,
 )
+from nengo.rc import rc
 from nengo.utils.numpy import is_array_like, scipy_sparse
 
 
@@ -87,7 +88,7 @@ class Dense(Transform):
         self.shape = shape
 
         if is_array_like(init):
-            init = np.asarray(init, dtype=np.float64)
+            init = np.asarray(init, dtype=rc.float_dtype)
 
             # check that the shape of init is compatible with the given shape
             # for this transform
@@ -266,9 +267,10 @@ class Sparse(Transform):
     ----------
     shape : tuple of int
         The full shape of the sparse matrix: ``(size_out, size_in)``.
-    inds : array_like of int
-        The indices of
-    init : `.Distribution` or array_like, optional (Default: 1.0)
+    indices : array_like of int
+        An Nx2 array of integers indicating the (row,col) coordinates for the
+        N non-zero elements in the matrix.
+    init : `.Distribution` or array_like, optional
         A Distribution used to initialize the transform matrix, or a concrete
         instantiation for the matrix. If the matrix is square we also allow a
         scalar (equivalent to ``np.eye(n) * init``) or a vector (equivalent to
@@ -416,7 +418,7 @@ class Convolution(Transform):
             ]
             kernel = np.reshape(kernel, self.kernel_shape)
         else:
-            kernel = np.array(self.init)
+            kernel = np.array(self.init, dtype=rc.float_dtype)
         return kernel
 
     @property
@@ -441,12 +443,12 @@ class Convolution(Transform):
     def output_shape(self):
         """Output shape after applying convolution to input."""
         output_shape = np.array(
-            self.input_shape.spatial_shape, dtype=np.float64)
+            self.input_shape.spatial_shape, dtype=rc.float_dtype)
         if self.padding == "valid":
             output_shape -= self.kernel_size
             output_shape += 1
         output_shape /= self.strides
-        output_shape = tuple(np.ceil(output_shape).astype(np.int64))
+        output_shape = tuple(np.ceil(output_shape).astype(rc.int_dtype))
         output_shape = (output_shape + (self.n_filters,) if self.channels_last
                         else (self.n_filters,) + output_shape)
 

--- a/nengo/utils/cache.py
+++ b/nengo/utils/cache.py
@@ -1,6 +1,6 @@
 """Utilities to convert to and from bytes.
 
-Used by nengo.runcom in order to present file sizes to users in
+Used by nengo.rc in order to present file sizes to users in
 human-readable formats.
 
 This code adapted from https://goo.gl/zeJZl under the MIT License.

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 
+import nengo
 from . import numpy as npext
 from ..exceptions import ValidationError
 
@@ -42,8 +43,9 @@ def target_function(eval_points, targets):
                   "the 'function' argument. That approach is faster, so this "
                   "function is deprecated and will be removed in the future.")
 
-    eval_points = npext.array(eval_points, dtype=np.float64, min_dims=2)
-    targets = npext.array(targets, dtype=np.float64, min_dims=2)
+    dtype = nengo.rc.float_dtype
+    eval_points = npext.array(eval_points, dtype=dtype, min_dims=2)
+    targets = npext.array(targets, dtype=dtype, min_dims=2)
 
     if len(eval_points) != len(targets):
         raise ValidationError(
@@ -93,15 +95,16 @@ def eval_point_decoding(conn, sim, eval_points=None):
     """
     from nengo.builder.ensemble import get_activities
     from nengo.builder.connection import get_targets
+    dtype = nengo.rc.float_dtype
 
     if eval_points is None:
         eval_points = sim.data[conn].eval_points
     else:
-        eval_points = np.asarray(eval_points)
+        eval_points = np.asarray(eval_points, dtype=dtype)
 
     ens = conn.pre_obj
     weights = sim.data[conn].weights
     activities = get_activities(sim.data[ens], ens, eval_points)
     decoded = np.dot(activities, weights.T)
-    targets = get_targets(conn, eval_points)
+    targets = get_targets(conn, eval_points, dtype=dtype)
     return eval_points, targets, decoded

--- a/nengo/utils/tests/test_connection.py
+++ b/nengo/utils/tests/test_connection.py
@@ -47,15 +47,23 @@ def test_target_function(Simulator, nl_nodirect, plt, dimensions, radius,
     assert np.allclose(sim.data[probe1], sim.data[probe2], atol=0.2 * radius)
 
 
-def test_eval_point_decoding(Simulator, nl_nodirect, plt, seed):
+@pytest.mark.parametrize("points_arg", [False, True])
+def test_eval_point_decoding(points_arg, Simulator, nl_nodirect, plt, seed):
     with nengo.Network(seed=seed) as model:
         model.config[nengo.Ensemble].neuron_type = nl_nodirect()
         a = nengo.Ensemble(200, 2)
         b = nengo.Ensemble(100, 1)
         c = nengo.Connection(a, b, function=lambda x: x[0] * x[1])
 
+    kwargs = {}
+    if points_arg:
+        x = np.linspace(-1, 1, 51)
+        y = np.linspace(-1, 1, 51)
+        X, Y = np.meshgrid(x, y)
+        kwargs['eval_points'] = np.column_stack([X.ravel(), Y.ravel()])
+
     with Simulator(model) as sim:
-        eval_points, targets, decoded = eval_point_decoding(c, sim)
+        eval_points, targets, decoded = eval_point_decoding(c, sim, **kwargs)
 
     def contour(xy, z):
         xi, yi = np.meshgrid(np.linspace(-1, 1, 101), np.linspace(-1, 1, 101))


### PR DESCRIPTION
Mostly, this just makes it possible to use `float16` and `float32` dtypes (using anything else wouldn't make much sense).

In order to see the effects of this change, I added a `--memory` option to `py.test` which spits out the total amount of memory used by the Python process running the test suite. This only works on Linux and Mac OS X for now.

To give a sense of what effect changing the dtype has on Nengo as a whole, here are the results from running the test suite on my machine.

`float64` (still the default):
- All tests pass
- Test suite takes ~120 seconds
- Test suite takes ~430 MiB of memory

`float32`:
- 2 tests fail (both because they check if two floats are exactly equal instead of just close; could fix in this PR)
- Test suite takes ~120 seconds
- Test suite takes ~290 MiB of memory

`float16`:
- 62 tests fail (Some `FloatingPointError`s in step functions, like due to NaNs or infs, other issues with float tolerances)
- Test suite takes ~140 seconds (I think all of this is overhead from `pytest` processing the failed tests to give verbose error messages)
- Test suite takes ~265 MiB of memory

So, it seems like running `float32`s is a pretty good option for machines with relatively little RAM! `float16` isn't feasible at the moment, though perhaps with some work it could be.
