### PR TITLE
Add `logger` fixture for saving test logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *~
 *.bak
 *.swp
+nengo.simulator.logs/
 nengo.simulator.analytics/
 nengo.simulator.plots/
 log.txt

--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -50,19 +50,19 @@ def build_network(model, network):
         for obj in network.objects[obj_type]:
             model.seeds[obj] = get_seed(obj, rng)
 
-    logger.info("Network step 1: Building ensembles and nodes")
+    logger.debug("Network step 1: Building ensembles and nodes")
     for obj in network.ensembles + network.nodes:
         model.build(obj)
 
-    logger.info("Network step 2: Building subnetworks")
+    logger.debug("Network step 2: Building subnetworks")
     for subnetwork in network.networks:
         model.build(subnetwork)
 
-    logger.info("Network step 3: Building connections")
+    logger.debug("Network step 3: Building connections")
     for conn in network.connections:
         model.build(conn)
 
-    logger.info("Network step 4: Building learning rules")
+    logger.debug("Network step 4: Building learning rules")
     for conn in network.connections:
         rule = conn.learning_rule
         if is_iterable(rule):
@@ -71,7 +71,7 @@ def build_network(model, network):
         elif rule is not None:
             model.build(rule)
 
-    logger.info("Network step 5: Building probes")
+    logger.debug("Network step 5: Building probes")
     for probe in network.probes:
         model.build(probe)
 

--- a/nengo/networks/tests/test_actionselection.py
+++ b/nengo/networks/tests/test_actionselection.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import nengo
 
@@ -48,8 +47,3 @@ def test_thalamus(Simulator, plt, seed):
 
     assert output[0] > 0.8
     assert np.all(output[1:] < 0.01)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/networks/tests/test_circularconv.py
+++ b/nengo/networks/tests/test_circularconv.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 import pytest
 
@@ -7,8 +5,6 @@ import nengo
 from nengo.networks.circularconvolution import (
     circconv, transform_in, transform_out)
 from nengo.utils.numpy import rmse
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('invert_a', [True, False])
@@ -90,8 +86,3 @@ def test_neural_accuracy(Simulator, seed, rng, dims, neurons_per_product=128):
     error = rmse(result, sim.data[res_p][-1])
 
     assert error < 0.1
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/networks/tests/test_ensemblearray.py
+++ b/nengo/networks/tests/test_ensemblearray.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 import pytest
 
@@ -7,8 +5,6 @@ import nengo
 from nengo.dists import Choice
 from nengo.utils.compat import range
 from nengo.utils.testing import WarningCatcher
-
-logger = logging.getLogger(__name__)
 
 
 def test_multidim(Simulator, plt, seed, rng):
@@ -230,8 +226,3 @@ def test_neuronconnection(Simulator, nl, seed):
                 catcher.record[0].category is UserWarning)
     else:
         assert len(catcher.record) == 0
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/networks/tests/test_integrator.py
+++ b/nengo/networks/tests/test_integrator.py
@@ -1,12 +1,6 @@
-import logging
-
-import pytest
-
 import nengo
 from nengo.utils.functions import piecewise
 from nengo.utils.numpy import rmse
-
-logger = logging.getLogger(__name__)
 
 
 def test_integrator(Simulator, plt, seed):
@@ -37,8 +31,3 @@ def test_integrator(Simulator, plt, seed):
     plt.legend(loc='best')
 
     assert rmse(sim.data[A_p], sim.data[T_p]) < 0.1
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/networks/tests/test_oscillator.py
+++ b/nengo/networks/tests/test_oscillator.py
@@ -1,13 +1,6 @@
-import logging
-
-import pytest
-
 import nengo
 from nengo.utils.functions import piecewise
 from nengo.utils.numpy import rmse
-
-
-logger = logging.getLogger(__name__)
 
 
 def test_oscillator(Simulator, plt, seed):
@@ -40,8 +33,3 @@ def test_oscillator(Simulator, plt, seed):
     plt.legend(loc='best')
 
     assert rmse(sim.data[A_probe], sim.data[T_probe]) < 0.2
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/networks/tests/test_product.py
+++ b/nengo/networks/tests/test_product.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import nengo
 from nengo.utils.compat import range
@@ -36,8 +35,3 @@ def test_sine_waves(Simulator, plt, seed):
     plt.xlim(right=t[-1])
 
     assert rmse(AB[:len(offset), :], sim.data[p][offset, :]) < 0.2
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/networks/tests/test_workingmemory.py
+++ b/nengo/networks/tests/test_workingmemory.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import nengo
 from nengo.utils.functions import piecewise
