### PR TITLE
Automatically prepend network labels to object labels

### DIFF
--- a/nengo/base.py
+++ b/nengo/base.py
@@ -24,7 +24,7 @@ class NetworkMember(type):
         inst.__init__(*args, **kwargs)
         if add_to_container:
             Network.add(inst)
-        inst._initialized = True  # value doesn't matter, just existance
+        inst._initialized = True  # value doesn't matter, just existence
         return inst
 
 

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -144,7 +144,7 @@ class Connection(NengoObject):
     But, we could create either of these two connections.
 
         nengo.Connection(node[0], ensemble)
-        nengo.Connection(ndoe[1], ensemble)
+        nengo.Connection(node[1], ensemble)
 
     Parameters
     ----------

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -111,6 +111,12 @@ class Network(object):
         if not isinstance(network, Network):
             raise RuntimeError("Current context is not a network: %s" %
                                network)
+
+        if (len(Network.context) > 1 and
+                hasattr(obj, 'label') and obj.label is not None and
+                network.label is not None):
+            obj.label = network.label + "_" + obj.label
+
         for cls in obj.__class__.__mro__:
             if cls in network.objects:
                 network.objects[cls].append(obj)

--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -54,8 +54,6 @@ class EnsembleArray(nengo.Network):
 
         self.config[nengo.Ensemble].update(ens_kwargs)
 
-        label_prefix = "" if label is None else label + "_"
-
         self.n_neurons = n_neurons
         self.n_ensembles = n_ensembles
         self.dimensions_per_ensemble = ens_dimensions
@@ -73,8 +71,7 @@ class EnsembleArray(nengo.Network):
 
             for i in range(n_ensembles):
                 e = nengo.Ensemble(
-                    n_neurons, self.dimensions_per_ensemble,
-                    label=label_prefix + str(i))
+                    n_neurons, self.dimensions_per_ensemble, label=str(i))
 
                 nengo.Connection(self.input[i * ens_dimensions:
                                             (i + 1) * ens_dimensions],


### PR DESCRIPTION
I found I was adding this boilerplate to every network I was creating, so I thought perhaps others were too and it was worth automating.  All it does is prepend the network label (if it exists) to the object label (if it exists).  So object "a" in network "A" gets labeled "A_a".

I made it so it doesn't apply to the top-level network, because it isn't really useful to add the same prefix to every object in the model.  This way you just get different prefixes for the different subnetworks.

I considered adding a flag to turn this on and off, but decided against it.  You know I'm always on my crusade to reduce the number of parameters, and I think in this case we can avoid it.  a) This only affects labels, which don't really matter. b) I think people will want it enabled almost all the time. c) It can kind of be disabled, by setting the network or object label to `None`.  So the only user that isn't satisfied is someone who wants a label for their subnetwork, wants a label for their object in that subnetwork, but really doesn't want the object label to indicate the subnetwork.  

Also snuck in a few typo fixes :neckbeard:.


Examples:
```python
with nengo.Network(label="net1"):
    a = nengo.Ensemble(10, 1, label="a")
    print a.label # a

    with nengo.Network(label="net2"):
        b = nengo.Ensemble(10, 1, label="b")
        print b.label # net2_b

        with nengo.Network(label="sub2"):
            c_0 = nengo.Ensemble(10, 1, label="c0")
            print c_0.label # net2_sub2_c0

        with nengo.Network():
            c_1 = nengo.Ensemble(10, 1, label="c1")
            print c_1.label # c1

    with nengo.Network():
        d = nengo.Ensemble(10, 1, label="d")
        print d.label # d

    ea = nengo.networks.EnsembleArray(5, 1, label="array")
    print ea.output.label # array_output
    print ea.ensembles[0].label # array_0
```