### PR TITLE
Add analytics fixture.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *~
 *.bak
 *.swp
+nengo.simulator.analytics/
 nengo.simulator.plots/
 log.txt
 .ipynb_checkpoints/

--- a/README.rst
+++ b/README.rst
@@ -142,18 +142,15 @@ Plotting the results of tests
 -----------------------------
 
 Many Nengo test routines have the built-in ability to plot test results
-for easier debugging. To enable this feature, set the environment variable
-``NENGO_TEST_PLOT=1``, for example::
+for easier debugging. To enable this feature, set the ``--plots`` flag,
+for example::
 
-  NENGO_TEST_PLOT=1 py.test --pyargs nengo
-
-Or, for the current terminal session::
-
-  export NENGO_TEST_PLOT=1
-  py.test --pyargs nengo
+  py.test --plots --pyargs nengo
 
 Plots are placed in ``nengo.simulator.plots`` in whatever directory
-``py.test`` is invoked from.
+``py.test`` is invoked from. You can also set a different directory::
+
+  py.test --plots=path-to-plots --pyargs nengo
 
 Contributing
 ============

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -29,8 +29,8 @@ class LearningRuleType(object):
                           "in floating point errors from too much current.")
         self.learning_rate = learning_rate
 
-    def __str__(self):
-        return self.__class__.__name__
+    def __repr__(self):
+        return '<%s>' % self.__class__.__name__
 
 
 class PES(LearningRuleType):

--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -62,6 +62,18 @@ def recorder_dirname(request, name):
     return dirname
 
 
+def parametrize_function_name(request, function_name):
+    suffixes = []
+    if 'parametrize' in request.keywords:
+        argnames = [
+            x.strip()
+            for x in request.keywords['parametrize'].args[0].split(',')]
+        for name in argnames:
+            suffixes.append('{0}={1}'.format(
+                name, request.getfuncargvalue(name)))
+    return '_'.join([function_name] + suffixes)
+
+
 @pytest.fixture
 def plt(request):
     """a pyplot-compatible plotting interface.
@@ -77,7 +89,8 @@ def plt(request):
     """
     dirname = recorder_dirname(request, 'plots')
     plotter = Plotter(
-        dirname, request.module.__name__, request.function.__name__)
+        dirname, request.module.__name__,
+        parametrize_function_name(request, request.function.__name__))
     request.addfinalizer(lambda: plotter.__exit__(None, None, None))
     return plotter.__enter__()
 