@@ -36,8 +35,3 @@ def test_inputgatedmemory(Simulator, plt, seed):
     assert abs(np.mean(data[t < 0.1])) < 0.01
     assert abs(np.mean(data[(t > 0.2) & (t <= 0.4)]) - 0.5) < 0.02
     assert abs(np.mean(data[t > 0.4]) - 0.5) < 0.02
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_action_objects.py
+++ b/nengo/spa/tests/test_action_objects.py
@@ -1,6 +1,5 @@
 import pytest
 
-import nengo
 from nengo.spa.action_objects import Symbol, Source, DotProduct
 
 A = Symbol('A')
@@ -239,8 +238,3 @@ def test_vector_list():
 
     assert str(-xy) == '-1 * x + -1 * y'
     assert str(-(-xy)) == 'x + y'
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_actions.py
+++ b/nengo/spa/tests/test_actions.py
@@ -1,6 +1,5 @@
 import pytest
 
-import nengo
 from nengo import spa
 from nengo.spa.actions import Expression, Effect, Action, Actions
 
@@ -122,8 +121,3 @@ def test_actions():
     assert str(a.actions[1].effect) == 'state=A'
     assert str(a.actions[2].condition) == '1.0'
     assert str(a.actions[2].effect) == 'state=C'
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_assoc_mem.py
+++ b/nengo/spa/tests/test_assoc_mem.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import nengo
 from nengo.spa import Vocabulary
@@ -243,8 +242,3 @@ def test_am_spa_interaction(Simulator, seed, rng):
 
     # Check to see if model builds properly. No functionality test needed
     Simulator(m)
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_basalganglia.py
+++ b/nengo/spa/tests/test_basalganglia.py
@@ -79,8 +79,3 @@ def test_errors():
             model.motor = spa.Buffer(dimensions=16)
             actions = spa.Actions('scalar --> motor=A')
             model.bg = spa.BasalGanglia(actions)
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_buffer.py
+++ b/nengo/spa/tests/test_buffer.py
@@ -70,8 +70,3 @@ def test_run(Simulator, seed):
     assert data[400, 1] > 0.9
     assert data[499, 0] < 0.2
     assert data[499, 1] < 0.2
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_compare.py
+++ b/nengo/spa/tests/test_compare.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import nengo
 from nengo import spa
@@ -44,8 +43,3 @@ def test_run(Simulator, seed):
 
     assert data[100] > 0.8
     assert data[199] < 0.2
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_cortical.py
+++ b/nengo/spa/tests/test_cortical.py
@@ -185,8 +185,3 @@ def test_convolution(Simulator, plt, seed):
     # Ideal answer: ~A*~B = [0,0,1,0,0]
     assert np.allclose(np.mean(sim.data[pAinvBinv][-10:], axis=0),
                        np.array([0, 0, 1, 0, 0]), atol=0.15)
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_input.py
+++ b/nengo/spa/tests/test_input.py
@@ -1,7 +1,5 @@
 import numpy as np
-import pytest
 
-import nengo
 from nengo import spa
 
 
@@ -87,7 +85,3 @@ def test_predefined_vocabs():
     assert np.dot(a1, a2) < 0.95
     assert np.dot(b1, b2) < 0.95
     assert np.dot(c1, c2) < 0.95
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_memory.py
+++ b/nengo/spa/tests/test_memory.py
@@ -100,8 +100,3 @@ def test_run_decay(Simulator, plt, seed):
 
     assert data[t == 0.05, 0] > 1.0
     assert data[t == 0.299, 0] < 0.4
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_pointer.py
+++ b/nengo/spa/tests/test_pointer.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import nengo
 from nengo.spa.pointer import SemanticPointer
 from nengo.utils.compat import range
 
@@ -186,8 +185,3 @@ def test_conv_matrix():
     m = b.get_convolution_matrix()
 
     assert np.allclose((a*b).v, np.dot(m, a.v))
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_thalamus.py
+++ b/nengo/spa/tests/test_thalamus.py
@@ -142,8 +142,3 @@ def test_errors():
             actions = spa.Actions('0.5 --> scalar=dot(scalar, FOO)')
             model.bg = spa.BasalGanglia(actions)
             model.thalamus = spa.Thalamus(model.bg)
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/spa/tests/test_vocabulary.py
+++ b/nengo/spa/tests/test_vocabulary.py
@@ -3,7 +3,6 @@ import re
 import numpy as np
 import pytest
 
-import nengo
 from nengo.spa import Vocabulary
 
 
