### PR TITLE
Improved probing of Connection transform and decoders

### DIFF
--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -33,10 +33,8 @@ def synapse_probe(model, key, probe):
         raise ValueError("Attribute '%s' is not probable on %s."
                          % (key, probe.obj))
 
-    if isinstance(probe.slice, slice):
+    if probe.slice is not None:
         sig = sig[probe.slice]
-    else:
-        raise NotImplementedError("Indexing slices not implemented")
 
     if probe.synapse is None:
         model.sig[probe]['in'] = sig

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -7,7 +7,7 @@ from nengo.ensemble import Ensemble
 from nengo.learning_rules import LearningRuleType, LearningRuleTypeParam
 from nengo.node import Node
 from nengo.params import (Default, BoolParam, DistributionParam, FunctionParam,
-                          IntParam, ListParam, NdarrayParam)
+                          IntParam, NdarrayParam)
 from nengo.solvers import LstsqL2, SolverParam
 from nengo.synapses import Lowpass, SynapseParam
 from nengo.utils.compat import is_iterable, iteritems
@@ -229,7 +229,6 @@ class Connection(NengoObject):
         default=None, optional=True, sample_shape=('*', 'size_in'))
     scale_eval_points = BoolParam(default=True)
     seed = IntParam(default=None, optional=True)
-    probeable = ListParam(default=['output', 'input', 'transform', 'decoders'])
 
     def __init__(self, pre, post, synapse=Default, transform=Default,
                  solver=Default, learning_rule_type=Default, function=Default,
@@ -238,7 +237,6 @@ class Connection(NengoObject):
         self.pre = pre
         self.post = post
 
-        self.probeable = Default
         self.solver = solver  # Must be set before learning rule
         self.learning_rule_type = learning_rule_type
         self.modulatory = modulatory
@@ -255,6 +253,14 @@ class Connection(NengoObject):
     @function.setter
     def function(self, function):
         self.function_info = function
+
+    @property
+    def probeable(self):
+        probeables = ["output", "input", "transform"]
+        if isinstance(self.pre, Ensemble):
+            probeables += ["decoders"]
+
+        return probeables
 
     @property
     def pre_obj(self):

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -2,7 +2,7 @@ from nengo.base import NengoObject, ObjView
 from nengo.dists import Uniform, UniformHypersphere
 from nengo.neurons import LIF, NeuronTypeParam, Direct
 from nengo.params import (
-    Default, DistributionParam, IntParam, ListParam, NumberParam,
+    Default, DistributionParam, IntParam, NumberParam,
     StochasticProcessParam, StringParam)
 
 
@@ -72,7 +72,6 @@ class Ensemble(NengoObject):
     noise = StochasticProcessParam(default=None, optional=True)
     seed = IntParam(default=None, optional=True)
     label = StringParam(default=None, optional=True)
-    probeable = ListParam(default=['decoded_output', 'input'])
 
     def __init__(self, n_neurons, dimensions, radius=Default, encoders=Default,
                  intercepts=Default, max_rates=Default, eval_points=Default,
@@ -93,7 +92,6 @@ class Ensemble(NengoObject):
         self.neuron_type = neuron_type
         self.noise = noise
         self.seed = seed
-        self.probeable = Default
         self._neurons = Neurons(self)
 
     def __getitem__(self, key):
@@ -109,6 +107,10 @@ class Ensemble(NengoObject):
     @neurons.setter
     def neurons(self, dummy):
         raise AttributeError("neurons cannot be overwritten.")
+
+    @property
+    def probeable(self):
+        return ["decoded_output", "input"]
 
     @property
     def size_in(self):

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import nengo.utils.numpy as npext
 from nengo.base import NengoObject, ObjView
-from nengo.params import Default, IntParam, ListParam, Parameter, StringParam
+from nengo.params import Default, IntParam, Parameter, StringParam
 from nengo.utils.stdlib import checked_call
 
 
@@ -113,7 +113,6 @@ class Node(NengoObject):
     size_in = IntParam(default=0, low=0)
     size_out = IntParam(default=None, low=0, optional=True)
     label = StringParam(default=None, optional=True)
-    probeable = ListParam(default=['output'])
 
     def __init__(self, output=Default,
                  size_in=Default, size_out=Default, label=Default):
@@ -121,10 +120,13 @@ class Node(NengoObject):
         self.size_out = size_out
         self.label = label
         self.output = output  # Must be set after size_out; may modify size_out
-        self.probeable = Default
 
     def __getitem__(self, key):
         return ObjView(self, key)
 
     def __len__(self):
         return self.size_out
+
+    @property
+    def probeable(self):
+        return ['output']

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -141,13 +141,6 @@ class StringParam(Parameter):
         super(StringParam, self).validate(instance, string)
 
 
-class ListParam(Parameter):
-    def validate(self, instance, lst):
-        if lst is not None and not isinstance(lst, list):
-            raise ValueError("Must be a list; got '%s'" % str(lst))
-        super(ListParam, self).validate(instance, lst)
-
-
 class DictParam(Parameter):
     def validate(self, instance, dct):
         if dct is not None and not isinstance(dct, dict):

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -105,7 +105,7 @@ class Probe(NengoObject):
     @property
     def slice(self):
         return (self.target.slice if isinstance(self.target, ObjView) else
-                slice(None))
+                None)
 
     @property
     def size_in(self):

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -164,24 +164,6 @@ def test_stringparam():
         inst.sp = 1
 
 
-def test_listparam():
-    """ListParams must be lists."""
-    class Test(object):
-        lp = params.ListParam(default=[1])
-
-    inst1 = Test()
-    assert inst1.lp == [1]
-    inst1.lp.append(2)
-
-    # The default list is mutable -- other instances will get the same list
-    inst2 = Test()
-    assert len(inst2.lp) == 2
-
-    # Non-lists no good
-    with pytest.raises(ValueError):
-        inst2.lp = (1, 2)
-
-
 def test_dictparam():
     """DictParams must be dictionaries."""
     class Test(object):


### PR DESCRIPTION
Fix for #665 and #667 

The only substantive change this makes is that `probeable` is no longer a `Parameter`.  And I think the only real difference that makes is that you can't use the config system to adjust it.  But I think it was always a bit weird to have `probeable` be a parameter like that.  It's really an internal variable, not a model parameter, and I don't think there's any good reason why the user would want to configure it.  I would actually be in favour of changing all the other `probeable` lists to be the same, but I didn't put that in here.