### PR TITLE
Fix recent IPython and Matplotlib issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
     - NUMPY="1.9"
     - SETUP_CMD="test -a 'nengo -n 2 -v'"
     - EXTRA_CMD=""
-    - CONDA_DEPS="matplotlib ipython-notebook pytest"
-    - PIP_DEPS="pytest-xdist"
+    - CONDA_DEPS="matplotlib ipython-notebook pygments pytest"
+    - PIP_DEPS="mistune pytest-xdist"
 
 matrix:
   include:

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -416,7 +416,7 @@ def test_slicing(Simulator, nl, plt, seed):
     t = sim.trange()
 
     for i, [y, p] in enumerate(zip(ys, probes)):
-        plt.subplot(len(ys), 1, i)
+        plt.subplot(len(ys), 1, i + 1)
         plt.plot(t, np.tile(y, (len(t), 1)), '--')
         plt.plot(t, sim.data[p])
 

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -60,13 +60,18 @@ def test_nooutput(nb_path):
     pytest.importorskip("IPython", minversion="1.0")
     pytest.importorskip("jinja2")
     from nengo.utils.ipython import load_notebook
-    nb = load_notebook(nb_path)
 
-    for ws in nb.worksheets:
-        for cell in ws.cells:
+    def check_all(cells):
+        for cell in cells:
             if cell.cell_type == 'code':
-                assert cell.outputs == [], (
-                    "Clear all cell outputs in " + nb_path)
+                assert cell.outputs == [], ("Clear outputs in %s" % nb_path)
+
+    nb = load_notebook(nb_path)
+    if nb.nbformat <= 3:
+        for ws in nb.worksheets:
+            check_all(ws.cells)
+    else:
+        check_all(nb.cells)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recent versions of IPython and Matplotlib cause our test to fail. This fixes them.

Details:

- IPython 3.0 ups the notebook format from 3 to 4. A few things need to be aware of this change; cb1eadff789ab32681f5bbb74e74e91dba7c2721 should work on all version of IPython>=1.2.1
- Matplotlib 1.5 (not yet released) will disallow making subplots with index 0. This has been deprecated for a while; apparently this was always bad as something like `plt.subplot(2, 1, 0)` would give you the second subplot, not the first, as you might have expected. In 1.5, if you do `plt.subplot(2, 1, 0)` you get a straight-up error.