@@ -128,8 +127,3 @@ def test_prob_cleanup():
     assert 0.999 > v.prob_cleanup(0.4, 1000) > 0.997
     assert 0.99 > v.prob_cleanup(0.4, 10000) > 0.97
     assert 0.9 > v.prob_cleanup(0.4, 100000) > 0.8
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -11,7 +11,7 @@ from nengo.neurons import Direct, LIF, LIFRate, RectifiedLinear, Sigmoid
 from nengo.rc import rc
 from nengo.simulator import Simulator as ReferenceSimulator
 from nengo.utils.compat import ensure_bytes, is_string
-from nengo.utils.testing import Analytics, Plotter
+from nengo.utils.testing import Analytics, Logger, Plotter
 
 test_seed = 0  # changing this will change seeds for all tests
 
@@ -119,6 +119,23 @@ def analytics(request):
     return analytics.__enter__()
 
 
+@pytest.fixture
+def logger(request):
+    """a logging.Logger object.
+
+    Please use this if your test emits log messages.
+
+    This will keep saved logs organized in a simulator-specific folder,
+    with an automatically generated name.
+    """
+    dirname = recorder_dirname(request, 'logs')
+    logger = Logger(
+        dirname, request.module.__name__,
+        parametrize_function_name(request, request.function.__name__))
+    request.addfinalizer(lambda: logger.__exit__(None, None, None))
+    return logger.__enter__()
+
+
 def function_seed(function, mod=0):
     c = function.__code__
 
@@ -170,6 +187,9 @@ def pytest_addoption(parser):
     parser.addoption(
         '--analytics', nargs='?', default=False, const=True,
         help='Save analytics (can optionally specify a directory for data).')
+    parser.addoption(
+        '--logs', nargs='?', default=False, const=True,
+        help='Save logs (can optionally specify a directory for logs).')
     parser.addoption('--noexamples', action='store_false', default=True,
                      help='Do not run examples')
     parser.addoption(
@@ -189,7 +209,8 @@ def pytest_runtest_setup(item):
         skipreasons = []
         for fixture_name, option, message in [
                 ('analytics', 'analytics', "analytics not requested"),
-                ('plt', 'plots', "plots not requested")]:
+                ('plt', 'plots', "plots not requested"),
+                ('logger', 'logs', "logs not requested")]:
             if fixture_name in item.fixturenames:
                 if item.config.getvalue(option):
                     skip = False

--- a/nengo/tests/test_base.py
+++ b/nengo/tests/test_base.py
@@ -59,8 +59,3 @@ def test_pickle():
             pickle.dump(a, f)
         with pytest.raises(NotImplementedError):
             pickle.dump(a[:2], f)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -223,7 +223,3 @@ def test_signal_reshape():
     assert three_d.reshape((-1, 4)).shape == (2, 4)
     assert three_d.reshape((2, -1, 2)).shape == (2, 2, 2)
     assert three_d.reshape((1, 2, 1, 2, 2, 1)).shape == (1, 2, 1, 2, 2, 1)
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -284,8 +284,3 @@ def test_cache_performance(tmpdir, Simulator, seed):
 
     assert calc_relative_timer_diff(t_no_cache, t_cache_miss) < 0.1
     assert calc_relative_timer_diff(t_cache_hit, t_no_cache) > 0.4
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -185,8 +185,3 @@ def test_instance_fallthrough():
     assert config[A].amount == 1
     assert config[inst1].amount == 2
     assert config[inst2].amount == 1
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 import pytest
 
@@ -10,8 +8,6 @@ from nengo.dists import UniformHypersphere
 from nengo.solvers import LstsqL2
 from nengo.utils.functions import piecewise
 from nengo.utils.testing import allclose
-
-logger = logging.getLogger(__name__)
 
 
 def test_args(nl, seed, rng):
@@ -724,8 +720,3 @@ def test_transform_probe(Simulator):
         nengo.Probe(c_ens, "transform")
         nengo.Probe(c_ens_neurons, "transform")
     assert Simulator(net)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import nengo
 import nengo.dists as dists
 import nengo.utils.numpy as npext
 
@@ -119,8 +118,3 @@ def test_sqrt_beta(n, m):
     hist, _ = np.histogram(samples, bins=num_bins)
 
     assert np.all(np.abs(np.asfarray(hist - expectation) / num_samples) < 0.16)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 import pytest
 
@@ -8,8 +6,6 @@ import nengo.utils.numpy as npext
 from nengo.dists import Choice, UniformHypersphere
 from nengo.processes import StochasticProcess
 from nengo.utils.testing import warns, allclose
