### PR TITLE
Better, faster .travis.yml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
-omit = nengo/tests/test*
+source = nengo
+omit = */tests/test*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,58 @@
-language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-env:
-  global:
-    - PIP_WHEEL_COMMAND="pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel --use-mirrors"  # Thanks astropy!
-matrix:
-  include:
-    - python: 2.7
-      env: TOXENV=pep8
-before_install:
-  - pip install --upgrade pip setuptools  # For wheel support
-install:
-  - "echo 'backend : Agg' > matplotlibrc"
-  - if [[ "$TOXENV" == "pep8" ]]; then pip install tox; fi
-  - if [[ "$TOXENV" != "pep8" ]]; then $PIP_WHEEL_COMMAND -r requirements.txt; fi
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" && "$TOXENV" != "pep8" ]]; then $PIP_WHEEL_COMMAND -r requirements-test-py26.txt; fi
-  - if [[ "$TRAVIS_PYTHON_VERSION" != "2.6" && "$TOXENV" != "pep8" ]]; then $PIP_WHEEL_COMMAND -r requirements-test.txt; fi
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TOXENV" != "pep8" ]]; then $PIP_WHEEL_COMMAND coverage pytest-cov coveralls; fi
-script:
-  - if [[ "$TOXENV" == "pep8" ]]; then tox; fi
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TOXENV" != "pep8" ]]; then py.test --cov-config .coveragerc --cov nengo -n 2 -v; fi
-  - if [[ "$TRAVIS_PYTHON_VERSION" != "2.7" ]]; then py.test -n 2 -v; fi
-after_success:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TOXENV" != "pep8" ]]; then coveralls; fi
+language: c
+sudo: false
 notifications:
   email:
     - tbekolay@gmail.com
+
+env:
+  global:
+    - SETUP_CMD="test -a 'nengo -n 2 -v'"
+    - EXTRA_CMD=""
+    - CONDA_DEPS="numpy matplotlib ipython-notebook pytest"
+    - PIP_DEPS="pytest-xdist"
+
+matrix:
+  include:
+    - env: >
+        PYTHON="2.6"
+        CONDA_DEPS="$CONDA_DEPS ordereddict pygments"
+        PIP_DEPS="$PIP_DEPS counter IPython==1.2.1"
+    - env: >
+        PYTHON="2.7"
+        SETUP_CMD="test -a '--cov-config .coveragerc --cov nengo nengo -n 2 -v'"
+        EXTRA_CMD="coveralls"
+        CONDA_DEPS="$CONDA_DEPS coverage"
+        PIP_DEPS="$PIP_DEPS pytest-cov coveralls"
+    - env: >
+        PYTHON="2.7"
+        SETUP_CMD=""
+        EXTRA_CMD="flake8 -v nengo"
+        CONDA_DEPS="flake8"
+        PIP_DEPS=""
+    - env: PYTHON="3.3"
+    - env: PYTHON="3.4"
+
+# Setup Miniconda
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda create -q -n test python=$PYTHON pip
+  - source activate test
+
+# Install packages with conda, then pip
+install:
+  - if [[ -n $CONDA_DEPS ]]; then conda install $CONDA_DEPS; fi
+  - if [[ -n $PIP_DEPS ]]; then eval pip install "$PIP_DEPS"; fi
+
+# Run the tests
+script:
+  - "echo 'backend : Agg' > matplotlibrc"
+  - if [[ -n $SETUP_CMD ]]; then
+      python setup.py -q install;
+      eval python setup.py "$SETUP_CMD";
+    fi
+  - if [[ -n $EXTRA_CMD ]]; then $EXTRA_CMD; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ notifications:
 
 env:
   global:
+    - NUMPY="1.9"
     - SETUP_CMD="test -a 'nengo -n 2 -v'"
     - EXTRA_CMD=""
-    - CONDA_DEPS="numpy matplotlib ipython-notebook pytest"
+    - CONDA_DEPS="matplotlib ipython-notebook pytest"
     - PIP_DEPS="pytest-xdist"
 
 matrix:
@@ -29,6 +30,9 @@ matrix:
         EXTRA_CMD="flake8 -v nengo"
         CONDA_DEPS="flake8"
         PIP_DEPS=""
