### PR TITLE
Probe outputs

### DIFF
--- a/examples/delay_node.ipynb
+++ b/examples/delay_node.ipynb
@@ -28,7 +28,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "from nengo.processes import WhiteNoise"
+      "from nengo.processes import WhiteSignal"
      ],
      "language": "python",
      "outputs": []
@@ -40,7 +40,7 @@
       "model = nengo.Network(label=\"Delayed connection\")\n",
       "with model:\n",
       "    # We'll use white noise as input\n",
-      "    inp = nengo.Node(WhiteNoise(2, high=5).f())\n",
+      "    inp = nengo.Node(WhiteSignal(2, high=5), size_out=1)\n",
       "    A = nengo.Ensemble(40, dimensions=1)\n",
       "    nengo.Connection(inp, A)\n",
       "\n",

--- a/examples/learn_communication_channel.ipynb
+++ b/examples/learn_communication_channel.ipynb
@@ -40,7 +40,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "from nengo.processes import WhiteNoise"
+      "from nengo.processes import WhiteSignal"
      ],
      "language": "python",
      "outputs": []
@@ -51,7 +51,7 @@
      "input": [
       "model = nengo.Network()\n",
       "with model:\n",
-      "    inp = nengo.Node(WhiteNoise(60, high=5).f(d=2))\n",
+      "    inp = nengo.Node(WhiteSignal(60, high=5), size_out=2)\n",
       "    pre = nengo.Ensemble(60, dimensions=2)\n",
       "    nengo.Connection(inp, pre)\n",
       "    post = nengo.Ensemble(60, dimensions=2)\n",

--- a/examples/learn_product.ipynb
+++ b/examples/learn_product.ipynb
@@ -34,7 +34,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "from nengo.processes import WhiteNoise"
+      "from nengo.processes import WhiteSignal"
      ],
      "language": "python",
      "outputs": []
@@ -57,7 +57,7 @@
       "model = nengo.Network()\n",
       "with model:\n",
       "    # -- input and pre popluation\n",
-      "    inp = nengo.Node(WhiteNoise(60, high=5).f(d=2))\n",
+      "    inp = nengo.Node(WhiteSignal(60, high=5), size_out=2)\n",
       "    pre = nengo.Ensemble(120, dimensions=2)\n",
       "    nengo.Connection(inp, pre)\n",
       "    \n",

--- a/examples/nef_summary.ipynb
+++ b/examples/nef_summary.ipynb
@@ -316,11 +316,11 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "from nengo.processes import WhiteNoise\n",
+      "from nengo.processes import WhiteSignal\n",
       "\n",
       "model = nengo.Network(label=\"NEF summary\")\n",
       "with model:\n",
-      "    input = nengo.Node(WhiteNoise(1, high=5).f(rng=np.random.RandomState(60)))\n",
+      "    input = nengo.Node(WhiteSignal(1, high=5), size_out=1)\n",
       "    input_probe = nengo.Probe(input)\n",
       "    A = nengo.Ensemble(30, dimensions=1, max_rates=Uniform(80, 100))\n",
       "    nengo.Connection(input, A)\n",
@@ -376,7 +376,7 @@
      "input": [
       "model = nengo.Network(label=\"NEF summary\")\n",
       "with model:\n",
-      "    input = nengo.Node(WhiteNoise(1, high=5).f(rng=np.random.RandomState(60)))\n",
+      "    input = nengo.Node(WhiteSignal(1, high=5), size_out=1))\n",
       "    input_probe = nengo.Probe(input,)\n",
       "    A = nengo.Ensemble(30, dimensions=1, max_rates=Uniform(80, 100))\n",
       "    Asquare = nengo.Node(size_in=1)\n",

--- a/nengo/builder/__init__.py
+++ b/nengo/builder/__init__.py
@@ -8,4 +8,5 @@ from .network import build_network
 from .neurons import build_lif, build_lifrate, build_alif, build_alifrate
 from .node import build_node
 from .probe import build_probe
+from .processes import build_process
 from .synapses import build_synapse

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -24,11 +24,15 @@ class Model(object):
         self.operators = []
         self.params = {}
         self.seeds = {}
-        self.probes = []
         self.sig = collections.defaultdict(dict)
 
     def __str__(self):
         return "Model: %s" % self.label
+
+    def default_signaldict(self):
+        return SignalDict(
+            __step__=np.array(0, dtype=np.int32),
+            __time__=np.array(0, dtype=np.float64))
 
     def build(self, obj, *args, **kwargs):
         return Builder.build(self, obj, *args, **kwargs)
@@ -36,7 +40,7 @@ class Model(object):
     def add_op(self, op):
         self.operators.append(op)
         # Fail fast by trying make_step with a temporary sigdict
-        signals = SignalDict(__time__=np.asarray(0.0, dtype=np.float64))
+        signals = self.default_signaldict()
         op.init_signals(signals)
         op.make_step(signals, self.dt, np.random)
 

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -30,8 +30,8 @@ class Model(object):
     def __str__(self):
         return "Model: %s" % self.label
 
-    def build(self, *objs):
-        return Builder.build(self, *objs)
+    def build(self, obj, *args, **kwargs):
+        return Builder.build(self, obj, *args, **kwargs)
 
     def add_op(self, op):
         self.operators.append(op)

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -5,7 +5,7 @@ import numpy as np
 import nengo.utils.numpy as npext
 from nengo.builder.builder import Builder
 from nengo.builder.ensemble import gen_eval_points
-from nengo.builder.node import build_pyfunc
+from nengo.builder.node import SimPyFunc
 from nengo.builder.operator import DotInc, ElementwiseInc, PreserveValue, Reset
 from nengo.builder.signal import Signal
 from nengo.builder.synapses import filtered_signal
@@ -88,18 +88,11 @@ def build_connection(model, conn):
                 (conn.pre_slice.step is None or conn.pre_slice.step == 1)):
             signal = model.sig[conn]['in'][conn.pre_slice]
         else:
