### PR TITLE
Explicitly specify Mathjax path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,10 @@ source_suffix = '.rst'
 source_encoding = 'utf-8'
 master_doc = 'index'
 
+# Need to include https Mathjax path for sphinx < v1.3
+mathjax_path = ("https://cdn.mathjax.org/mathjax/latest/MathJax.js"
+                "?config=TeX-AMS-MML_HTMLorMML")
+
 project = u'Nengo'
 authors = u'Applied Brain Research'
 copyright = nengo.__copyright__


### PR DESCRIPTION
I noticed that math wasn't rendering on https://pythonhosted.org/nengo/. This was because we were using `http` to access the MathJax CDN, but pythonhosted serves our docs through `https`. This is fixed in the upcoming v1.3 of Sphinx, but this PR makes it explicit so that it works now.

I've rebuilt and updated the pythonhosted docs, so it works now, FYI.