+    - env: PYTHON="2.7" NUMPY="1.6"
+    - env: PYTHON="2.7" NUMPY="1.7"
+    - env: PYTHON="2.7" NUMPY="1.8"
     - env: PYTHON="3.3"
     - env: PYTHON="3.4"
 
@@ -45,6 +49,7 @@ before_install:
 
 # Install packages with conda, then pip
 install:
+  - if [[ -n $NUMPY ]]; then export CONDA_DEPS="$CONDA_DEPS numpy=$NUMPY"; fi
   - if [[ -n $CONDA_DEPS ]]; then conda install $CONDA_DEPS; fi
   - if [[ -n $PIP_DEPS ]]; then eval pip install "$PIP_DEPS"; fi
 

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import nengo
+import nengo.utils.numpy as npext
 from nengo.connection import ConnectionSolverParam
 from nengo.dists import UniformHypersphere
 from nengo.solvers import LstsqL2
@@ -629,7 +630,7 @@ def test_eval_points_scaling(Simulator, sample, radius, seed, rng, scale):
                                scale_eval_points=scale)
 
     sim = Simulator(model)
-    dists = np.linalg.norm(sim.data[con].eval_points, axis=1)
+    dists = npext.norm(sim.data[con].eval_points, axis=1)
     limit = radius if scale else 1.0
     assert np.all(dists <= limit)
     assert np.any(dists >= 0.9 * limit)

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -245,7 +245,7 @@ def test_eval_points_scaling(Simulator, sample, radius, seed, rng):
         a = nengo.Ensemble(1, 3, eval_points=eval_points, radius=radius)
 
     sim = Simulator(model)
-    dists = np.linalg.norm(sim.data[a].eval_points, axis=1)
+    dists = npext.norm(sim.data[a].eval_points, axis=1)
     assert np.all(dists <= radius)
     assert np.any(dists >= 0.9 * radius)
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,1 +1,2 @@
+scikit-learn
 scipy>=0.13.0

--- a/setup.py
+++ b/setup.py
@@ -94,5 +94,6 @@ setup(
     cmdclass={
         'test': PyTest,
         'tox': Tox,
-    }
+    },
+    zip_safe=False,
 )


### PR DESCRIPTION
Short version: with this PR, builds go from [8 - 14 minutes](https://travis-ci.org/nengo/nengo/builds/49638662) (with plenty of random failures) to [~3 minutes](https://travis-ci.org/nengo/nengo/builds/49803517) (haven't seen any random failures yet; `flake8`, which is usually what fails, runs in 26 seconds). They're also guaranteed to start faster, due to using recent TravisCI infrastructure upgrades.

----

Long version: This PR enables TravisCI to build and test Nengo faster. No functionality is lost; we still test on Python 2.6, and [coveralls info](https://coveralls.io/builds/1880935) is still maintained.

The two most significant ways in which we make TravisCI build faster are to

1. use `sudo: false` to enable container-based builds as described in [this blog post](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) and [these docs](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) and
2. use Miniconda to download and install binaries in the home directory, so that we don't need to use `sudo`, and don't have to build anything from source.

Note that, since we're doing `sudo: false`, we could also enable caching; however, since we don't actually do any building from source (all the binaries are downloaded from `conda`; we only install a few things from `pip` and they're pure Python) we won't gain much in terms of speed because the cache is stored on Amazon S3, so it'd still have to be downloaded at the start. Plus, doing it this way without the cache ensures that we're testing with the most recent stable versions of these things.

A few additional things that I haven't yet done, but could do if people think they're worthwhile:

- Test with multiple versions of NumPy (we should maybe test with at least the earliest version we claim to support?)
- Test on Mac OS X (TravisCI has some Mac OS X VMs that we can use; you can't normally use them for Python, but since we install Python with `conda` we can use them)
  - Before anyone asks, they don't have any Windows VMs, but I'm going to make another PR to enable Nengo to be tested with [appveyor](http://www.appveyor.com/), which is basically TravisCI for Windows
- Add another target that builds the documentation to ensure there are no warnings (we can add in some more checkers to this later as well)
- Other ideas?