### PR TITLE
Minor fixes to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,10 @@
-include *.py
+global-include *.py
 include *.rst
 include *.sh
 include *.txt
+
+# Include this file, to ensure we can recreate source distributions
+include MANIFEST.in
 
 # Directories to include
 graft benchmarks
@@ -11,8 +14,12 @@ graft nengo-data
 
 # Subdirectories to exclude, if they exist
 prune docs/_build
+prune dist
 
 # Patterns to exclude from any directory
-global-exclude .git
-global-exclude .ipynb_checkpoints
+global-exclude *.git*
+global-exclude *.ipynb_checkpoints*
+global-exclude *.tox*
+
+# Exclude all bytecode
 global-exclude *.pyc *.pyo *.pyd


### PR DESCRIPTION
The biggest change is to properly exclude `.ipynb_checkpoints`; this didn't happen properly for the 2.0.1 release (I removed them manually). But this also makes sure that `.git` and `.tox` don't get included, and makes sure MANIFEST.in is included too (though I think it was already, but best to be explicit!)