### PR TITLE
Add pytest norecursedirs setting.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,6 @@ ignore =
 
 [upload_sphinx]
 upload-dir = doc/_build/html
+
+[pytest]
+norecursedirs = .* *.egg build dist docs


### PR DESCRIPTION
Fixes #650 by preventing py.test from looking into the build directory.
Also added some other directories where there should be no tests.