### PR TITLE
Error on attempted pickling of Nengo objects

### DIFF
--- a/nengo/base.py
+++ b/nengo/base.py
@@ -68,6 +68,12 @@ class NengoObject(with_metaclass(NetworkMember)):
             e.args = (arg0,) + e.args[1:]
             raise
 
+    def __getstate__(self):
+        raise NotImplementedError("Nengo objects do not support pickling")
+
+    def __setstate__(self, state):
+        raise NotImplementedError("Nengo objects do not support pickling")
+
     @classmethod
     def param_list(cls):
         """Returns a list of parameter names that can be set."""
@@ -113,6 +119,12 @@ class ObjView(object):
         if self.size_in is None and self.size_out is None:
             raise IndexError("Invalid slice '%s' of %s"
                              % (self.slice, self.obj))
+
+    def __getstate__(self):
+        raise NotImplementedError("Nengo objects do not support pickling")
+
+    def __setstate__(self, state):
+        raise NotImplementedError("Nengo objects do not support pickling")
 
     def __len__(self):
         return self.size_out

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -94,6 +94,12 @@ class Network(object):
         if add_to_container:
             Network.add(self)
 
+    def __getstate__(self):
+        raise NotImplementedError("Nengo Networks do not support pickling")
+
+    def __setstate__(self, state):
+        raise NotImplementedError("Nengo Networks do not support pickling")
+
     @staticmethod
     def default_config():
         """Constructs a Config object for setting Nengo object defaults."""

--- a/nengo/tests/test_base.py
+++ b/nengo/tests/test_base.py
@@ -1,3 +1,6 @@
+import pickle
+import tempfile
+
 import pytest
 
 import nengo
@@ -45,6 +48,17 @@ def test_nengoobjectparam_nonzero():
 
         inst.nin = nout
         inst.nout = nin
+
+
+def test_pickle():
+    with nengo.Network():
+        a = nengo.Ensemble(10, 3)
+
+    with tempfile.TemporaryFile() as f:
+        with pytest.raises(NotImplementedError):
+            pickle.dump(a, f)
+        with pytest.raises(NotImplementedError):
+            pickle.dump(a[:2], f)
 
 
 if __name__ == "__main__":

--- a/nengo/tests/test_network.py
+++ b/nengo/tests/test_network.py
@@ -1,3 +1,6 @@
+import pickle
+import tempfile
+
 import pytest
 
 import nengo
@@ -122,6 +125,16 @@ def test_get_objects(Simulator):
     assert Counter([subnet, subnet2]) == Counter(model.all_networks)
     # Make sure it works a second time
     assert Counter([ens1, ens2, ens3]) == Counter(model.all_ensembles)
+
+
+def test_pickle():
+    with nengo.Network() as model:
+        nengo.Ensemble(10, 1)
+
+    with tempfile.TemporaryFile() as f:
+        with pytest.raises(NotImplementedError):
+            pickle.dump(model, f)
+
 
 if __name__ == '__main__':
     nengo.log(debug=True)


### PR DESCRIPTION
Fixes #674. We now throw an error when trying to pickle a Network,
since the default unpickling doesn't work.

I also added errors for NengoObjects and ObjViews, since we haven't
tested pickling with them, so we might as well not allow it, rather
than allowing something that may break.