### PR TITLE
Added min_voltage parameter to nengo.LIF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Release History
 2.1.0 (unreleased)
 ==================
 
+**API changes**
+
+- Spiking ``LIF`` neuron models now accept an additional argument,
+  ``min_voltage``. Voltages are clipped such that they do not drop below
+  this value (previously, this was fixed at 0).
+  (`#666 <https://github.com/nengo/nengo/pull/666>`_)
+
 **Behavioural changes**
 
 - The ``probeable`` attribute of all Nengo objects is now implemented

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -223,14 +223,19 @@ class LIFRate(NeuronType):
 class LIF(LIFRate):
     """Spiking version of the leaky integrate-and-fire (LIF) neuron model."""
 
+    min_voltage = NumberParam(high=0)
     probeable = ['spikes', 'voltage', 'refractory_time']
+
+    def __init__(self, tau_rc=0.02, tau_ref=0.002, min_voltage=0):
+        super(LIF, self).__init__(tau_rc=tau_rc, tau_ref=tau_ref)
+        self.min_voltage = min_voltage
 
     def step_math(self, dt, J, spiked, voltage, refractory_time):
 
         # update voltage using accurate exponential integration scheme
         dV = -np.expm1(-dt / self.tau_rc) * (J - voltage)
         voltage += dV
-        voltage[voltage < 0] = 0  # clip values below zero
+        voltage[voltage < self.min_voltage] = self.min_voltage
 
         # update refractory period assuming no spikes for now
         refractory_time -= dt


### PR DESCRIPTION
This is needed for one version of the adaptive LIF neuron.  As mentioned https://github.com/nengo/nengo/pull/644#commitcomment-9593615 it was felt that having a parameter like this might also be useful for hyperpolarizing neurons too.