### PR TITLE
Ignore PEP8 error for binary op linebreaks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,5 @@ commands = flake8 -v nengo
 
 [flake8]
 exclude = __init__.py
-ignore = E123,E133,E226,E241,E242,E731
+ignore = E123,E133,E226,E241,E242,E731,W503
 max-complexity = 10


### PR DESCRIPTION
Error W503 occurs when a line break occurs before a binary operator
instead of after it. We were ignoring this before `flake8` checked
it, so let's continue ignoring it.

See brief discussion at end of #640.