@@ -97,7 +110,8 @@ def analytics(request):
     """
     dirname = recorder_dirname(request, 'analytics')
     analytics = Analytics(
-        dirname, request.module.__name__, request.function.__name__)
+        dirname, request.module.__name__,
+        parametrize_function_name(request, request.function.__name__))
     request.addfinalizer(lambda: analytics.__exit__(None, None, None))
     return analytics.__enter__()
 

--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -1,4 +1,5 @@
 import hashlib
+import inspect
 import os
 
 import numpy as np
@@ -69,8 +70,10 @@ def parametrize_function_name(request, function_name):
             x.strip()
             for x in request.keywords['parametrize'].args[0].split(',')]
         for name in argnames:
-            suffixes.append('{0}={1}'.format(
-                name, request.getfuncargvalue(name)))
+            value = request.getfuncargvalue(name)
+            if inspect.isclass(value):
+                value = value.__name__
+            suffixes.append('{0}={1}'.format(name, value))
     return '_'.join([function_name] + suffixes)
 
 

--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -10,7 +10,7 @@ from nengo.neurons import Direct, LIF, LIFRate, RectifiedLinear, Sigmoid
 from nengo.rc import rc
 from nengo.simulator import Simulator as ReferenceSimulator
 from nengo.utils.compat import ensure_bytes
-from nengo.utils.testing import Plotter
+from nengo.utils.testing import Analytics, Plotter
 
 test_seed = 0  # changing this will change seeds for all tests
 
@@ -64,6 +64,20 @@ def plt(request):
     plotter = Plotter(simulator, request.module, request.function, nl=nl)
     request.addfinalizer(lambda p=plotter: p.__exit__(None, None, None))
     return plotter.__enter__()
+
+
+@pytest.fixture
+def analytics(request):
+    simulator, nl = ReferenceSimulator, None
+    if 'Simulator' in request.funcargnames:
+        simulator = request.getfuncargvalue('Simulator')
+    if 'nl' in request.funcargnames:
+        nl = request.getfuncargvalue('nl')
+    elif 'nl_nodirect' in request.funcargnames:
+        nl = request.getfuncargvalue('nl_nodirect')
+    analytics = Analytics(simulator, request.module, request.function, nl=nl)
+    request.addfinalizer(lambda: analytics.__exit__(None, None, None))
+    return analytics.__enter__()
 
 
 def function_seed(function, mod=0):

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -264,7 +264,7 @@ def calc_relative_timer_diff(t1, t2):
     return (t2.duration - t1.duration) / (t2.duration + t1.duration)
 
 
-@pytest.mark.benchmark
+@pytest.mark.slow
 def test_cache_performance(tmpdir, Simulator, seed):
     cache_dir = str(tmpdir)
 

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -181,7 +181,6 @@ def test_unsupervised(Simulator, learning_rule_type, seed, rng, plt):
     sim.run(0.5)
     t = sim.trange()
 
-    name = learning_rule_type.__class__.__name__
     plt.subplot(2, 1, 1)
     plt.plot(t, sim.data[inp_p], label="Input")
     plt.plot(t, sim.data[ap], label="Pre")
@@ -191,7 +190,6 @@ def test_unsupervised(Simulator, learning_rule_type, seed, rng, plt):
     plt.plot(sim.trange(dt=0.01), sim.data[trans_p][..., 4])
     plt.xlabel("Time (s)")
     plt.ylabel("Transform weight")
-    plt.saveas = 'test_learning_rules.test_unsupervised_%s.pdf' % name
 
     assert not np.all(sim.data[trans_p][0] == sim.data[trans_p][-1])
 
@@ -247,9 +245,6 @@ def test_dt_dependence(Simulator, plt, learning_rule, seed, rng):
     plt.xlim(right=sim.trange()[-1])
     plt.ylabel("Presynaptic activity")
 
-    plt.saveas = "test_learning_rules.test_dt_dependence_%s.pdf" % (
-        learning_rule.__name__)
-
     assert np.allclose(trans_data[0], trans_data[1], atol=2e-3)
     assert not np.all(sim.data[trans_p][0] == sim.data[trans_p][-1])
 
@@ -280,9 +275,6 @@ def test_reset(Simulator, learning_rule, plt, seed, rng):
     plt.ylabel("Connection weight")
     plt.plot(first_t_trans, first_trans_p[..., 0], c='b')
     plt.plot(sim.trange(dt=0.01), sim.data[trans_p][..., 0], c='g')
-
-    plt.saveas = "test_learning_rules.test_reset_%s.pdf" % (
-        learning_rule.__name__)
 
     assert np.all(sim.trange() == first_t)
     assert np.all(sim.trange(dt=0.01) == first_t_trans)

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -79,7 +79,6 @@ def test_gaussian_whitenoise(rms, rng, plt):
     plt.subplot(2, 1, 2)
     plt.title("Power spectrum")
     plt.plot(freq, val_psd, drawstyle='steps')
-    plt.saveas = 'test_processes.test_gaussian_white_noise_rms%.1f.pdf' % rms
 
     assert np.allclose(np.std(values), rms, rtol=0.02)
     assert np.allclose(val_psd[1:-1], rms, rtol=0.2)
@@ -103,7 +102,6 @@ def test_whitenoise_rms(rms, rng, plt):
     plt.subplot(2, 1, 2)
     plt.title("Power spectrum")
     plt.plot(freq, val_psd, drawstyle='steps')
-    plt.saveas = 'test_processes.test_whitenoise_rms_%.1f.pdf' % rms
 
     assert np.allclose(np.std(values), rms, rtol=0.02)
     assert np.allclose(val_psd[1:-1], rms, rtol=0.35)
@@ -129,7 +127,6 @@ def test_whitenoise_high(high, rng, plt):
     plt.title("Power spectrum")
     plt.plot(freq, val_psd, drawstyle='steps')
     plt.xlim(right=high * 2.0)
-    plt.saveas = 'test_processes.test_whitenoise_high_%d.pdf' % high
 
     assert np.allclose(np.std(values, axis=1), rms, rtol=0.15)
     assert np.all(val_psd[rfftfreq(t, dt) > high] < rms * 0.5)

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -95,7 +95,6 @@ def test_decoder_solver(Solver, plt, rng):
     plt.plot(test, np.zeros_like(test), 'k--')
     plt.plot(test, test - est)
     plt.title("relative RMSE: %0.2e" % rel_rmse)
-    plt.saveas = 'test_solvers.test_decoder_solver.%s.pdf' % Solver.__name__
 
     atol = 3.5e-2 if Solver is LstsqNoise else 1.5e-2
     assert np.allclose(test, est, atol=atol, rtol=1e-3)
@@ -189,7 +188,6 @@ def test_nnls(Solver, plt, rng):
     plt.subplot(212)
     plt.plot(x, np.zeros_like(x), 'k--')
     plt.plot(x, yest - y)
-    plt.saveas = 'test_solvers.test_nnls.%s.pdf' % Solver.__name__
 
     assert np.allclose(yest, y, atol=3e-2, rtol=1e-3)
     assert rel_rmse < 0.02

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -124,13 +124,21 @@ class Analytics(Recorder):
 
         if self.record:
             self.data[name] = data
-            self.doc[name] = doc
+            if doc != "":
+                self.doc[name] = doc
+
+    def save_data(self):
+        if len(self.data) == 0:
+            return
+
+        npz_data = dict(self.data)
+        if len(self.doc) > 0:
+            npz_data.update({self.DOC_KEY: self.doc})
+        np.savez(self.get_filepath(ext='npz'), **npz_data)
 
     def __exit__(self, type, value, traceback):
         if self.record:
-            npz_data = dict(self.data)
-            npz_data.update({self.DOC_KEY: self.doc})
-            np.savez(self.get_filepath(ext='npz'), **npz_data)
+            self.save_data()
 
 
 class Timer(object):

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -106,30 +106,30 @@ class Plotter(Recorder):
 
 
 class Analytics(Recorder):
-    DESC_KEY = 'descriptions'
+    DOC_KEY = 'documentation'
 
     def __init__(self, dirname, module_name, function_name):
         super(Analytics, self).__init__(dirname, module_name, function_name)
 
         self.data = {}
-        self.desc = {}
+        self.doc = {}
 
     def __enter__(self):
         return self
 
-    def add_data(self, name, data, desc=""):
-        if name == self.DESC_KEY:
+    def add_data(self, name, data, doc=""):
+        if name == self.DOC_KEY:
             raise ValueError("The name '{0}' is reserved.".format(
-                self.DESC_KEY))
+                self.DOC_KEY))
 
         if self.record:
             self.data[name] = data
-            self.desc[name] = desc
+            self.doc[name] = doc
 
     def __exit__(self, type, value, traceback):
         if self.record:
             npz_data = dict(self.data)
-            npz_data.update({self.DESC_KEY: self.desc})
+            npz_data.update({self.DOC_KEY: self.doc})
             np.savez(self.get_filepath(ext='npz'), **npz_data)
 
 

--- a/nengo/utils/tests/test_connection.py
+++ b/nengo/utils/tests/test_connection.py
@@ -44,7 +44,5 @@ def test_target_function(Simulator, nl_nodirect, plt, dimensions, radius,
     plt.subplot(2, 1, 2)
     plt.plot(sim.trange(), sim.data[probe2])
     plt.title('Square by passing in function to connection')
-    plt.saveas = ('utils.test_connection.test_target_function_%d_%g.pdf'
-                  % (dimensions, radius))
 
     assert np.allclose(sim.data[probe1], sim.data[probe2], atol=0.2 * radius)

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -42,7 +42,6 @@ def test_tuning_curves(Simulator, nl_nodirect, plt, seed, dimensions):
 
     eval_points, activities = tuning_curves(ens, sim)
 
-    plt.saveas = 'utils.test_ensemble.test_tuning_curves_%d.pdf' % dimensions
     plot_tuning_curves(plt, eval_points, activities)
 
     # Check that eval_points cover up to the radius.
@@ -64,8 +63,6 @@ def test_tuning_curves_direct_mode(Simulator, plt, seed, dimensions):
 
     eval_points, activities = tuning_curves(ens, sim)
 
-    plt.saveas = ('utils.test_ensemble.test_tuning_curves_direct_mode_%d.pdf'
-                  % dimensions)
     plot_tuning_curves(plt, eval_points, activities)
 
     # eval_points is passed through in direct mode neurons
@@ -103,8 +100,6 @@ def test_response_curves_direct_mode(Simulator, plt, seed, dimensions):
 
     eval_points, activities = response_curves(ens, sim)
 
-    plt.saveas = ('utils.test_ensemble.test_response_curves_direct_mode_%d.pdf'
-                  % dimensions)
     plot_tuning_curves(plt, eval_points, activities)
 
     assert eval_points.ndim == 1 and eval_points.size > 0

--- a/nengo/utils/tests/test_matplotlib.py
+++ b/nengo/utils/tests/test_matplotlib.py
@@ -23,5 +23,3 @@ def test_rasterplot(use_eventplot, Simulator, seed, plt):
     sim.run(1.0)
 
     rasterplot(sim.trange(), sim.data[ap], use_eventplot=use_eventplot)
-    if use_eventplot:
-        plt.saveas = 'utils.test_matplotlib.test_rasterplot.eventplot.pdf'

--- a/nengo/utils/tests/test_matplotlib.py
+++ b/nengo/utils/tests/test_matplotlib.py
@@ -8,7 +8,7 @@ import nengo
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.plot
+@pytest.mark.noassertions
 @pytest.mark.parametrize('use_eventplot', [True, False])
 def test_rasterplot(use_eventplot, Simulator, seed, plt):
     from nengo.utils.matplotlib import rasterplot

--- a/nengo/utils/tests/test_neurons.py
+++ b/nengo/utils/tests/test_neurons.py
@@ -77,7 +77,7 @@ def test_rates_kernel(Simulator, plt, seed):
     assert rel_rmse < 0.2
 
 
-@pytest.mark.benchmark
+@pytest.mark.noassertions
 def test_rates(Simulator, plt, seed):
     functions = [
         ('isi_zero', lambda t, s: rates_isi(
@@ -95,10 +95,11 @@ def test_rates(Simulator, plt, seed):
         ('kernel_alpha', lambda t, s: rates_kernel(t, s, kind='alpha')),
     ]
 
-    print("\ntest_rates:")
     for name, function in functions:
         rel_rmse = _test_rates(Simulator, function, plt, seed, name)
-        print("%20s relative rmse: %0.3f" % (name, rel_rmse))
+        logger.info('rate estimator: %s', name)
+        logger.info('relative RMSE: %0.4f', rel_rmse)
+    plt.saveas = None
 
 
 if __name__ == "__main__":

--- a/nengo/utils/tests/test_neurons.py
+++ b/nengo/utils/tests/test_neurons.py
@@ -15,10 +15,7 @@ from nengo.utils.numpy import rms
 logger = logging.getLogger(__name__)
 
 
-def _test_rates(Simulator, rates, plt, seed, name=None):
-    if name is None:
-        name = rates.__name__
-
+def _test_rates(Simulator, rates, plt, seed):
     n = 100
     intercepts = np.linspace(-0.99, 0.99, n)
 
@@ -59,7 +56,6 @@ def _test_rates(Simulator, rates, plt, seed, name=None):
     implot(plt, t, intercepts, (b_rates - a_rates).T, ax=ax)
     ax.set_xlabel('time [s]')
     ax.set_ylabel('intercept')
-    plt.saveas = 'utils.test_neurons.test_rates.%s.pdf' % name
 
     tmask = (t > 0.1) & (t < 1.9)
     relative_rmse = rms(b_rates[tmask] - a_rates[tmask]) / rms(a_rates[tmask])
@@ -96,7 +92,7 @@ def test_rates(Simulator, plt, seed):
     ]
 
     for name, function in functions:
-        rel_rmse = _test_rates(Simulator, function, plt, seed, name)
+        rel_rmse = _test_rates(Simulator, function, plt, seed)
         logger.info('rate estimator: %s', name)
         logger.info('relative RMSE: %0.4f', rel_rmse)
     plt.saveas = None

--- a/nengo/utils/tests/test_testing.py
+++ b/nengo/utils/tests/test_testing.py
@@ -17,6 +17,16 @@ def test_timer():
     assert timer.duration < 1.0  # Pretty bad worst case
 
 
+def test_analytics_empty():
+    analytics = Analytics('nengo.simulator.analytics',
+                          'nengo.utils.tests.test_testing',
+                          'test_analytics_empty')
+    with analytics:
+        pass
+    path = analytics.get_filepath(ext='npz')
+    assert not os.path.exists(path)
+
+
 def test_analytics_record():
     analytics = Analytics('nengo.simulator.analytics',
                           'nengo.utils.tests.test_testing',

--- a/nengo/utils/tests/test_testing.py
+++ b/nengo/utils/tests/test_testing.py
@@ -24,9 +24,9 @@ def test_analytics_record():
     with analytics:
         analytics.add_data('test', 1, "Test analytics implementation")
         assert analytics.data['test'] == 1
-        assert analytics.desc['test'] == "Test analytics implementation"
+        assert analytics.doc['test'] == "Test analytics implementation"
         with pytest.raises(ValueError):
-            analytics.add_data('descriptions', '')
+            analytics.add_data('documentation', '')
     path = analytics.get_filepath(ext='npz')
     assert os.path.exists(path)
     os.remove(path)
@@ -44,7 +44,7 @@ def test_analytics_norecord():
     with analytics:
         analytics.add_data('test', 1, "Test analytics implementation")
         assert 'test' not in analytics.data
-        assert 'test' not in analytics.desc
+        assert 'test' not in analytics.doc
     with pytest.raises(ValueError):
         analytics.get_filepath(ext='npz')
 

--- a/nengo/utils/tests/test_testing.py
+++ b/nengo/utils/tests/test_testing.py
@@ -1,0 +1,58 @@
+import logging
+import os
+
+import pytest
+
+import nengo
+from nengo.utils.testing import Analytics, Timer
+
+logger = logging.getLogger(__name__)
+
+
+def test_timer():
+    with Timer() as timer:
+        2 + 2
+    assert timer.duration > 0.0
+    assert timer.duration < 1.0  # Pretty bad worst case
+
+
+class MockWithName(object):
+    def __init__(self, name):
+        self.__name__ = name
+
+
+def test_analytics_store():
+    analytics = Analytics(nengo.Simulator,
+                          MockWithName('nengo.utils.tests.test_testing'),
+                          MockWithName('test_analytics_store'),
+                          store=True)
+    with analytics:
+        analytics.add_data('test', 1, "Test analytics implementation")
+        assert analytics.data['test'] == 1
+        assert analytics.desc['test'] == "Test analytics implementation"
+    datapath = os.path.join(analytics.dirname, analytics.data_filename)
+    descpath = os.path.join(analytics.dirname, analytics.desc_filename)
+    assert os.path.exists(datapath)
+    assert os.path.exists(descpath)
+    os.remove(datapath)
+    os.remove(descpath)
+
+
+def test_analytics_nostore():
+    analytics = Analytics(nengo.Simulator,
+                          MockWithName('nengo.utils.tests.test_testing'),
+                          MockWithName('test_analytics_nostore'),
+                          store=False)
+    with analytics:
+        analytics.add_data('test', 1, "Test analytics implementation")
+        assert 'test' not in analytics.data
+        assert 'test' not in analytics.desc
+    datapath = os.path.join(analytics.dirname, analytics.data_filename)
+    descpath = os.path.join(analytics.dirname, analytics.desc_filename)
+    assert not os.path.exists(datapath)
+    assert not os.path.exists(descpath)
+
+
+if __name__ == "__main__":
+    nengo.log(debug=True)
+    pytest.main([__file__, '-v'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,17 @@ ignore =
     *.ipynb_checkpoints
     *.ipynb_checkpoints/*
 
-[upload_sphinx]
-upload-dir = doc/_build/html
+[flake8]
+exclude = __init__.py
+ignore = E123,E133,E226,E241,E242,E731,W503
+max-complexity = 10
 
 [pytest]
 norecursedirs = .* *.egg build dist docs
+markers =
+    example: Mark a test as an example.
+    noassertions: Mark a test without assertions. It will only be run if plots or analytics data are produced.
+    slow: Mark a test as slow to skip it per default.
+
+[upload_sphinx]
+upload-dir = doc/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,3 @@ deps =
 [testenv:pep8]
 deps = flake8
 commands = flake8 -v nengo
-
-[flake8]
-exclude = __init__.py
-ignore = E123,E133,E226,E241,E242,E731,W503
-max-complexity = 10


### PR DESCRIPTION
This allows to store additional data in test. A use case would be in
benchmarking and comparing different implementations/revisions. To
store analytics data add the following to your tests:

```python
def test_something(analytics):
    # code
    analytics.add_data('some_key', np.array([1, 2]), 'description')
```

You also have to set the NENGO_ANALYTICS environment variable to 1. The
data will be stored in the nengo.simulator.analytics subdirectory. Two
files will be generated for each test. The txt file contains the
description of the stored data and the npz file the actual data. It can
be loaded with numpy.load.


I am putting this PR out as basis for discussion. At the moment there is some code duplication between `Plotter` and `Analytics` which I would reduce before a merge into `master`.

The questions I would like to discuss:

1. File format: Numpy files are efficient and easily loadable in a Python stack. However, other file formats (e.g. CSV, JSON) might be easier to process in other programming language if someone wants to use those for analysis.
2. Environment variable for activation: To activate the storage of the data an environment variable has to be set. This follows what `Plotter` is doing. However, to me it seems (also in the case of `Plotter`) a bit obscure as `py.test --help` won't tell you about it, in contrast to options (like `--optional`).
3. Overwriting of files: Each execution of the test suite might overwrite the analytics files. It might be easier to compare different revisions if this doesn't happen (by including a timestamp or the Git hash somehow). But in that case it might produce too much unused files.

I will probably implement some helpers to compare the stored data once I have written some actual benchmarks.