### PR TITLE
Ss alif

### DIFF
--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -276,7 +276,7 @@ class AdaptiveLIFRate(LIFRate):
         """Compute rates for input current (incl. bias)"""
         n = adaptation
         LIFRate.step_math(self, dt, J - n, output)
-        n += (dt / self.tau_n) * (self.inc_n * output - n)
+        n += -np.expm1(-dt / self.tau_n) * (self.inc_n * output - n)
 
 
 class AdaptiveLIF(AdaptiveLIFRate, LIF):
@@ -284,11 +284,11 @@ class AdaptiveLIF(AdaptiveLIFRate, LIF):
 
     probeable = ['spikes', 'adaptation', 'voltage', 'refractory_time']
 
-    def step_math(self, dt, J, output, voltage, ref, adaptation):
+    def step_math(self, dt, J, spiked, voltage, ref, adaptation):
         """Compute rates for input current (incl. bias)"""
         n = adaptation
-        LIF.step_math(self, dt, J - n, output, voltage, ref)
-        n += (dt / self.tau_n) * (self.inc_n * output - n)
+        LIF.step_math(self, dt, J - n, spiked, voltage, ref)
+        n += -np.expm1(-dt / self.tau_n) * (self.inc_n * spiked - n)
 
 
 class Izhikevich(NeuronType):

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -284,6 +284,104 @@ class AdaptiveLIF(AdaptiveLIFRate, LIF):
 
     probeable = ['spikes', 'adaptation', 'voltage', 'refractory_time']
 
+    def _J_tspk(self, tspk):
+        """Computes the input J that produces a steady state spike interval"""
+        t0 = 1. / (1. - np.exp(-tspk / self.tau_rc))
+        if self.tau_rc != self.tau_n:
+            t1 = (self.inc_n * np.exp(-self.tau_ref / self.tau_n) *
+                  (np.exp(-tspk / self.tau_n) - np.exp(-tspk / self.tau_rc)))
+            t2 = ((1. - np.exp(-(self.tau_ref + tspk) / self.tau_n)) *
+                  (self.tau_rc-self.tau_n))
+        elif self.tau_rc == self.tau_n:  # Python doesn't know LHopital's Rule
+            t1 = (-self.inc_n * tspk *
+                  np.exp(-(self.tau_ref + tspk) / self.tau_rc))
+            t2 = (self.tau_rc**2 *
+                  (1 - np.exp(-(self.tau_ref + tspk) / self.tau_rc)))
+        J = t0 * (1. - t1 / t2)
+        return J
+
+    def _num_rates(self, J, min_f=.001, max_f=None, max_iter=100, tol=1e-3):
+        """Numerically determine the spiking adaptive LIF neuron tuning curve
+
+        Uses the bisection method (binary search in CS parlance) to find the
+        steady state firing rate for a given input
+
+        Parameters
+        ----------
+        J : array-like of floats
+            input
+        min_f : float (optional)
+            minimum firing rate to consider nonzero
+        max_f : float (optional)
+            maximum firing rate to seed bisection method with. Be sure that the
+            maximum firing rate will indeed be within this bound otherwise the
+            binary search will break
+        max_iter : int (optional)
+            maximium number of iterations in binary search
+        tol : float (optional)
+            tolerance of binary search algorithm in J. The algorithm terminates
+            when maximum difference between estimated J and input J is within
+            tol
+        """
+        f_ret = np.zeros_like(J)
+        f_high = max_f
+        if max_f is None:
+            f_high = 1. / self.tau_ref
+        f_low = min_f
+        tspk_high = 1. / f_low - self.tau_ref
+        tspk_low = 1. / f_high - self.tau_ref
+
+        # check for J that produces firing rates below the minimum firing rate
+        J_min = self._J_tspk(tspk_high)
+        idx = J > J_min  # selects the range of J that produces spikes
+        if not idx.any():
+            return f_ret
+        tspk_high = np.zeros(J[idx].shape) + tspk_high
+        tspk_low = np.zeros(J[idx].shape) + tspk_low
+
+        for i in xrange(max_iter):
+            assert (tspk_low <= tspk_low).all(), 'binary search failed'
+            tspk = (tspk_high + tspk_low) / 2.
+            Jhat = self._J_tspk(tspk)
+            max_diff = np.max(np.abs(J[idx]-Jhat))
+            if max_diff < tol:
+                break
+            high_idx = Jhat > J[idx]  # where our estimate of J is too high
+            low_idx = Jhat <= J[idx]  # where our estimate of J is too low
+            tspk_high[low_idx] = tspk[low_idx]
+            tspk_low[high_idx] = tspk[high_idx]
+        f_ret[idx] = 1. / (self.tau_ref + tspk)
+        return f_ret
+
+    def rates(self, x, gain, bias):
+        J = gain * x + bias
+        out = self._num_rates(J)
+        return out
+
+    def gain_bias(self, max_rates, intercepts):
+        """Compute the alpha and bias needed to satisfy max_rates, intercepts.
+
+        Returns gain (alpha) and offset (j_bias) values of neurons.
+
+        Parameters
+        ----------
+        max_rates : list of floats
+            Maximum firing rates of neurons.
+        intercepts : list of floats
+            X-intercepts of neurons.
+        """
+        inv_tau_ref = 1. / self.tau_ref if self.tau_ref > 0 else np.inf
+        if (max_rates > inv_tau_ref).any():
+            raise ValueError(
+                "Max rates must be below the inverse refractory period (%0.3f)"
+                % (inv_tau_ref))
+
+        tspk = 1. / max_rates - self.tau_ref
+        x = self._J_tspk(tspk)
+        gain = (1 - x) / (intercepts - 1.0)
+        bias = 1 - gain * intercepts
+        return gain, bias
+
     def step_math(self, dt, J, spiked, voltage, ref, adaptation):
         """Compute rates for input current (incl. bias)"""
         n = adaptation

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -226,7 +226,6 @@ class LIF(LIFRate):
     probeable = ['spikes', 'voltage', 'refractory_time']
 
     def step_math(self, dt, J, spiked, voltage, refractory_time):
