### PR TITLE
Comparison tests for analytics data.

### DIFF
--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -117,6 +117,15 @@ class Analytics(Recorder):
         self.data = {}
         self.doc = {}
 
+    @staticmethod
+    def load(path, module, function_name):
+        modparts = module.split('.')
+        modparts = modparts[1:]
+        modparts.remove('tests')
+
+        return np.load(os.path.join(path, "%s.%s.npz" % (
+            '.'.join(modparts), function_name)))
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
Github does not allow to change the branch a PR is made against. Had to close #657 and reopen a new PR. Copied the description, but not the comments.

--------------------------------------

This is a follow-up PR to #647.

It allows to mark test functions with `pytest.mark.compare` and indicates that the function will compare the data from two test runs producing analytics data. A test marked with `compare` will not run per default. Actually, it will be pruned from the collected tests and does not influence the success/skipped/failure statistics.

To run the comparison tests one has to pass `--compare [old-data] [new-data]` to `py.test`. This will prune all normal tests and only collect the comparison tests.

## How to write a comparison test

1. Mark it with `pytest.mark.compare`.
2. Name it `test_compare_<testname>` given that `test_<testname>` produced the relevant data. This naming scheme is necessary to automatically load the relevant analytics data. It would be possible to add the mark based on the test name, but maybe that's too much magic. It would also be possible to get rid of the `test_` prefix (but again it would be a bit more magic).
3. Add the `analytics_data` fixture as function argument. It will be a two element sequence with the same order as the arguments to `--compare`. By conventions the first one should be the older data.
4. Print some useful information (e.g., "X got Y% more accurate.").
5. Do an `assert` whether the metric improved. That way a failure will be reported when something got worse.

All output to stdout and stderr will also be shown for successful tests as there might be useful information (like by how much something got better).

I'll prepare another PR demonstrating such a comparison test.