-
-logger = logging.getLogger(__name__)
 
 
 def test_missing_attribute():
@@ -372,8 +368,3 @@ def test_noise_copies_ok(Simulator, nl_nodirect, seed, plt):
 
     assert np.allclose(sim.data[ap], sim.data[bp])
     assert np.allclose(sim.data[bp], sim.data[cp])
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -17,7 +17,8 @@ _pytest.capture.DontReadFromInput.write = lambda: None
 _pytest.capture.DontReadFromInput.flush = lambda: None
 
 
-all_examples = set([os.path.splitext(f)[0] for f in os.listdir(examples_dir)])
+all_examples = set([os.path.splitext(f)[0] for f in os.listdir(examples_dir)
+                    if f.endswith('.ipynb')])
 slow_examples = set(['inhibitory_gating',
                      'izhikevich',
                      'learn_communication_channel',
@@ -88,7 +89,3 @@ def test_nooutput(nb_file):
             check_all(ws.cells)
     else:
         check_all(nb.cells)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -327,8 +327,3 @@ def test_learningrule_attr(seed):
         assert set(c3.learning_rule) == set(r3)  # assert same keys
         for key in r3:
             check_rule(c3.learning_rule[key], c3, r3[key])
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_network.py
+++ b/nengo/tests/test_network.py
@@ -134,8 +134,3 @@ def test_pickle():
     with tempfile.TemporaryFile() as f:
         with pytest.raises(NotImplementedError):
             pickle.dump(model, f)
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 import pytest
 
@@ -10,8 +9,6 @@ from nengo.utils.ensemble import tuning_curves
 from nengo.utils.matplotlib import implot, rasterplot
 from nengo.utils.neurons import rates_kernel
 from nengo.utils.numpy import rms, rmse
-
-logger = logging.getLogger(__name__)
 
 
 def test_lif_builtin(rng):
@@ -39,7 +36,7 @@ def test_lif_builtin(rng):
     assert np.allclose(sim_rates, math_rates, atol=1, rtol=0.02)
 
 
-def test_lif(Simulator, plt, rng):
+def test_lif(Simulator, plt, rng, logger):
     """Test that the dynamic model approximately matches the rates"""
     dt = 0.001
     n = 5000
@@ -78,9 +75,9 @@ def test_lif(Simulator, plt, rng):
         x, *ens.neuron_type.gain_bias(max_rates, intercepts))
     spikes = sim.data[spike_probe]
     sim_rates = (spikes > 0).sum(0) / t_final
-    logger.debug("ME = %f", (sim_rates - math_rates).mean())
-    logger.debug("RMSE = %f",
-                 rms(sim_rates - math_rates) / (rms(math_rates) + 1e-20))
+    logger.info("ME = %f", (sim_rates - math_rates).mean())
+    logger.info("RMSE = %f",
+                rms(sim_rates - math_rates) / (rms(math_rates) + 1e-20))
     assert np.sum(math_rates > 0) > 0.5 * n, (
         "At least 50% of neurons must fire")
     assert np.allclose(sim_rates, math_rates, atol=1, rtol=0.02)
@@ -359,8 +356,3 @@ def test_neurontypeparam():
     assert isinstance(inst.ntp, nengo.LIF)
     with pytest.raises(ValueError):
         inst.ntp = 'a'
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -1,13 +1,8 @@
-import logging
-
 import numpy as np
 import pytest
 
 import nengo
 from nengo.utils.testing import warns
-
-
-logger = logging.getLogger(__name__)
 
 
 def test_time(Simulator):
@@ -330,8 +325,3 @@ def test_args(Simulator, plt):
 
     sim = Simulator(model)
     sim.run(0.01)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -1,14 +1,9 @@
-import logging
-
 import numpy as np
 import pytest
 
-import nengo
 from nengo import params
 from nengo.dists import UniformHypersphere
 from nengo.utils.compat import PY2
-
-logger = logging.getLogger(__name__)
 
 
 def test_default():
@@ -267,8 +262,3 @@ def test_functionparam():
     # Not OK: not a function
     with pytest.raises(ValueError):
         inst.fp = 0
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -1,13 +1,8 @@
-import logging
-
 import numpy as np
-import pytest
 
 import nengo
 from nengo.utils.compat import range
 from nengo.utils.testing import Timer
-
-logger = logging.getLogger(__name__)
 
 
 def test_multirun(Simulator, rng):
@@ -55,7 +50,7 @@ def test_dts(Simulator, seed, rng):
             dt, dt2, tend, len(t), len(x))
 
 