-
         # update voltage using accurate exponential integration scheme
         dV = -np.expm1(-dt / self.tau_rc) * (J - voltage)
         voltage += dV
@@ -385,8 +384,13 @@ class AdaptiveLIF(AdaptiveLIFRate, LIF):
     def step_math(self, dt, J, spiked, voltage, ref, adaptation):
         """Compute rates for input current (incl. bias)"""
         n = adaptation
+        k = np.expm1(-dt / self.tau_n)
+        inc = -k
+        dec = k+1
+
+        n *= dec  # decay adaptation
         LIF.step_math(self, dt, J - n, spiked, voltage, ref)
-        n += -np.expm1(-dt / self.tau_n) * (self.inc_n * spiked - n)
+        n += inc * (self.inc_n * spiked)  # increment adaptation
 
 
 class Izhikevich(NeuronType):

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -8,7 +8,6 @@ from nengo.processes import WhiteNoise
 from nengo.solvers import LstsqL2nz
 from nengo.utils.ensemble import tuning_curves
 from nengo.utils.matplotlib import implot, rasterplot
-from nengo.utils.neurons import rates_kernel
 from nengo.utils.numpy import rms, rmse
 
 logger = logging.getLogger(__name__)
@@ -183,7 +182,7 @@ def test_alif(Simulator, plt, rng):
     i = 3
     t = sim.trange()
     idx = t < t_ss
-    plt.figure(figsize=(10,6))
+    plt.figure(figsize=(10, 6))
     plt.subplot(411)
     plt.plot(t[idx], sim.data[spike_probe][idx, :i])
     plt.subplot(412)

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -196,7 +196,7 @@ def test_alif_neuron(Simulator, plt):
             rel_diff = abs(est_rate - sim_rates[idx]) / est_rate
             assert rel_diff < .01, (
                 'Estimated rate differs from rate extracted from simulation' +
-                ' by more than 1\% for u=%f' % (u))
+                ' by more than 1%% for u=%f' % (u))
         else:
             assert sim_rates[idx] == 0.
 

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -34,7 +34,7 @@ def get_eval_points(n_points, dims, rng=None, sort=False):
 
 
 def get_rate_function(n_neurons, dims, neuron_type=nengo.LIF, rng=None):
-    neurons = neuron_type(n_neurons)
+    neurons = neuron_type()
     gain, bias = neurons.gain_bias(
         rng.uniform(50, 100, n_neurons), rng.uniform(-1, 1, n_neurons))
     rates = lambda x: neurons.rates(x, gain, bias)


### PR DESCRIPTION
This pull request addresses https://github.com/nengo/nengo/issues/540 . The AdaptiveLIF neuron class in this branch implements custom gain_bias and rates functions based on the steady-state firing rate of the adaptive LIF neuron model. The current master branch AdaptiveLIF relies on the base LIF neuron's gain_bias and rates function.  This branch also modifies the step_math function to better match the theory (developed for continuous, not discrete time) and uses a version of the LIF neuron's step_math that doesn't clip the voltages below 0 to 0. The AdaptiveLIF unit tests were modified to check steady state firing rate predictions.

These changes cause the builder to use the  steady state firing rates instead of the initial transient firing rates of the AdaptiveLIF model when building decoders.

I can see a few of ways to go forward with this merge. The AdaptiveLIF model developed in this branch could be maintained as a separate model from the existing AdaptiveLIF model or could overwrite the existing AdaptiveLIF model. Maintaining as a separate model makes sense if there exist or users are planning to create models that leverage the current model's method of finding decoders. Otherwise, I think it makes more sense to overwrite. Alternatively, the models could be merged and have a parameter that let's the user decide which behavior to use.