-            sig_in, signal = build_pyfunc(
-                fn=(lambda x: x[conn.pre_slice]) if conn.function is None else
-                   (lambda x: conn.function(x[conn.pre_slice])),
-                t_in=False,
-                n_in=model.sig[conn]['in'].size,
-                n_out=conn.size_mid,
-                label=str(conn),
-                model=model)
-            model.add_op(DotInc(model.sig[conn]['in'],
-                                model.sig['common'][1],
-                                sig_in,
-                                tag="%s input" % conn))
+            signal = Signal(np.zeros(conn.size_mid), name='%s.func' % conn)
+            fn = ((lambda x: x[conn.pre_slice]) if conn.function is None else
+                  (lambda x: conn.function(x[conn.pre_slice])))
+            model.add_op(SimPyFunc(
+                output=signal, fn=fn, t_in=False, x=model.sig[conn]['in']))
     elif isinstance(conn.pre_obj, Ensemble):
         # Normal decoded connection
         eval_points, activities, targets = build_linear_system(

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import nengo.utils.numpy as npext
 from nengo.builder.builder import Builder
-from nengo.builder.operator import Copy, DotInc, Reset, SimNoise
+from nengo.builder.operator import Copy, DotInc, Reset
 from nengo.builder.signal import Signal
 from nengo.dists import Distribution
 from nengo.ensemble import Ensemble
@@ -106,7 +106,7 @@ def build_ensemble(model, ens):
 
     # Inject noise if specified
     if ens.noise is not None:
-        model.add_op(SimNoise(model.sig[ens.neurons]['in'], ens.noise))
+        model.build(ens.noise, sig_out=model.sig[ens.neurons]['in'], inc=True)
 
     # Create output signal, using built Neurons
     model.add_op(DotInc(

--- a/nengo/builder/node.py
+++ b/nengo/builder/node.py
@@ -2,95 +2,34 @@ import numpy as np
 
 from nengo.builder.builder import Builder
 from nengo.builder.signal import Signal
-from nengo.builder.operator import DotInc, Operator, Reset
+from nengo.builder.operator import Reset, SimPyFunc
 from nengo.node import Node
-
-
-class SimPyFunc(Operator):
-    """Set signal `output` by some non-linear function of x, possibly t"""
-
-    def __init__(self, output, fn, t_in, x):
-        self.output = output
-        self.fn = fn
-        self.t_in = t_in
-        self.x = x
-
-        self.sets = [] if output is None else [output]
-        self.incs = []
-        self.reads = [] if x is None else [x]
-        self.updates = []
-
-    def __str__(self):
-        return "SimPyFunc(%s -> %s '%s')" % (self.x, self.output, self.fn)
-
-    def make_step(self, signals, dt, rng):
-        output = signals[self.output] if self.output is not None else None
-        fn = self.fn
-        t_in = self.t_in
-        t_sig = signals['__time__']
-
-        args = []
-        if self.x is not None:
-            x_sig = signals[self.x].view()
-            x_sig.flags.writeable = False
-            args += [x_sig]
-
-        def step():
-            y = fn(t_sig.item(), *args) if t_in else fn(*args)
-            if output is not None:
-                if y is None:
-                    raise ValueError(
-                        "Function '%s' returned invalid value" % fn.__name__)
-                output[...] = y
-
-        return step
-
-
-def build_pyfunc(model, fn, t_in, n_in, n_out, label):
-    if n_in:
-        sig_in = Signal(np.zeros(n_in), name="%s.input" % label)
-        model.add_op(Reset(sig_in))
-    else:
-        sig_in = None
-
-    if n_out > 0:
-        sig_out = Signal(np.zeros(n_out), name="%s.output" % label)
-    else:
-        sig_out = None
-
-    model.add_op(SimPyFunc(output=sig_out, fn=fn, t_in=t_in, x=sig_in))
-
-    return sig_in, sig_out
+from nengo.utils.compat import is_array_like
 
 
 @Builder.register(Node)
 def build_node(model, node):
-    # Get input
-    if node.output is None or callable(node.output):
-        if node.size_in > 0:
-            model.sig[node]['in'] = Signal(
-                np.zeros(node.size_in), name="%s.signal" % node)
-            # Reset input signal to 0 each timestep
-            model.add_op(Reset(model.sig[node]['in']))
+    # input signal
+    if not is_array_like(node.output) and node.size_in > 0:
+        sig_in = Signal(np.zeros(node.size_in), name="%s.in" % node)
+        model.add_op(Reset(sig_in))
+    else:
+        sig_in = None
 
     # Provide output
     if node.output is None:
-        model.sig[node]['out'] = model.sig[node]['in']
-    elif not callable(node.output):
-        model.sig[node]['out'] = Signal(node.output, name=str(node))
+        sig_out = sig_in
+    elif callable(node.output):
+        sig_out = (Signal(np.zeros(node.size_out), name="%s.out" % node)
+                   if node.size_out > 0 else None)
+        model.add_op(SimPyFunc(
+            output=sig_out, fn=node.output, t_in=True, x=sig_in))
+    elif is_array_like(node.output):
+        sig_out = Signal(node.output, name="%s.out" % node)
     else:
-        sig_in, sig_out = build_pyfunc(model=model,
-                                       fn=node.output,
-                                       t_in=True,
-                                       n_in=node.size_in,
-                                       n_out=node.size_out,
-                                       label="%s.pyfn" % node)
-        if sig_in is not None:
-            model.add_op(DotInc(model.sig[node]['in'],
-                                model.sig['common'][1],
-                                sig_in,
-                                tag="%s input" % node))
-        if sig_out is not None:
-            model.sig[node]['out'] = sig_out
+        raise ValueError("Invalid node output type '%s'" % (
+            node.output.__class__.__name__))
 
+    model.sig[node]['in'] = sig_in
+    model.sig[node]['out'] = sig_out
     model.params[node] = None

--- a/nengo/builder/node.py
+++ b/nengo/builder/node.py
@@ -4,6 +4,7 @@ from nengo.builder.builder import Builder
 from nengo.builder.signal import Signal
 from nengo.builder.operator import Reset, SimPyFunc
 from nengo.node import Node
+from nengo.processes import Process
 from nengo.utils.compat import is_array_like
 
 
@@ -19,6 +20,9 @@ def build_node(model, node):
     # Provide output
     if node.output is None:
         sig_out = sig_in
+    elif isinstance(node.output, Process):
+        sig_out = Signal(np.zeros(node.size_out), name="%s.out" % node)
+        model.build(node.output, sig_in, sig_out)
     elif callable(node.output):
         sig_out = (Signal(np.zeros(node.size_out), name="%s.out" % node)
                    if node.size_out > 0 else None)

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -128,6 +128,9 @@ class Operator(object):
             if sig.base not in signals:
                 signals.init(sig.base)
 
+    def reset(self):
+        pass
+
 
 class PreserveValue(Operator):
     """Marks a signal as `set` for the graph checker.

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -330,3 +330,43 @@ class SimNoise(Operator):
             Yview[...] += sample_f()
 
         return step
+
+
+class SimPyFunc(Operator):
+    """Set signal `output` by some non-linear function of x, possibly t"""
+
+    def __init__(self, output, fn, t_in, x):
+        self.output = output
+        self.fn = fn
+        self.t_in = t_in
+        self.x = x
+
+        self.sets = [] if output is None else [output]
+        self.incs = []
+        self.reads = [] if x is None else [x]
+        self.updates = []
+
+    def __str__(self):
+        return "SimPyFunc(%s -> %s '%s')" % (self.x, self.output, self.fn)
+
+    def make_step(self, signals, dt, rng):
+        output = signals[self.output] if self.output is not None else None
+        fn = self.fn
+        t_in = self.t_in
+        t_sig = signals['__time__']
+
+        args = []
+        if self.x is not None:
+            x_sig = signals[self.x].view()
+            x_sig.flags.writeable = False
+            args += [x_sig]
+
+        def step():
+            y = fn(t_sig.item(), *args) if t_in else fn(*args)
+            if output is not None:
+                if y is None:
+                    raise ValueError(
+                        "Function '%s' returned invalid value" % fn.__name__)
+                output[...] = y
+
+        return step

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -311,27 +311,6 @@ class DotInc(Operator):
         return step
 
 
-class SimNoise(Operator):
-    def __init__(self, output, process):
-        self.output = output
-        self.process = process
-
-        self.sets = []
-        self.incs = [output]
-        self.reads = []
-        self.updates = []
-
-    def make_step(self, signals, dt, rng):
-        Y = signals[self.output]
-        sample_f = self.process.make_sample(dt=dt, d=Y.size, rng=rng)
-        Yview = Y.reshape(-1)
-
-        def step():
-            Yview[...] += sample_f()
-
-        return step
-
-
 class SimPyFunc(Operator):
     """Set signal `output` by some non-linear function of x, possibly t"""
 

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -48,7 +48,7 @@ class SimProbeBuffer(SimProbeOutput):
 @Builder.register(ProbeBuffer)
 def build_probe_buffer(model, probe_buffer, probe):
     op = SimProbeBuffer(model.sig[probe]['in'], probe.sample_every)
-    model.add_op(op)
+    model.add_op(op, probe=True)
 
     # Add a reference so that Simulator can get this data for the user
     model.params[probe] = op.buffer

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -1,14 +1,57 @@
 import numpy as np
 
 from nengo.builder.builder import Builder
-from nengo.builder.operator import Reset
+from nengo.builder.operator import Operator, Reset
 from nengo.builder.signal import Signal
 from nengo.builder.synapses import filtered_signal
 from nengo.connection import Connection, LearningRule
 from nengo.ensemble import Ensemble, Neurons
 from nengo.node import Node
-from nengo.probe import Probe
+from nengo.probe import Probe, ProbeBuffer
 from nengo.utils.compat import iteritems
+
+
+class SimProbeOutput(Operator):
+    def __init__(self, signal):
+        self.signal = signal
+
+        self.sets = []
+        self.incs = []
+        self.reads = [signal]
+        self.updates = []
+
+
+class SimProbeBuffer(SimProbeOutput):
+
+    def __init__(self, signal, sampling_dt=None):
+        super(SimProbeBuffer, self).__init__(signal)
+        self.sampling_dt = sampling_dt
+
+        self.buffer = []
+
+    def make_step(self, signals, dt, rng):
+        # clear buffer, in case this has been run before
+        del self.buffer[:]
+
+        period = 1 if self.sampling_dt is None else self.sampling_dt / dt
+        target = signals[self.signal]
+        sim_step = signals['__step__']
+        buf = self.buffer
+
+        def step():
+            if sim_step % period < 1:
+                buf.append(target.copy())
+
+        return step
+
+
+@Builder.register(ProbeBuffer)
+def build_probe_buffer(model, probe_buffer, probe):
+    op = SimProbeBuffer(model.sig[probe]['in'], probe.sample_every)
+    model.add_op(op)
+
+    # Add a reference so that Simulator can get this data for the user
+    model.params[probe] = op.buffer
 
 
 def conn_probe(model, probe):
@@ -73,7 +116,4 @@ def build_probe(model, probe):
     else:
         synapse_probe(model, key, probe)
 
-    model.probes.append(probe)
-
-    # Simulator will fill this list with probe data during simulation
-    model.params[probe] = []
+    model.build(probe.output, probe)

--- a/nengo/builder/processes.py
+++ b/nengo/builder/processes.py
@@ -1,0 +1,44 @@
+from nengo.builder.builder import Builder
+from nengo.builder.operator import Operator
+from nengo.processes import Process
+
+
+class SimProcess(Operator):
+    """Simulate a Process object."""
+    def __init__(self, process, input, output, inc=False):
+        self.process = process
+        self.input = input
+        self.output = output
+        self.inc = inc
+
+        if inc:
+            self.sets = []
+            self.incs = [output] if output is not None else []
+        else:
+            self.sets = [output] if output is not None else []
+            self.incs = []
+        self.reads = [input] if input is not None else []
+        self.updates = []
+
+    def make_step(self, signals, dt, rng):
+        input = signals[self.input] if self.input is not None else None
+        output = signals[self.output] if self.output is not None else None
+        size_in = input.size if input is not None else 0
+        size_out = output.size if output is not None else 0
+        step_f = self.process.make_step(size_in, size_out, dt, rng)
+        inc = self.inc
+
+        def step():
+            result = step_f(input) if input is not None else step_f()
+            if output is not None:
+                if inc:
+                    output[...] += result
+                else:
+                    output[...] = result
+
+        return step
+
+
+@Builder.register(Process)
+def build_process(model, process, sig_in=None, sig_out=None, inc=False):
+    model.add_op(SimProcess(process, sig_in, sig_out, inc=inc))

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -3,10 +3,11 @@ import logging
 import numpy as np
 
 from nengo.base import NengoObject, NengoObjectParam, ObjView
+from nengo.dists import DistOrArrayParam
 from nengo.ensemble import Ensemble
 from nengo.learning_rules import LearningRuleType, LearningRuleTypeParam
 from nengo.node import Node
-from nengo.params import (Default, BoolParam, DistributionParam, FunctionParam,
+from nengo.params import (Default, BoolParam, FunctionParam,
                           IntParam, ListParam, NdarrayParam)
 from nengo.solvers import LstsqL2, SolverParam
 from nengo.synapses import Lowpass, SynapseParam
@@ -47,7 +48,7 @@ class ConnectionSolverParam(SolverParam):
                     "(got '%s')" % conn.post.__class__.__name__)
 
 
-class EvalPointsParam(DistributionParam):
+class EvalPointsParam(DistOrArrayParam):
     def validate(self, conn, ndarray):
         """Eval points are only valid when pre is an ensemble."""
         if not isinstance(conn.pre, Ensemble):

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import numpy as np
 
+from nengo.params import NdarrayParam, Parameter, Unconfigurable
 import nengo.utils.numpy as npext
 
 
@@ -227,3 +228,26 @@ class Choice(Distribution):
 
         i = np.searchsorted(np.cumsum(self.p), rng.rand(n))
         return self.options[i]
+
+
+class DistributionParam(Parameter):
+    """A Distribution."""
+
+    def validate(self, instance, dist):
+        if dist is not None and not isinstance(dist, Distribution):
+            raise ValueError("'%s' is not a Distribution type" % dist)
+        super(DistributionParam, self).validate(instance, dist)
+
+
+class DistOrArrayParam(NdarrayParam):
+    """Can be a Distribution or samples from a distribution."""
+
+    def __init__(self, default=Unconfigurable, sample_shape=None,
+                 optional=False, readonly=False):
+        super(DistOrArrayParam, self).__init__(
+            default, sample_shape, optional, readonly)
+
+    def validate(self, instance, dist):
+        if dist is not None and not isinstance(dist, Distribution):
+            dist = super(DistOrArrayParam, self).validate(instance, dist)
+        return dist

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -2,8 +2,8 @@ from nengo.base import NengoObject, ObjView
 from nengo.dists import DistOrArrayParam, Uniform, UniformHypersphere
 from nengo.neurons import LIF, NeuronTypeParam, Direct
 from nengo.params import (
-    Default, IntParam, ListParam, NumberParam,
-    StochasticProcessParam, StringParam)
+    Default, IntParam, ListParam, NumberParam, StringParam)
+from nengo.processes import ProcessParam
 
 
 class Ensemble(NengoObject):
@@ -38,7 +38,7 @@ class Ensemble(NengoObject):
         determine the number of evaluation points.
     neuron_type : Neurons, optional
         The model that simulates all neurons in the ensemble.
-    noise : StochasticProcess, optional
+    noise : Process, optional
         Random noise injected directly into each neuron in the ensemble
         as current. A sample is drawn for each individual neuron on
         every simulation step.
@@ -69,7 +69,7 @@ class Ensemble(NengoObject):
     gain = DistOrArrayParam(default=None,
                             optional=True,
                             sample_shape=('n_neurons',))
-    noise = StochasticProcessParam(default=None, optional=True)
+    noise = ProcessParam(default=None, optional=True)
     seed = IntParam(default=None, optional=True)
     label = StringParam(default=None, optional=True)
     probeable = ListParam(default=['decoded_output', 'input'])

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -1,8 +1,8 @@
 from nengo.base import NengoObject, ObjView
-from nengo.dists import Uniform, UniformHypersphere
+from nengo.dists import DistOrArrayParam, Uniform, UniformHypersphere
 from nengo.neurons import LIF, NeuronTypeParam, Direct
 from nengo.params import (
-    Default, DistributionParam, IntParam, ListParam, NumberParam,
+    Default, IntParam, ListParam, NumberParam,
     StochasticProcessParam, StringParam)
 
 
@@ -52,23 +52,23 @@ class Ensemble(NengoObject):
     dimensions = IntParam(default=None, low=1)
     radius = NumberParam(default=1.0, low=1e-10)
     neuron_type = NeuronTypeParam(default=LIF())
-    encoders = DistributionParam(default=UniformHypersphere(surface=True),
-                                 sample_shape=('n_neurons', 'dimensions'))
-    intercepts = DistributionParam(default=Uniform(-1.0, 1.0),
-                                   optional=True,
-                                   sample_shape=('n_neurons',))
-    max_rates = DistributionParam(default=Uniform(200, 400),
+    encoders = DistOrArrayParam(default=UniformHypersphere(surface=True),
+                                sample_shape=('n_neurons', 'dimensions'))
+    intercepts = DistOrArrayParam(default=Uniform(-1.0, 1.0),
                                   optional=True,
                                   sample_shape=('n_neurons',))
+    max_rates = DistOrArrayParam(default=Uniform(200, 400),
+                                 optional=True,
+                                 sample_shape=('n_neurons',))
     n_eval_points = IntParam(default=None, optional=True)
-    eval_points = DistributionParam(default=UniformHypersphere(),
-                                    sample_shape=('*', 'dimensions'))
-    bias = DistributionParam(default=None,
-                             optional=True,
-                             sample_shape=('n_neurons',))
-    gain = DistributionParam(default=None,
-                             optional=True,
-                             sample_shape=('n_neurons',))
+    eval_points = DistOrArrayParam(default=UniformHypersphere(),
+                                   sample_shape=('*', 'dimensions'))
+    bias = DistOrArrayParam(default=None,
+                            optional=True,
+                            sample_shape=('n_neurons',))
+    gain = DistOrArrayParam(default=None,
+                            optional=True,
+                            sample_shape=('n_neurons',))
     noise = StochasticProcessParam(default=None, optional=True)
     seed = IntParam(default=None, optional=True)
     label = StringParam(default=None, optional=True)

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -22,13 +22,12 @@ class OutputParam(Parameter):
                 warnings.warn("'Node.size_out' is being overwritten with "
                               "'Node.size_in' since 'Node.output=None'")
             node.size_out = node.size_in
-        elif callable(output) and node.size_out is not None:
+        elif callable(output):
             # We trust user's size_out if set, because calling output
             # may have unintended consequences (e.g., network communication)
-            pass
-        elif callable(output):
-            result = self.validate_callable(node, output)
-            node.size_out = 0 if result is None else result.size
+            if node.size_out is None:
+                result = self.validate_callable(node, output)
+                node.size_out = 0 if result is None else result.size
         else:
             # Make into correctly shaped numpy array before validation
             output = npext.array(

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -5,6 +5,7 @@ import numpy as np
 import nengo.utils.numpy as npext
 from nengo.base import NengoObject, ObjView
 from nengo.params import Default, IntParam, ListParam, Parameter, StringParam
+from nengo.processes import Process
 from nengo.utils.stdlib import checked_call
 
 
@@ -22,6 +23,9 @@ class OutputParam(Parameter):
                 warnings.warn("'Node.size_out' is being overwritten with "
                               "'Node.size_in' since 'Node.output=None'")
             node.size_out = node.size_in
+        elif isinstance(output, Process):
+            if node.size_out is None:
+                node.size_out = output.default_size_out
         elif callable(output):
             # We trust user's size_out if set, because calling output
             # may have unintended consequences (e.g., network communication)

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -3,7 +3,6 @@ import weakref
 
 import numpy as np
 
-from nengo.dists import Distribution
 from nengo.processes import StochasticProcess
 from nengo.utils.compat import is_integer, is_number, is_string
 from nengo.utils.numpy import compare
@@ -37,7 +36,7 @@ class Parameter(object):
         Whether this parameter accepts the value None. By default,
         parameters are not optional (i.e., cannot be set to ``None``).
     readonly : bool, optional
-        Whether the parameter can be set multiple times.
+        If true, the parameter can only be set once.
         By default, parameters can be set multiple times.
     """
     def __init__(self, default=Unconfigurable, optional=False, readonly=False):
@@ -198,34 +197,6 @@ class NdarrayParam(Parameter):
                 raise ValueError("shape[%d] should be %d (got %d)"
                                  % (i, desired, ndarray.shape[i]))
         return ndarray
-
-
-class DistributionParam(NdarrayParam):
-    """Can be a Distribution or samples from a distribution."""
-
-    def __init__(self, default=Unconfigurable, sample_shape=None,
-                 optional=False, readonly=False):
-        super(DistributionParam, self).__init__(
-            default, sample_shape, optional, readonly)
-
-    def validate(self, instance, dist):
-        if dist is not None and not isinstance(dist, Distribution):
-            dist = super(DistributionParam, self).validate(instance, dist)
-        return dist
-
-
-class StochasticProcessParam(Parameter):
-    """Can be a StochasticProcess."""
-
-    def validate(self, instance, process):
-        super(StochasticProcessParam, self).validate(instance, process)
-
-        if process is not None and not isinstance(process, StochasticProcess):
-            raise ValueError(
-                "Must be StochasticProcess (got type {0}).".format(
-                    process.__class__.__name__))
-
-        return process
 
 
 FunctionInfo = collections.namedtuple('FunctionInfo', ['function', 'size'])

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -3,7 +3,6 @@ import weakref
 
 import numpy as np
 
-from nengo.processes import StochasticProcess
 from nengo.utils.compat import is_integer, is_number, is_string
 from nengo.utils.numpy import compare
 from nengo.utils.stdlib import checked_call

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -27,6 +27,23 @@ class ProbeBuffer(ProbeOutput):
     pass
 
 
+class ProbeFunction(ProbeOutput):
+    def __init__(self, function):
+        self.function = function
+
+
+class ProbeOutputParam(Parameter):
+    def __set__(self, instance, value):
+        if not isinstance(value, ProbeOutput) and callable(value):
+            value = ProbeFunction(value)
+
+        super(ProbeOutputParam, self).__set__(instance, value)
+
+    def validate(self, probe, probe_output):
+        if not isinstance(probe_output, ProbeOutput):
+            raise ValueError("Must be a 'ProbeOutput' object")
+
+
 class TargetParam(NengoObjectParam):
     def validate(self, probe, target):
         obj = target.obj if isinstance(target, ObjView) else target
@@ -59,12 +76,6 @@ class ProbeSolverParam(SolverParam):
         if solver is not None and solver.weights:
             raise ValueError("weight solvers only work for ensemble to "
                              "ensemble connections, not probes")
-
-
-class ProbeOutputParam(Parameter):
-    def validate(self, probe, probe_output):
-        if not isinstance(probe_output, ProbeOutput):
-            raise ValueError("Must be a 'ProbeOutput' object")
 
 
 class Probe(NengoObject):

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -13,7 +13,6 @@ import numpy as np
 
 import nengo.utils.numpy as npext
 from nengo.builder import Model
-from nengo.builder.signal import SignalDict
 from nengo.cache import get_default_decoder_cache
 from nengo.utils.compat import range
 from nengo.utils.graphs import toposort

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -118,6 +118,7 @@ class Simulator(object):
         self.dg = operator_depencency_graph(self.model.operators)
         self._step_order = [op for op in toposort(self.dg)
                             if hasattr(op, 'make_step')]
+        self._step_order.extend(op for op in self.model.probe_operators)
 
         # Add built states to the probe dictionary
         self._probe_outputs = self.model.params

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -102,6 +102,41 @@ def test_choice(weights, rng):
     assert np.allclose(p, p_empirical, atol=2 * sterr)
 
 
+def test_distributionparam():
+    """DistOrArrayParams can be distributions or samples."""
+    class Test(object):
+        dp = dists.DistOrArrayParam(default=None, sample_shape=['*', '*'])
+
+    inst = Test()
+    inst.dp = dists.UniformHypersphere()
+    assert isinstance(inst.dp, dists.UniformHypersphere)
+    inst.dp = np.array([[1], [2], [3]])
+    assert np.all(inst.dp == np.array([[1], [2], [3]]))
+    with pytest.raises(ValueError):
+        inst.dp = 'a'
+    # Sample must have correct dims
+    with pytest.raises(ValueError):
+        inst.dp = np.array([1])
+
+
+def test_distributionparam_sample_shape():
+    """sample_shape dictates the shape of the sample that can be set."""
+    class Test(object):
+        dp = dists.DistOrArrayParam(default=None, sample_shape=['d1', 10])
+        d1 = 4
+
+    inst = Test()
+    # Distributions are still cool
+    inst.dp = dists.UniformHypersphere()
+    assert isinstance(inst.dp, dists.UniformHypersphere)
+    # Must be shape (4, 10)
+    inst.dp = np.ones((4, 10))
+    assert np.all(inst.dp == np.ones((4, 10)))
+    with pytest.raises(ValueError):
+        inst.dp = np.ones((10, 4))
+    assert np.all(inst.dp == np.ones((4, 10)))
+
+
 if __name__ == "__main__":
     nengo.log(debug=True)
     pytest.main([__file__, '-v'])

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -5,8 +5,8 @@ import pytest
 
 import nengo
 import nengo.utils.numpy as npext
-from nengo.dists import Choice, UniformHypersphere
-from nengo.processes import StochasticProcess
+from nengo.dists import Choice, Gaussian, UniformHypersphere
+from nengo.processes import WhiteNoise, FilteredNoise
 from nengo.utils.testing import warns, allclose
 
 logger = logging.getLogger(__name__)
@@ -296,24 +296,20 @@ def test_gain_bias(Simulator):
     assert np.array_equal(bias, sim.data[a].bias)
 
 
-def test_noise(Simulator, nl_nodirect, seed, plt):
+def test_noise_gen(Simulator, nl_nodirect, seed, plt):
     """Ensure that setting Ensemble.noise generates noise."""
     with nengo.Network(seed=seed) as model:
-        inp, gain, bias = 1, 5, 2
-        neg_noise, pos_noise = -4, 20
+        gain, bias = 1, 2
+        neg_noise, pos_noise = -4, 5
         model.config[nengo.Ensemble].neuron_type = nl_nodirect()
         model.config[nengo.Ensemble].encoders = Choice([[1]])
         model.config[nengo.Ensemble].gain = Choice([gain])
         model.config[nengo.Ensemble].bias = Choice([bias])
-        const = nengo.Node(output=inp)
         pos = nengo.Ensemble(
-            1, 1, noise=StochasticProcess(Choice([pos_noise])))
+            1, 1, noise=WhiteNoise(Gaussian(pos_noise, 0.01)))
         normal = nengo.Ensemble(1, 1)
         neg = nengo.Ensemble(
-            1, 1, noise=StochasticProcess(Choice([neg_noise])))
-        nengo.Connection(const, pos)
-        nengo.Connection(const, normal)
-        nengo.Connection(const, neg)
+            1, 1, noise=WhiteNoise(Gaussian(neg_noise, 0.01)))
         pos_p = nengo.Probe(pos.neurons, synapse=0.1)
         normal_p = nengo.Probe(normal.neurons, synapse=0.1)
         neg_p = nengo.Probe(neg.neurons, synapse=0.1)
@@ -321,7 +317,7 @@ def test_noise(Simulator, nl_nodirect, seed, plt):
     sim.run(0.06)
 
     t = sim.trange()
-    plt.title("input=%d, bias=%d, gain=%d" % (inp, bias, gain))
+    plt.title("bias=%d, gain=%d" % (bias, gain))
     plt.plot(t, sim.data[pos_p], c='b', label="noise=%d" % pos_noise)
     plt.plot(t, sim.data[normal_p], c='k', label="no noise")
     plt.plot(t, sim.data[neg_p], c='r', label="noise=%d" % neg_noise)
@@ -339,7 +335,7 @@ def test_noise_copies_ok(Simulator, nl_nodirect, seed, plt):
     We test this both with the default system and without.
     """
 
-    process = StochasticProcess(Choice([0.5]), synapse=nengo.Alpha(1.))
+    process = FilteredNoise(synapse=nengo.Alpha(1.), dist=Choice([0.5]))
     with nengo.Network(seed=seed) as model:
         inp, gain, bias = 1, 5, 2
         model.config[nengo.Ensemble].neuron_type = nl_nodirect()

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -3,7 +3,7 @@ import pytest
 
 import nengo
 from nengo.learning_rules import LearningRuleTypeParam, PES, BCM, Oja
-from nengo.processes import WhiteNoise
+from nengo.processes import WhiteSignal
 from nengo.solvers import LstsqL2nz
 
 
@@ -159,7 +159,7 @@ def test_unsupervised(Simulator, learning_rule_type, seed, rng, plt):
 
     m = nengo.Network(seed=seed)
     with m:
-        u = nengo.Node(WhiteNoise(0.5, high=5).f(d=2, rng=rng))
+        u = nengo.Node(WhiteSignal(0.5, high=5), size_out=2)
         a = nengo.Ensemble(n, dimensions=2)
         u_learned = nengo.Ensemble(n, dimensions=2)
 

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -4,7 +4,7 @@ import pytest
 
 import nengo
 from nengo.neurons import NeuronTypeParam
-from nengo.processes import WhiteNoise
+from nengo.processes import WhiteSignal
 from nengo.solvers import LstsqL2nz
 from nengo.utils.ensemble import tuning_curves
 from nengo.utils.matplotlib import implot, rasterplot
@@ -207,7 +207,7 @@ def test_izhikevich(Simulator, plt, seed, rng):
     simulated in Nengo (but doesn't test any properties of them).
     """
     with nengo.Network() as m:
-        u = nengo.Node(output=WhiteNoise(0.6, 8).f(d=1, rng=rng))
+        u = nengo.Node(output=WhiteSignal(0.6, 8), size_out=1)
 
         # Seed the ensembles (not network) so we get the same sort of neurons
         ens_args = {'n_neurons': 4, 'dimensions': 1, 'seed': seed}
@@ -258,7 +258,7 @@ def test_dt_dependence(Simulator, nl_nodirect, plt, seed, rng):
     """Neurons should not wildly change with different dt."""
     with nengo.Network(seed=seed) as m:
         m.config[nengo.Ensemble].neuron_type = nl_nodirect()
-        u = nengo.Node(output=WhiteNoise(0.1, 5).f(d=2, rng=rng))
+        u = nengo.Node(output=WhiteSignal(0.1, 5), size_out=2)
         pre = nengo.Ensemble(60, dimensions=2)
         square = nengo.Ensemble(60, dimensions=2)
         nengo.Connection(u, pre)
@@ -300,7 +300,7 @@ def test_reset(Simulator, nl_nodirect, seed, rng):
     m = nengo.Network(seed=seed)
     with m:
         m.config[nengo.Ensemble].neuron_type = nl_nodirect()
-        u = nengo.Node(output=WhiteNoise(0.15, 5).f(d=2, rng=rng))
+        u = nengo.Node(output=WhiteSignal(0.15, 5), size_out=2)
         ens = nengo.Ensemble(60, dimensions=2)
         square = nengo.Ensemble(60, dimensions=2)
         nengo.Connection(u, ens)

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -5,7 +5,6 @@ import pytest
 
 import nengo
 from nengo import params
-from nengo.dists import UniformHypersphere
 from nengo.utils.compat import PY2
 
 logger = logging.getLogger(__name__)
@@ -198,41 +197,6 @@ def test_dictparam():
     # Non-dicts no good
     with pytest.raises(ValueError):
         inst2.dp = [('a', 1), ('b', 2)]
-
-
-def test_distributionparam():
-    """DistributionParams can be distributions or samples."""
-    class Test(object):
-        dp = params.DistributionParam(default=None, sample_shape=['*', '*'])
-
-    inst = Test()
-    inst.dp = UniformHypersphere()
-    assert isinstance(inst.dp, UniformHypersphere)
-    inst.dp = np.array([[1], [2], [3]])
-    assert np.all(inst.dp == np.array([[1], [2], [3]]))
-    with pytest.raises(ValueError):
-        inst.dp = 'a'
-    # Sample must have correct dims
-    with pytest.raises(ValueError):
-        inst.dp = np.array([1])
-
-
-def test_distributionparam_sample_shape():
-    """sample_shape dictates the shape of the sample that can be set."""
-    class Test(object):
-        dp = params.DistributionParam(default=None, sample_shape=['d1', 10])
-        d1 = 4
-
-    inst = Test()
-    # Distributions are still cool
-    inst.dp = UniformHypersphere()
-    assert isinstance(inst.dp, UniformHypersphere)
-    # Must be shape (4, 10)
-    inst.dp = np.ones((4, 10))
-    assert np.all(inst.dp == np.ones((4, 10)))
-    with pytest.raises(ValueError):
-        inst.dp = np.ones((10, 4))
-    assert np.all(inst.dp == np.ones((4, 10)))
 
 
 def test_ndarrayparam():

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -4,8 +4,9 @@ import numpy as np
 import pytest
 
 import nengo
+import nengo.utils.numpy as npext
 from nengo.dists import Distribution, Gaussian
-from nengo.processes import BrownNoise, StochasticProcess, WhiteNoise
+from nengo.processes import BrownNoise, WhiteNoise, WhiteSignal
 from nengo.utils.numpy import rfftfreq
 
 
@@ -20,24 +21,27 @@ class DistributionMock(Distribution):
         return np.ones((n, d)) * self.retval
 
 
-def test_stochasticprocess(rng):
+def test_whitenoise(rng):
     dist = DistributionMock(42)
-    process = StochasticProcess(dist)
-    samples = nengo.processes.sample(5, process, d=2, rng=rng)
+    process = WhiteNoise(dist, scale=False)
+    samples = process.run_steps(5, d=2, rng=rng)
     assert np.all(samples == 42 * np.ones((5, 2)))
-    assert nengo.processes.sample(5, process).shape == (5,)
-    assert nengo.processes.sample(1, process, d=1).shape == (1, 1)
-    assert nengo.processes.sample(2, process, d=3).shape == (2, 3)
+    assert process.run_steps(5, rng=rng).shape == (5, 1)
+    assert process.run_steps(1, d=1, rng=rng).shape == (1, 1)
+    assert process.run_steps(2, d=3, rng=rng).shape == (2, 3)
 
 
 def test_brownnoise(rng, plt):
     d = 5000
-    t = 500
+    t = 0.5
     dt = 0.001
-    samples = nengo.processes.sample(t, BrownNoise(), dt=dt, d=d, rng=rng)
+    std = 1.5
 
-    trange = np.arange(1, t + 1) * dt
-    expected_std = np.sqrt((np.arange(t) + 1) * dt)
+    process = BrownNoise(dist=Gaussian(0, std))
+    samples = process.run(t, d=d, dt=dt, rng=rng)
+
+    trange = process.trange(t, dt=dt)
+    expected_std = std * np.sqrt(trange)
     atol = 3.5 * expected_std / np.sqrt(d)
 
     plt.subplot(2, 1, 1)
@@ -63,15 +67,15 @@ def psd(values, dt=0.001):
 @pytest.mark.parametrize('rms', [0.5, 1, 100])
 def test_gaussian_whitenoise(rms, rng, plt):
     d = 500
-    t = 100
+    t = 0.1
     dt = 0.001
 
-    process = StochasticProcess(Gaussian(0., rms))
+    process = WhiteNoise(Gaussian(0., rms))
 
-    values = nengo.processes.sample(t, process, dt=dt, d=d, rng=rng)
+    values = process.run(t, d=d, dt=dt, rng=rng)
     freq, val_psd = psd(values)
 
-    trange = np.arange(1, t + 1) * dt
+    trange = process.trange(t, dt=dt)
     plt.subplot(2, 1, 1)
     plt.title("First two dimensions of white noise process, rms=%.1f" % rms)
     plt.plot(trange, values[:, :2])
@@ -81,21 +85,22 @@ def test_gaussian_whitenoise(rms, rng, plt):
     plt.plot(freq, val_psd, drawstyle='steps')
     plt.saveas = 'test_processes.test_gaussian_white_noise_rms%.1f.pdf' % rms
 
-    assert np.allclose(np.std(values), rms, rtol=0.02)
-    assert np.allclose(val_psd[1:-1], rms, rtol=0.2)
+    val_rms = npext.rms(values, axis=0) * np.sqrt(dt)
+    assert np.allclose(val_rms.mean(), rms, rtol=0.02)
+    assert np.allclose(val_psd[1:-1] * np.sqrt(dt), rms, rtol=0.2)
 
 
 @pytest.mark.parametrize('rms', [0.5, 1, 100])
-def test_whitenoise_rms(rms, rng, plt):
+def test_whitesignal_rms(rms, rng, plt):
     d = 500
-    t = 100
+    t = 1
     dt = 0.001
 
-    process = WhiteNoise(dt * t, rms=rms)
-    values = nengo.processes.sample(t, process, dt=dt, d=d, rng=rng)
+    process = WhiteSignal(t, rms=rms)
+    values = process.run(t, d=d, dt=dt, rng=rng)
     freq, val_psd = psd(values)
 
-    trange = np.arange(1, t + 1) * dt
+    trange = process.trange(t, dt=dt)
     plt.subplot(2, 1, 1)
     plt.title("First two D of white noise process, rms=%.1f" % rms)
     plt.plot(trange, values[:, :2])
@@ -110,17 +115,17 @@ def test_whitenoise_rms(rms, rng, plt):
 
 
 @pytest.mark.parametrize('high', [5, 50])
-def test_whitenoise_high(high, rng, plt):
+def test_whitesignal_high(high, rng, plt):
     rms = 0.5
     d = 500
-    t = 1000
+    t = 1
     dt = 0.001
 
-    process = WhiteNoise(dt * t, high, rms=rms)
-    values = nengo.processes.sample(t, process, dt=dt, d=d, rng=rng)
+    process = WhiteSignal(t, high, rms=rms)
+    values = process.run(t, d=d, dt=dt, rng=rng)
     freq, val_psd = psd(values)
 
-    trange = np.arange(1, t + 1) * dt
+    trange = process.trange(t, dt=dt)
     plt.subplot(2, 1, 1)
     plt.title("First two D of white noise process, high=%d Hz" % high)
     plt.plot(trange, values[:, :2])
@@ -135,18 +140,18 @@ def test_whitenoise_high(high, rng, plt):
     assert np.all(val_psd[rfftfreq(t, dt) > high] < rms * 0.5)
 
 
-def test_whitenoise_dt(rng, plt):
+def test_whitesignal_dt(rng, plt):
     rms = 0.5
     high = 10
     d = 500
-    t = 100
+    t = 1
     dt = 0.01
 
-    process = WhiteNoise(dt * t, high, rms=rms)
-    values = nengo.processes.sample(t, process, dt=dt, d=d, rng=rng)
+    process = WhiteSignal(t, high, rms=rms)
+    values = process.run(t, d=d, dt=dt, rng=rng)
     freq, val_psd = psd(values, dt=dt)
 
-    trange = np.arange(1, t + 1) * dt
+    trange = process.trange(t, dt=dt)
     plt.subplot(2, 1, 1)
     plt.title("First two D of white noise process, high=%d Hz" % high)
     plt.plot(trange, values[:, :2])
@@ -161,10 +166,10 @@ def test_whitenoise_dt(rng, plt):
 
 
 def test_sampling_shape():
-    process = WhiteNoise(0.1)
-    assert nengo.processes.sample(1, process).shape == (1,)
-    assert nengo.processes.sample(5, process, d=1).shape == (5, 1)
-    assert nengo.processes.sample(1, process, d=2). shape == (1, 2)
+    process = WhiteSignal(0.1)
+    assert process.run_steps(1).shape == (1, 1)
+    assert process.run_steps(5, d=1).shape == (5, 1)
+    assert process.run_steps(1, d=2). shape == (1, 2)
 
 
 if __name__ == "__main__":

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -172,6 +172,25 @@ def test_sampling_shape():
     assert process.run_steps(1, d=2). shape == (1, 2)
 
 
+def test_reset(seed):
+    trun = 0.1
+
+    with nengo.Network() as model:
+        u = nengo.Node(WhiteNoise(Gaussian(0, 1), scale=False))
+        up = nengo.Probe(u)
+
+    sim = nengo.Simulator(model, seed=seed)
+
+    sim.run(trun)
+    x = np.array(sim.data[up])
+
+    sim.reset()
+    sim.run(trun)
+    y = np.array(sim.data[up])
+
+    assert (x == y).all()
+
+
 if __name__ == "__main__":
     nengo.log(debug=True)
     pytest.main([__file__, "-v"])

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -6,10 +6,8 @@ import pytest
 import nengo
 import nengo.simulator
 from nengo.builder import Model
-from nengo.builder.operator import Copy, Reset, DotInc, SimNoise
+from nengo.builder.operator import Copy, Reset, DotInc
 from nengo.builder.signal import Signal
-from nengo.utils.compat import range
-
 
 logger = logging.getLogger(__name__)
 
@@ -90,32 +88,6 @@ def test_probedict():
     probedict = nengo.simulator.ProbeDict(raw)
     assert np.all(probedict["scalar"] == np.asarray(raw["scalar"]))
     assert np.all(probedict.get("list") == np.asarray(raw.get("list")))
-
-
-def test_noise(RefSimulator, seed):
-    """Make sure that we can generate noise properly."""
-
-    n = 1000
-    mean, std = 0.1, 0.8
-    noise = Signal(np.zeros(n), name="noise")
-    process = nengo.processes.StochasticProcess(
-        nengo.dists.Gaussian(mean, std))
-
-    m = Model(dt=0.001)
-    m.operators += [Reset(noise), SimNoise(noise, process)]
-
-    sim = RefSimulator(None, model=m, seed=seed)
-    samples = np.zeros((100, n))
-    for i in range(100):
-        sim.step()
-        samples[i] = sim.signals[noise]
-
-    h, xedges = np.histogram(samples.flat, bins=51)
-    x = 0.5 * (xedges[:-1] + xedges[1:])
-    dx = np.diff(xedges)
-    z = 1./np.sqrt(2 * np.pi * std**2) * np.exp(-0.5 * (x - mean)**2 / std**2)
-    y = h / float(h.sum()) / dx
-    assert np.allclose(y, z, atol=0.02)
 
 
 if __name__ == "__main__":

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -6,7 +6,6 @@ import pytest
 import nengo
 import nengo.simulator
 from nengo.builder import Model
-from nengo.builder.node import build_pyfunc
 from nengo.builder.operator import Copy, Reset, DotInc, SimNoise
 from nengo.builder.signal import Signal
 from nengo.utils.compat import range
@@ -82,27 +81,6 @@ def test_signal_indexing_1(RefSimulator):
     assert np.all(sim.signals[one] == 3)
     assert np.all(sim.signals[two] == [4, 2])
     assert np.all(sim.signals[three] == [1, 2, 3])
-
-
-def test_simple_pyfunc(RefSimulator):
-    dt = 0.001
-    time = Signal(np.zeros(1), name="time")
-    sig = Signal(np.zeros(1), name="sig")
-    m = Model(dt=dt)
-    sig_in, sig_out = build_pyfunc(m, lambda t, x: np.sin(x), True, 1, 1, None)
-    m.operators += [
-        Reset(sig),
-        DotInc(Signal([[1.0]]), time, sig_in),
-        DotInc(Signal([[1.0]]), sig_out, sig),
-        DotInc(Signal(dt), Signal(1), time, as_update=True),
-    ]
-
-    sim = RefSimulator(None, model=m)
-    for i in range(5):
-        sim.step()
-        t = i * dt
-        assert np.allclose(sim.signals[sig], np.sin(t))
-        assert np.allclose(sim.signals[time], t + dt)
 
 
 def test_probedict():

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import nengo
-from nengo.processes import WhiteNoise
+from nengo.processes import WhiteSignal
 from nengo.synapses import (
     Alpha, filt, filtfilt, LinearFilter, Lowpass, SynapseParam)
 from nengo.utils.testing import allclose
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 def run_synapse(Simulator, seed, synapse, dt=1e-3, runtime=1., n_neurons=None):
     model = nengo.Network(seed=seed)
     with model:
-        u = nengo.Node(
-            output=WhiteNoise(runtime, 5).f(rng=np.random.RandomState(seed)))
+        u = nengo.Node(output=WhiteSignal(runtime, 5))
 
         if n_neurons is not None:
             a = nengo.Ensemble(n_neurons, 1)

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -84,6 +84,14 @@ def is_string(obj):
     return isinstance(obj, string_types)
 
 
+def is_array(obj):
+    return isinstance(obj, np.ndarray)
+
+
+def is_array_like(obj):
+    return is_array(obj) or is_iterable(obj) or is_number(obj)
+
+
 def with_metaclass(meta, *bases):
     """Function for creating a class with a metaclass.
 

--- a/nengo/utils/tests/test_neurons.py
+++ b/nengo/utils/tests/test_neurons.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import nengo
 from nengo.dists import Choice
-from nengo.processes import WhiteNoise
+from nengo.processes import WhiteSignal
 from nengo.utils.matplotlib import implot
 from nengo.utils.neurons import rates_isi, rates_kernel
 from nengo.utils.numpy import rms
@@ -26,8 +26,7 @@ def _test_rates(Simulator, rates, plt, seed, name=None):
     with model:
         model.config[nengo.Ensemble].max_rates = Choice([50])
         model.config[nengo.Ensemble].encoders = Choice([[1]])
-        u = nengo.Node(output=WhiteNoise(2., 5).f(
-            rng=np.random.RandomState(seed=seed)))
+        u = nengo.Node(output=WhiteSignal(2, high=5))
         a = nengo.Ensemble(n, 1,
                            intercepts=intercepts, neuron_type=nengo.LIFRate())
         b = nengo.Ensemble(n, 1,


### PR DESCRIPTION
This sets up the framework for probe outputs as discussed in #613. The idea is that various subclasses of ProbeOutput can indicate whether a probe writes to a buffer, file, plot, etc. This PR sets that up by making Probes and ProbeOutputs things that are built, so it's easy to specify a builder function for different types of ProbeOutputs. Currently, there is just ProbeBuffer, which probes to a list like our old probes did. 

I've put this on top of my Process stuff because they both use the new `reset` function for Simulator, but otherwise it's independent of that PR.