-def test_large(Simulator, seed):
+def test_large(Simulator, seed, logger):
     """Test with a lot of big probes. Can also be used for speed."""
 
     n = 10
@@ -75,8 +70,8 @@ def test_large(Simulator, seed):
 
     with Timer() as timer:
         sim.run(simtime)
-    logger.debug("Ran %d probes for %f sec simtime in %0.3f sec",
-                 n, simtime, timer.duration)
+    logger.info("Ran %d probes for %f sec simtime in %0.3f sec",
+                n, simtime, timer.duration)
 
     t = sim.trange()
     x = np.asarray([input_fn(ti) for ti in t])
@@ -202,8 +197,3 @@ def test_solver_defaults(Simulator):
     assert d.solver is solver2
     assert e.solver is solver1
     assert f.solver is solver3
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -162,8 +162,3 @@ def test_sampling_shape():
     assert nengo.processes.sample(1, process).shape == (1,)
     assert nengo.processes.sample(5, process, d=1).shape == (5, 1)
     assert nengo.processes.sample(1, process, d=2). shape == (1, 2)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, "-v"])

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -1,7 +1,4 @@
-import logging
-
 import numpy as np
-import pytest
 
 import nengo
 import nengo.simulator
@@ -10,9 +7,6 @@ from nengo.builder.node import build_pyfunc
 from nengo.builder.operator import Copy, Reset, DotInc, SimNoise
 from nengo.builder.signal import Signal
 from nengo.utils.compat import range
-
-
-logger = logging.getLogger(__name__)
 
 
 def test_steps(RefSimulator):
