### PR TITLE
Comparison tests for analytics data.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Release History
 2.1.0 (unreleased)
 ==================
 
+**API changes**
+
+- Spiking ``LIF`` neuron models now accept an additional argument,
+  ``min_voltage``. Voltages are clipped such that they do not drop below
+  this value (previously, this was fixed at 0).
+  (`#666 <https://github.com/nengo/nengo/pull/666>`_)
+
 **Behavioural changes**
 
 - The ``probeable`` attribute of all Nengo objects is now implemented

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -223,14 +223,19 @@ class LIFRate(NeuronType):
 class LIF(LIFRate):
     """Spiking version of the leaky integrate-and-fire (LIF) neuron model."""
 
+    min_voltage = NumberParam(high=0)
     probeable = ['spikes', 'voltage', 'refractory_time']
+
+    def __init__(self, tau_rc=0.02, tau_ref=0.002, min_voltage=0):
+        super(LIF, self).__init__(tau_rc=tau_rc, tau_ref=tau_ref)
+        self.min_voltage = min_voltage
 
     def step_math(self, dt, J, spiked, voltage, refractory_time):
 
         # update voltage using accurate exponential integration scheme
         dV = -np.expm1(-dt / self.tau_rc) * (J - voltage)
         voltage += dV
-        voltage[voltage < 0] = 0  # clip values below zero
+        voltage[voltage < self.min_voltage] = self.min_voltage
 
         # update refractory period assuming no spikes for now
         refractory_time -= dt

--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -1,6 +1,7 @@
 import hashlib
 import inspect
 import os
+import re
 
 import numpy as np
 import pytest
@@ -119,6 +120,15 @@ def analytics(request):
     return analytics.__enter__()
 
 
+@pytest.fixture
+def analytics_data(request):
+    paths = request.config.getvalue('compare')
+    function_name = re.sub(
+        '^test_[a-zA-Z0-9]*_', 'test_', request.function.__name__, count=1)
+    return [Analytics.load(
+        p, request.module.__name__, function_name) for p in paths]
+
+
 def function_seed(function, mod=0):
     c = function.__code__
 
@@ -170,6 +180,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--analytics', nargs='?', default=False, const=True,
         help='Save analytics (can optionally specify a directory for data).')
+    parser.addoption('--compare', nargs=2, help='Compare analytics results.')
     parser.addoption('--noexamples', action='store_false', default=True,
                      help='Do not run examples')
     parser.addoption(
@@ -178,6 +189,10 @@ def pytest_addoption(parser):
 
 
 def pytest_runtest_setup(item):
+    if (item.config.getvalue('compare') and
+            not getattr(item.obj, 'compare', None)):
+        return
+
     for mark, option, message in [
             ('example', 'noexamples', "examples not requested"),
             ('slow', 'slow', "slow tests not requested")]:
@@ -197,3 +212,21 @@ def pytest_runtest_setup(item):
                     skipreasons.append(message)
         if skip:
             pytest.skip(" and ".join(skipreasons))
+
+
+def pytest_collection_modifyitems(session, config, items):
+    compare = config.getvalue('compare') is None
+    for item in list(items):
+        if (getattr(item.obj, 'compare', None) is None) != compare:
+            items.remove(item)
+
+
+def pytest_terminal_summary(terminalreporter):
+    reports = terminalreporter.getreports('passed')
+    if not reports or terminalreporter.config.getvalue('compare') is None:
+        return
+    terminalreporter.write_sep("=", "PASSED")
+    for rep in reports:
+        for name, content in rep.sections:
+            terminalreporter.writer.sep("-", name)
+            terminalreporter.writer.line(content)

--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -123,8 +123,8 @@ def analytics(request):
 @pytest.fixture
 def analytics_data(request):
     paths = request.config.getvalue('compare')
-    function_name = re.sub(
-        '^test_[a-zA-Z0-9]*_', 'test_', request.function.__name__, count=1)
+    function_name = parametrize_function_name(request, re.sub(
+        '^test_[a-zA-Z0-9]*_', 'test_', request.function.__name__, count=1))
     return [Analytics.load(
         p, request.module.__name__, function_name) for p in paths]
 

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -114,6 +114,15 @@ class Analytics(Recorder):
         self.data = {}
         self.doc = {}
 
+    @staticmethod
+    def load(path, module, function_name):
+        modparts = module.split('.')
+        modparts = modparts[1:]
+        modparts.remove('tests')
+
+        return np.load(os.path.join(path, "%s.%s.npz" % (
+            '.'.join(modparts), function_name)))
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
This is a follow-up PR to #647.

It allows to mark test functions with `pytest.mark.compare` and indicates that the function will compare the data from two test runs producing analytics data. A test marked with `compare` will not run per default. Actually, it will be pruned from the collected tests and does not influence the success/skipped/failure statistics.

To run the comparison tests one has to pass `--compare [old-data] [new-data]` to `py.test`. This will prune all normal tests and only collect the comparison tests.

## How to write a comparison test

1. Mark it with `pytest.mark.compare`.
2. Name it `test_compare_<testname>` given that `test_<testname>` produced the relevant data. This naming scheme is necessary to automatically load the relevant analytics data. It would be possible to add the mark based on the test name, but maybe that's too much magic. It would also be possible to get rid of the `test_` prefix (but again it would be a bit more magic).
3. Add the `analytics_data` fixture as function argument. It will be a two element sequence with the same order as the arguments to `--compare`. By conventions the first one should be the older data.
4. Print some useful information (e.g., "X got Y% more accurate.").
5. Do an `assert` whether the metric improved. That way a failure will be reported when something got worse.

All output to stdout and stderr will also be shown for successful tests as there might be useful information (like by how much something got better).

I'll prepare another PR demonstrating such a comparison test.