@@ -138,8 +132,3 @@ def test_noise(RefSimulator, seed):
     z = 1./np.sqrt(2 * np.pi * std**2) * np.exp(-0.5 * (x - mean)**2 / std**2)
     y = h / float(h.sum()) / dx
     assert np.allclose(y, z, atol=0.02)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, "-v"])

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -5,8 +5,6 @@ TODO:
 """
 from __future__ import print_function
 
-import logging
-
 import numpy as np
 import pytest
 
@@ -20,8 +18,6 @@ from nengo.solvers import (
     Lstsq, LstsqNoise, LstsqL2, LstsqL2nz,
     LstsqL1, LstsqDrop,
     Nnls, NnlsL2, NnlsL2nz)
-
-logger = logging.getLogger(__name__)
 
 
 def get_encoders(n_neurons, dims, rng=None):
@@ -194,7 +190,7 @@ def test_nnls(Solver, plt, rng):
 
 
 @pytest.mark.slow
-def test_subsolvers_L2(rng):
+def test_subsolvers_L2(rng, logger):
     pytest.importorskip('scipy')
 
     ref_solver = cholesky
@@ -222,7 +218,7 @@ def test_subsolvers_L2(rng):
 
 
 @pytest.mark.noassertions
-def test_subsolvers_L1(rng):
+def test_subsolvers_L1(rng, logger):
     pytest.importorskip('sklearn')
 
     A, B = get_system(m=2000, n=1000, d=10, rng=rng)
@@ -409,7 +405,7 @@ def test_eval_points_static(Simulator, plt, rng):
 
 @pytest.mark.slow
 @pytest.mark.noassertions
-def test_eval_points(Simulator, nl_nodirect, plt, seed, rng):
+def test_eval_points(Simulator, nl_nodirect, plt, seed, rng, logger):
     n = 100
     d = 5
     filter = 0.08
@@ -470,8 +466,3 @@ def test_eval_points(Simulator, nl_nodirect, plt, seed, rng):
     plt.semilogx(eval_points, low, 'b-')
     plt.xlim([eval_points[0], eval_points[-1]])
     plt.xticks(eval_points, eval_points)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 import pytest
 
@@ -8,8 +6,6 @@ from nengo.processes import WhiteNoise
 from nengo.synapses import (
     Alpha, filt, filtfilt, LinearFilter, Lowpass, SynapseParam)
 from nengo.utils.testing import allclose
-
-logger = logging.getLogger(__name__)
 
 
 def run_synapse(Simulator, seed, synapse, dt=1e-3, runtime=1., n_neurons=None):
@@ -161,8 +157,3 @@ def test_synapseparam():
     # Non-synapse not OK
     with pytest.raises(ValueError):
         inst.sp = 'a'
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -39,10 +39,19 @@ if PY2:
         assert isinstance(s, bytes)
         return s
 
+    class TextIO(StringIO):
+        def write(self, data):
+            if not isinstance(data, unicode):
+                data = unicode(data,
+                               getattr(self, '_encoding', 'UTF-8'),
+                               'replace')
+            StringIO.write(self, data)
+
 else:
     import pickle
     import configparser
     from io import StringIO
+    TextIO = StringIO
     string_types = (str,)
     int_types = (int,)
     range = range
@@ -63,7 +72,7 @@ else:
 
 assert configparser
 assert pickle
-assert StringIO
+assert TextIO
 
 
 def is_integer(obj):

--- a/nengo/utils/tests/test_builder.py
+++ b/nengo/utils/tests/test_builder.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import nengo
 from nengo.utils.builder import full_transform
@@ -100,8 +99,3 @@ def test_full_transform():
         conn = nengo.Connection(ens3, ens2[[0, 1, 0]])
         assert np.all(full_transform(conn) == np.array([[1, 0, 1],
                                                        [0, 1, 0]]))
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_builder_graphviz.py
+++ b/nengo/utils/tests/test_builder_graphviz.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import nengo
 from nengo.utils.builder import (
@@ -33,7 +32,3 @@ def test_create_dot():
         *remove_passthrough_nodes(objs, conns))
     assert len(dot.splitlines()) == 27
     # not sure what else to check here
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_builder_passthrough.py
+++ b/nengo/utils/tests/test_builder_passthrough.py
@@ -4,8 +4,7 @@ import numpy as np
 import pytest
 
 import nengo
-from nengo.utils.builder import (remove_passthrough_nodes,
-                                 objs_and_connections)
+from nengo.utils.builder import objs_and_connections, remove_passthrough_nodes
 
 
 def test_remove_passthrough():
@@ -75,8 +74,3 @@ def test_passthrough_errors():
         nengo.Connection(node, node, synapse=0.01)
     with pytest.raises(Exception):
         remove_passthrough_nodes(*objs_and_connections(model))
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_cache.py
+++ b/nengo/utils/tests/test_cache.py
@@ -1,6 +1,3 @@
-import pytest
-
-import nengo
 from nengo.utils.cache import byte_align, bytes2human, human2bytes
 
 
@@ -22,8 +19,3 @@ def test_byte_align():
     assert byte_align(13, 1) == 13
     assert byte_align(0, 16) == 0
     assert byte_align(32, 8) == 32
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_compat.py
+++ b/nengo/utils/tests/test_compat.py
@@ -1,6 +1,3 @@
-import pytest
-
-import nengo
 from nengo.utils.compat import ensure_bytes
 
 
@@ -8,8 +5,3 @@ def test_ensure_bytes():
     """Test that ensure_bytes is always the right bytes value."""
     assert ensure_bytes(u"hello") == b"hello"
     assert ensure_bytes("hello") == b"hello"
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_connection.py
+++ b/nengo/utils/tests/test_connection.py
@@ -1,13 +1,9 @@
-import logging
-
 import numpy as np
 import pytest
 
 import nengo
 from nengo.dists import UniformHypersphere
 from nengo.utils.connection import target_function
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("dimensions", [1, 4])

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -106,8 +106,3 @@ def test_response_curves_direct_mode(Simulator, plt, seed, dimensions):
     assert np.all(-1.0 <= eval_points) and np.all(eval_points <= 1.0)
     # eval_points is passed through in direct mode neurons
     assert np.allclose(eval_points, activities)
-
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_filter_design.py
+++ b/nengo/utils/tests/test_filter_design.py
@@ -1,12 +1,8 @@
-import logging
 import pytest
 
 import numpy as np
 
-import nengo
 from nengo.utils.filter_design import expm, cont2discrete
-
-logger = logging.getLogger(__name__)
 
 
 def test_expm(rng):
@@ -46,8 +42,3 @@ def test_cont2discrete_zoh(dt):
     num1, den1, _ = cont2discrete((num, den), dt)
     assert np.allclose(num0, num1)
     assert np.allclose(den0, den1)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_functions_piecewise.py
+++ b/nengo/utils/tests/test_functions_piecewise.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import nengo
 from nengo.utils.functions import piecewise
 
 
@@ -72,8 +71,3 @@ def test_function_list():
     assert np.allclose(f(0.5), func2(0.5))
     assert np.allclose(f(0.75), func2(0.75))
     assert np.allclose(f(1.0), func2(1.0))
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_graphs.py
+++ b/nengo/utils/tests/test_graphs.py
@@ -1,11 +1,4 @@
-import logging
-
-import pytest
-
-import nengo
 from nengo.utils import graphs
-
-logger = logging.getLogger(__name__)
 
 
 def test_reversedict():
@@ -23,8 +16,3 @@ def test_add_edges():
     edges = graphs.graph({'a': set(['b', 'c'])})
     graphs.add_edges(edges, [('a', 'd'), ('b', 'c')])
     assert edges == {'a': set(['b', 'c', 'd']), 'b': set(['c'])}
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_logging.py
+++ b/nengo/utils/tests/test_logging.py
@@ -1,8 +1,3 @@
-try:
-    # Reload moved to the imp module in Python 3
-    from imp import reload
-except AttributeError:
-    pass
 import logging
 
 import pytest
@@ -12,34 +7,29 @@ import nengo.utils.logging
 
 
 def test_log_to_console():
-    logging.shutdown()
-    reload(logging)
     nengo.log(debug=False, path=None)
     assert logging.root.getEffectiveLevel() == logging.WARNING
-    assert len(logging.root.handlers) == 1
-    handler = logging.root.handlers[0]
-    assert isinstance(handler, logging.StreamHandler)
-    assert handler.formatter == nengo.utils.logging.console_formatter
+    assert nengo.utils.logging.console_handler in logging.root.handlers
+    n_handlers = len(logging.root.handlers)
     nengo.log(debug=True, path=None)
     assert logging.root.getEffectiveLevel() == logging.DEBUG
-    assert len(logging.root.handlers) == 1
+    assert len(logging.root.handlers) == n_handlers
+    logging.root.handlers.remove(nengo.utils.logging.console_handler)
 
 
 def test_log_to_file(tmpdir):
-    logging.shutdown()
-    reload(logging)
     tmpfile = str(tmpdir.join("log.txt"))
     nengo.log(debug=False, path=tmpfile)
+    n_handlers = len(logging.root.handlers)
+    handler = logging.root.handlers[-1]
     assert logging.root.getEffectiveLevel() == logging.WARNING
-    assert len(logging.root.handlers) == 1
-    handler = logging.root.handlers[0]
     assert isinstance(handler, logging.FileHandler)
-    assert handler.formatter == nengo.utils.logging.file_formatter
+    assert handler.baseFilename == tmpfile
     nengo.log(debug=True, path=tmpfile)
     assert logging.root.getEffectiveLevel() == logging.DEBUG
-    assert len(logging.root.handlers) == 1
-
+    assert len(logging.root.handlers) == n_handlers
+    logging.root.handlers.remove(handler)
 
 if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])
+    import sys
+    pytest.main(sys.argv)

--- a/nengo/utils/tests/test_magic.py
+++ b/nengo/utils/tests/test_magic.py
@@ -1,12 +1,7 @@
 import inspect
-import logging
 
-import pytest
-
-import nengo
 from nengo.utils.magic import decorator, memoize
 
-logger = logging.getLogger(__name__)
 state = None  # Used to make sure decorators are running
 
 
@@ -267,8 +262,3 @@ def test_memoize():  # noqa: C901
 
     # Second run should be all hits
     check_all(inst, 1, 1)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_matplotlib.py
+++ b/nengo/utils/tests/test_matplotlib.py
@@ -1,11 +1,7 @@
-import logging
-
 import numpy as np
 import pytest
 
 import nengo
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.mark.noassertions

--- a/nengo/utils/tests/test_nco.py
+++ b/nengo/utils/tests/test_nco.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_equal
 import pytest
 
-import nengo
 import nengo.utils.nco as nco
 from nengo.utils.nco import Subfile
 
@@ -104,8 +103,3 @@ def test_nco_roundtrip(tmpdir):
 
     assert pickle_data == pickle_data2
     assert_equal(array, array2)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_network.py
+++ b/nengo/utils/tests/test_network.py
@@ -1,10 +1,4 @@
-import logging
-
-import pytest
-
 import nengo
-
-logger = logging.getLogger(__name__)
 
 
 def test_withself():
@@ -25,8 +19,3 @@ def test_withself():
             e2 = nengo.Ensemble(10, dimensions=1)
             assert e2 in ea1.ensembles
     assert len(nengo.Network.context) == 0
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_neurons.py
+++ b/nengo/utils/tests/test_neurons.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import logging
 import pytest
 
 import numpy as np
@@ -11,8 +10,6 @@ from nengo.processes import WhiteNoise
 from nengo.utils.matplotlib import implot
 from nengo.utils.neurons import rates_isi, rates_kernel
 from nengo.utils.numpy import rms
-
-logger = logging.getLogger(__name__)
 
 
 def _test_rates(Simulator, rates, plt, seed):
@@ -74,7 +71,8 @@ def test_rates_kernel(Simulator, plt, seed):
 
 
 @pytest.mark.noassertions
-def test_rates(Simulator, plt, seed):
+def test_rates(Simulator, plt, seed, logger):
+    pytest.importorskip('scipy')
     functions = [
         ('isi_zero', lambda t, s: rates_isi(
             t, s, midpoint=False, interp='zero')),
@@ -96,8 +94,3 @@ def test_rates(Simulator, plt, seed):
         logger.info('rate estimator: %s', name)
         logger.info('relative RMSE: %0.4f', rel_rmse)
     plt.saveas = None
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_numpy.py
+++ b/nengo/utils/tests/test_numpy.py
@@ -1,15 +1,8 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
-import logging
+from __future__ import absolute_import, print_function
 
 import numpy as np
-import pytest
 
-import nengo
 from nengo.utils.numpy import meshgrid_nd
-
-logger = logging.getLogger(__name__)
 
 
 def test_meshgrid_nd():
@@ -28,8 +21,3 @@ def test_meshgrid_nd():
                   [[23, 42], [23, 42], [23, 42]]])]
     actual = meshgrid_nd(a, b, c)
     assert np.allclose(expected, actual)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_probe.py
+++ b/nengo/utils/tests/test_probe.py
@@ -77,7 +77,3 @@ def test_probe_all_kwargs():
     for probe in model.probes + subnet.probes:
         assert probe.sample_every == 0.1
         assert probe.seed == 10
-
-if __name__ == '__main__':
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -1,8 +1,5 @@
 import time
 
-import pytest
-
-import nengo
 from nengo.utils.progress import (
     AutoProgressBar, UpdateEveryN, UpdateEveryT, UpdateN, Progress,
     ProgressBar, ProgressTracker)
@@ -152,8 +149,3 @@ class TestUpdateEveryT(object):
             t = 4.
             p.step()
             assert progress_bar.n_update_calls == 1
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_stdlib.py
+++ b/nengo/utils/tests/test_stdlib.py
@@ -1,12 +1,7 @@
-import logging
-
 import numpy as np
 import pytest
 
-import nengo
 from nengo.utils.stdlib import checked_call, groupby
-
-logger = logging.getLogger(__name__)
 
 
 def test_checked_call():
@@ -101,8 +96,3 @@ def test_groupby(hashable, force_list, rng):
         group = groups[keys.index(key2)]
         group2 = map(lambda x: x[1], keygroup2)
         assert sorted(group2) == sorted(group)
-
-
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])

--- a/nengo/utils/tests/test_testing.py
+++ b/nengo/utils/tests/test_testing.py
@@ -1,13 +1,9 @@
 import errno
-import logging
 import os
 
 import pytest
 
-import nengo
-from nengo.utils.testing import Analytics, Timer
-
-logger = logging.getLogger(__name__)
+from nengo.utils.testing import Analytics, Logger, Timer
 
 
 def test_timer():
@@ -59,6 +55,27 @@ def test_analytics_norecord():
         analytics.get_filepath(ext='npz')
 
 
-if __name__ == "__main__":
-    nengo.log(debug=True)
-    pytest.main([__file__, '-v'])
+def test_logger_record():
+    logger_obj = Logger('nengo.simulator.logs',
+                        'nengo.utils.tests.test_testing',
+                        'test_logger_record')
+    with logger_obj as logger:
+        logger.info("Testing that logger records")
+    path = logger_obj.get_filepath(ext='txt')
+    assert os.path.exists(path)
+    os.remove(path)
+    # This will remove the logger directory, only if it's empty
+    try:
+        os.rmdir(logger_obj.dirname)
+    except OSError as ex:
+        assert ex.errno == errno.ENOTEMPTY
+
+
+def test_logger_norecord():
+    logger_obj = Logger(None,
+                        'nengo.utils.tests.test_testing',
+                        'test_logger_norecord')
+    with logger_obj as logger:
+        logger.info("Testing that logger doesn't record")
+    with pytest.raises(ValueError):
+        logger_obj.get_filepath(ext='txt')


### PR DESCRIPTION
And a corresponding py.test `--logs` command line option. See the commit message for more details.

This is a WIP because I get some really weird test failures at unexpected times. E.g., if I run all of the unit tests, `test_rates` fails with
```
>       logging.StreamHandler.__init__(self, stream=TextIO())
E       TypeError: unbound method __init__() must be called with StreamHandler instance as first argument (got CaptureLogHandler instance instead)
```
but if I run this test individually, it runs fine. I'm investigating now, but figured I would make this PR to get opinions on the interface, and whether this is sufficient to replace what the analytics summary data was doing.