### PR TITLE
Change progress bar instantiation for IPython >= 3 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - env: >
         PYTHON="2.6"
         CONDA_DEPS="$CONDA_DEPS ordereddict pygments"
-        PIP_DEPS="$PIP_DEPS counter IPython==1.2.1"
+        PIP_DEPS="$PIP_DEPS counter importlib IPython==1.2.1"
     - env: >
         PYTHON="2.7"
         SETUP_CMD="test -a '--cov-config .coveragerc --cov nengo nengo -n 2 -v'"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,9 @@ Release History
   vector).
   (`#775 <https://github.com/nengo/nengo/issues/775>`_,
   `#782 <https://github.com/nengo/nengo/pull/782>`_)
+- The IPython notebook progress bar has to be activated with
+  ``%load_ext nengo.ipynb``.
+  (`#693 <https://github.com/nengo/nengo/pull/693>`_)
 
 **Improvements**
 
@@ -112,6 +115,9 @@ Release History
   `#791 <https://github.com/nengo/nengo/pull/791>`_)
 - The ``Product`` network is now more accurate.
   (`#651 <https://github.com/nengo/nengo/pull/651>`_)
+- Added ``[progress]`` section to ``nengorc`` which allows setting
+  ``progress_bar`` and ``updater``.
+  (`#693 <https://github.com/nengo/nengo/pull/693>`_)
 
 **Bug fixes**
 

--- a/examples/advanced/inhibitory_gating.ipynb
+++ b/examples/advanced/inhibitory_gating.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:2a37277f9d1e6bb3dbafdf237eed79a60bacf8bd4f425639d852e551e7647e46"
+  "signature": "sha256:4286a5dfc627265c6b6286f86e28f67e66b047dcf4212ef33124c79f9e8892a3"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -23,9 +23,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/advanced/izhikevich.ipynb
+++ b/examples/advanced/izhikevich.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:5cf426ddace406fb065dd715b9dcba5eeae8131a8253ea0ca26106a2ddd8927e"
+  "signature": "sha256:2d48c60d9971ad985fc33e122e73ae1f159476dce041d743c057e76025a8ca8b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -35,9 +35,11 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.utils.matplotlib import rasterplot"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/advanced/matrix_multiplication.ipynb
+++ b/examples/advanced/matrix_multiplication.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:9229c15e50f09b574c6f4dc7c8dbd03e866e3e1789a23267db362cb2ddd985b0"
+  "signature": "sha256:c162d9b783412230e95e4a2d1c50a612db018b2b6d56fee495303bafbd1f4e3c"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -25,7 +25,8 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/advanced/nef_summary.ipynb
+++ b/examples/advanced/nef_summary.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:508fa05fca38bcc725097025b98170177e476a3615fbf264e88bf0aea807518e"
+  "signature": "sha256:2128ecf1d3df2c50e28c71266d91f7de1b93cd542404235f87a7047c39b3f91b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -17,6 +17,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Uniform\n",
       "from nengo.utils.ensemble import tuning_curves\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/basic/2d_representation.ipynb
+++ b/examples/basic/2d_representation.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:fd61990ef486b56e719a4a1f8d5e291b7f57f0bbeb41c8b36c78a665e756e463"
+  "signature": "sha256:0d2cf768593894f6851a1b938fc6eddef2f2a208f5f544efa89c8eaad7b868b8"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -34,6 +34,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "\n",
       "model = nengo.Network(label='2D Representation')\n",
       "with model:\n",

--- a/examples/basic/addition.ipynb
+++ b/examples/basic/addition.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:1aa678aac44cf5a5b55b8d5bab576ce387897785b94c01f7181338a7f8ff165e"
+  "signature": "sha256:ed991982a55324b1fce065d4db7d4aeae1084f89fec94a0c1a29b302d702cae4"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -29,7 +29,8 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/combining.ipynb
+++ b/examples/basic/combining.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:5d56a25132993fbfe9ded322d61dde5bd17ab74458c26b6f16dcfe3808c43acc"
+  "signature": "sha256:b1ca4291bd898141204101b6b31fa0a8531f4339995f0e926d472b8f446f1e78"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -24,9 +24,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/basic/communication_channel.ipynb
+++ b/examples/basic/communication_channel.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:cce344481e15b9d106e05f5576388065f343ec07ea1c5341ab429483a82f5aa0"
+  "signature": "sha256:28d0a8e8998416079f60f839b7e6c5c0cb8de613d272af289087f194023fb066"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -36,9 +36,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/basic/many_neurons.ipynb
+++ b/examples/basic/many_neurons.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:bc06d14016b637fbe4bc187d832710e7e172660605f160386bc37a5c3968cf7f"
+  "signature": "sha256:07cff1d33415571eace221e6e528278d6ee36fe4fc9d51511c86f394ec58b9e9"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -29,9 +29,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/basic/multiplication.ipynb
+++ b/examples/basic/multiplication.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:1d4b4a3ce5d014fe5b874ce69cfd47b81696d87078849dd904ef56feef757907"
+  "signature": "sha256:36fc9d0047a1b5d13d7448ae818621d998f92a0aeb194530ab6efbda7ba2b43b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -30,7 +30,8 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/single_neuron.ipynb
+++ b/examples/basic/single_neuron.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:c0f1570c9faf11c4bf9838c9feeddf28ae9f2352df37ae45de5ba6b5cda1d2df"
+  "signature": "sha256:6dda49e49c0c91754f8916ac2e9e0bd3f9f8e95652971c0a0c04b17923e43a84"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -24,9 +24,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/basic/squaring.ipynb
+++ b/examples/basic/squaring.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:f58233c60f377fa6e291e025de2cfaba3cbc969d9930e65a69dd4ef2e7ee8cbb"
+  "signature": "sha256:3d193a94d941aac9f4e546dba231f95aa545e6173aaf7fb0fcdd36fb3b5b9776"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -30,9 +30,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/basic/two_neurons.ipynb
+++ b/examples/basic/two_neurons.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:8925aecd7ebfd578edb3131e5a20b7e7820445c9dd8c3c7d22f934cf4680c8a1"
+  "signature": "sha256:8f72bd9bb0a9480806aceffdb8a0303341a57307de2e2b0e6457bf670ab69e92"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -29,9 +29,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/dynamics/controlled_integrator.ipynb
+++ b/examples/dynamics/controlled_integrator.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:b0e31875f70dcd801b91b7e1c4e5aaf9aa54afde2161e1431bbee1562801efc4"
+  "signature": "sha256:c0345a7d9609f073a0ae0dc2ed8663bcb9a7ba2f8e4f3408eda769549ffc38a8"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -47,7 +47,8 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/controlled_integrator2.ipynb
+++ b/examples/dynamics/controlled_integrator2.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:ab217e9ce3c7f067c1fdda5a495618fac268f2082d97c89b0dfbd0d6008b3a64"
+  "signature": "sha256:fdd38e9c384256d334e90fdc895cb8c96367c35331837e6a37c9cb7bf3a72a3a"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -24,9 +24,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/dynamics/controlled_oscillator.ipynb
+++ b/examples/dynamics/controlled_oscillator.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:a15c571db4294bb656f5d28e34c8addb69ca53a2b14a6ca2e47d18670f514b4e"
+  "signature": "sha256:00e52bb5fc01cbca98c4cd50a25bb578ab323bb7039992a491170406d5554c3d"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -64,9 +64,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/dynamics/integrator.ipynb
+++ b/examples/dynamics/integrator.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:1b4c1f67b697d810394bffb7c19d6cc689e6eca7a8b18068a9fb5c6b545ce777"
+  "signature": "sha256:5117f6bdbe3325cb5c6a5887f26a7fead650fee6a8c4a6fc498e2d953270619b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -28,9 +28,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/dynamics/lorenz_attractor.ipynb
+++ b/examples/dynamics/lorenz_attractor.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:f4d643d04fe83deae35449370532a6da2fb03140fa687fd96ba2721cc6c7f368"
+  "signature": "sha256:0533b7885b69597d3645c7152cff8a82630aaab763b29c758201e9e78bd8a790"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -39,9 +39,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/dynamics/oscillator.ipynb
+++ b/examples/dynamics/oscillator.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:b0817b1b084b9473b13c94874aa954454cd615b1c4bc9cf52cd1f2666dd33284"
+  "signature": "sha256:a4fc96b278943b8e2b2f76a246ebe4cc62283b89dd05f650fff5fb2a429dbc42"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -23,9 +23,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/learning/learn_communication_channel.ipynb
+++ b/examples/learning/learn_communication_channel.ipynb
@@ -40,6 +40,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",

--- a/examples/learning/learn_product.ipynb
+++ b/examples/learning/learn_product.ipynb
@@ -34,6 +34,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",

--- a/examples/learning/learn_square.ipynb
+++ b/examples/learning/learn_square.ipynb
@@ -30,7 +30,8 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/learning/learn_unsupervised.ipynb
+++ b/examples/learning/learn_unsupervised.ipynb
@@ -48,7 +48,8 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/networks/basal_ganglia.ipynb
+++ b/examples/networks/basal_ganglia.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:ffe14b2a4ce2539f3c58ad1945399e40c2061b37ec5e3af43ee85a2e756cadc3"
+  "signature": "sha256:21c107ff1231191020a6913327018f65dce9df4c5fc925aaeab7fbafa288852b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -33,7 +33,8 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/networks/ensemble_array.ipynb
+++ b/examples/networks/ensemble_array.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:f808de7de18f166aab912b9d4d772e987777be624eecf1196eefa961fb6f41ea"
+  "signature": "sha256:c6aae384881d330e1f9f2e0a89dab9fdf87537cd59a5a900f6988bef583dac6a"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -27,9 +27,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/networks/integrator_network.ipynb
+++ b/examples/networks/integrator_network.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:39f8250e4b13d6e46f6b8f4b8f6c5b2ca28ea4861f4287bb47221178f49eebd1"
+  "signature": "sha256:7d9995c1fb63388fe99de5dfd596f9d2aeba02ec92cf02469ce606e1321c2336"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -28,9 +28,11 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/spa/convolution.ipynb
+++ b/examples/spa/convolution.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:2837486c68544cc747d26f14e86cfccc8bbf69632d84119687c9be0ed927d210"
+  "signature": "sha256:96a66e632ae03f66c9dead0415a850a66c6ce26877cea719a43ba4f789c1f003"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -26,6 +26,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.spa import Vocabulary\n",
       "\n",
       "# Change the seed of this RNG to change the vocabulary\n",

--- a/examples/spa/question.ipynb
+++ b/examples/spa/question.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:d686bee833f550e3342dce0c06c1db509fd8ddfe0d91ae13045ea7db16ad4bae"
+  "signature": "sha256:4d1ab5b15eacbeac3c66babb4e1002bdee62cc0bc5b5bd15cb36b96442e494e0"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -27,6 +27,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/question_control.ipynb
+++ b/examples/spa/question_control.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:391457277ea8a2d37bf9828f124f416fd826265feb40d1c31bbb5ea9c1f3fab4"
+  "signature": "sha256:f562acc310f39070670e8da518041b95ec9d138581e370527a12e9058f8130cf"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -28,6 +28,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/question_memory.ipynb
+++ b/examples/spa/question_memory.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:dfee5aa0fe4431bd0979962cb2a80ead301519221130cbd64290263d5ceadf87"
+  "signature": "sha256:8a5ec101c22ea6602a7f7a50ed40046ca7fc36b21dadcab2ffd99396450fc9a6"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -27,6 +27,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_parser.ipynb
+++ b/examples/spa/spa_parser.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:8bf9845ad7346be32fe4d6bbb7b2e96320db1a6f0bbaa40f3214251749cf7bb4"
+  "signature": "sha256:b9f5b2cbecf282acbc6527a2f6db9f91375072979a2172919931d8b201e6c92b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -35,6 +35,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_sequence.ipynb
+++ b/examples/spa/spa_sequence.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:4a88fdf94adcf467c7deb5bdbf08ae3d7c6f87325b2185a95175abbae96ab138"
+  "signature": "sha256:ebaea4f1e78a061b26883a7b6ddb89da391f17842dde1850678149363be62a6b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -34,6 +34,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_sequence_routed.ipynb
+++ b/examples/spa/spa_sequence_routed.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:05e9590b2db06a76474f3d6ddecdd52d5d4ddd0e0eb350e615957bdd81f94a57"
+  "signature": "sha256:553043f54cc6c2200ec31e71b8f19771e107d45381cf92d3d3ef353f3f3c36e1"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -32,6 +32,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/usage/config.ipynb
+++ b/examples/usage/config.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:6a7370b53bdc81cf72ce559b985fa5426e544e42cb929305f8ece4d739212983"
+  "signature": "sha256:cba10c1a7dccbe927b655c459b37bf28a90ef6622809103e22e05701e9147210"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -39,6 +39,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.utils.functions import piecewise\n",
       "from nengo.utils.ipython import hide_input\n",
       "hide_input()"

--- a/examples/usage/delay_node.ipynb
+++ b/examples/usage/delay_node.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:464b82dcf1df7daf5604bf31669b32a85555f89ab435b28667ff6b0d939fed27"
+  "signature": "sha256:b1f4459a86096ef2c0f677e69a0729b698e42cfa6ba6d287053ab03b1e6be9c9"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -28,9 +28,11 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {
@@ -81,6 +83,7 @@
       "sim.run(2)"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": []
     },
     {

--- a/examples/usage/network_design.ipynb
+++ b/examples/usage/network_design.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:617318f5140a623036c10131f453095faffb5aa025d23b83505e54dbf1150196"
+  "signature": "sha256:80a64c5b889568dc590a5e3c1a2e11f86f110456724d8dc52bfd29ff0a25effe"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -52,6 +52,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Choice\n",
       "from nengo.utils.functions import piecewise\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/usage/network_design_advanced.ipynb
+++ b/examples/usage/network_design_advanced.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:11ae37c25d975bee65c17c733615c8453ffbbde47279521c0d7463e4180637eb"
+  "signature": "sha256:4e5bd93abfb50773c85dc49f9799ac3cdb6d426a7900bf2cb5487344c54b6409"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -42,6 +42,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Choice\n",
       "from nengo.utils.functions import piecewise\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/usage/rectified_linear.ipynb
+++ b/examples/usage/rectified_linear.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:09c626429bb55eed4aabf3fa251a1f093077e36d7ddbdf4e4261e1d1248b58aa"
+  "signature": "sha256:09bde728cac23394e3038d1a2a7ee800ef229d04de5a069f9dfdf8c921def053"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -46,6 +46,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "\n",
       "class RectifiedLinear(nengo.neurons.NeuronType):  # Neuron types must subclass `nengo.Neurons`\n",
       "    \"\"\"A rectified linear neuron model.\"\"\"\n",

--- a/examples/usage/strings.ipynb
+++ b/examples/usage/strings.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:aa35ca33542ab5c2e883e84c800e79d7e0462f40b955ebca08bb00142b358047"
+  "signature": "sha256:67c31673d77e56d4746a91b1fa4c9905fe5304e42ddf8a4376c41dc1e61c83f1"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -24,7 +24,8 @@
      "collapsed": false,
      "input": [
       "import numpy as np\n",
-      "import nengo"
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/usage/tuning_curves.ipynb
+++ b/examples/usage/tuning_curves.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:b60ae49f56f70e699a7860b189beb0d7323f7f9a4de03afd99e2f9825b013fe3"
+  "signature": "sha256:41e34a6255d5244299c4c5e3aee968de174807e68d1b83733ec29d8839a345a2"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -47,6 +47,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
+      "%load_ext nengo.ipynb\n",
       "from nengo.utils.ensemble import tuning_curves"
      ],
      "language": "python",

--- a/nengo-data/nengorc
+++ b/nengo-data/nengorc
@@ -45,3 +45,19 @@
 
 # Path where the cached decoders will be stored. (string)
 #path: ~/.cache/nengo/decoders  # Linux default
+
+
+# Settings for the progress bar
+[progress]
+
+# Progress bar to use. Can be 'none' (disable the progress bar), 'auto'
+# (automatically show the progress bar for long running simulations), or the
+# name of some class implementing the nengo.utils.progress.ProgressBar
+# interface (e.g., 'nengo.utils.progress.ProgressBar').
+#progress_bar: auto
+
+# Progress updating scheme. Can be 'auto' (automatically determine the updating
+# scheme) or the name of some class implementing the
+# nengo.utils.progress.ProgressUpdater interface (e.g.,
+# 'nengo.utils.progress.UpdateEveryT').
+#updater: auto

--- a/nengo/ipynb.py
+++ b/nengo/ipynb.py
@@ -11,12 +11,107 @@ This IPython extension cannot be unloaded.
 """
 
 from nengo.rc import rc
-from nengo.utils.progress import IPython2ProgressBar, IPythonProgressWidget
+from nengo.utils.ipython import get_ipython, has_ipynb_widgets
+from nengo.utils.progress import ProgressBar, timestamp2timedelta
+
+if has_ipynb_widgets():
+    from IPython.html.widgets import DOMWidget
+    from IPython.display import display
+    import IPython.utils.traitlets as traitlets
+else:
+    DOMWidget = object
 
 
 def load_ipython_extension(ipython):
     IPythonProgressWidget.load_frontend()
     if rc.get('progress', 'progress_bar') == 'auto':
         rc.set('progress', 'progress_bar', '.'.join((
-            'nengo.utils.progress',
-            IPython2ProgressBar.__name__)))
+            __name__, IPython2ProgressBar.__name__)))
+
+
+class IPythonProgressWidget(DOMWidget):
+    """IPython widget for displaying a progress bar."""
+
+    # pylint: disable=too-many-public-methods
+    _view_name = traitlets.Unicode('NengoProgressBar', sync=True)
+    progress = traitlets.Float(0., sync=True)
+    text = traitlets.Unicode(u'', sync=True)
+
+    FRONTEND = '''
+    require(["widgets/js/widget", "widgets/js/manager"],
+        function(widget, manager) {
+      if (typeof widget.DOMWidgetView == 'undefined') {
+        widget = IPython;
+      }
+      if (typeof manager.WidgetManager == 'undefined') {
+        manager = IPython;
+      }
+
+      var NengoProgressBar = widget.DOMWidgetView.extend({
+        render: function() {
+          // $el is the DOM of the widget
+          this.$el.css({width: '100%', marginBottom: '0.5em'});
+          this.$el.html([
+            '<div style="',
+                'width: 100%;',
+                'border: 1px solid #cfcfcf;',
+                'border-radius: 4px;',
+                'text-align: center;',
+                'position: relative;">',
+              '<div class="pb-text" style="',
+                  'position: absolute;',
+                  'width: 100%;">',
+                '0%',
+              '</div>',
+              '<div class="pb-bar" style="',
+                  'background-color: #bdd2e6;',
+                  'width: 0%;',
+                  'transition: width 0.1s linear;">',
+                '&nbsp;',
+              '</div>',
+            '</div>'].join(''));
+        },
+
+        update: function() {
+          this.$el.css({width: '100%', marginBottom: '0.5em'});
+          var progress = 100 * this.model.get('progress');
+          var text = this.model.get('text');
+          this.$el.find('div.pb-bar').width(progress.toString() + '%');
+          this.$el.find('div.pb-text').text(text);
+        },
+      });
+
+      manager.WidgetManager.register_widget_view(
+        'NengoProgressBar', NengoProgressBar);
+    });'''
+
+    @classmethod
+    def load_frontend(cls):
+        """Loads the JavaScript front-end code required by then widget."""
+        get_ipython().run_cell_magic('javascript', '', cls.FRONTEND)
+
+
+class IPython2ProgressBar(ProgressBar):
+    """IPython progress bar based on widgets."""
+
+    supports_fast_ipynb_updates = True
+
+    def __init__(self, task="Simulation"):
+        super(IPython2ProgressBar, self).__init__(task)
+        self._widget = IPythonProgressWidget()
+        self._initialized = False
+
+    def update(self, progress):
+        if not self._initialized:
+            display(self._widget)
+            self._initialized = True
+
+        self._widget.progress = progress.progress
+        if progress.finished:
+            self._widget.text = "{0} finished in {1}.".format(
+                self.task,
+                timestamp2timedelta(progress.elapsed_seconds()))
+        else:
+            self._widget.text = "{progress:.0f}%, ETA: {eta}".format(
+                progress=100 * progress.progress,
+                eta=timestamp2timedelta(progress.eta()))

--- a/nengo/ipynb.py
+++ b/nengo/ipynb.py
@@ -11,20 +11,25 @@ This IPython extension cannot be unloaded.
 """
 
 from nengo.rc import rc
-from nengo.utils.ipython import get_ipython, has_ipynb_widgets
+from nengo.utils.ipython import has_ipynb_widgets
 from nengo.utils.progress import ProgressBar, timestamp2timedelta
 
 if has_ipynb_widgets():
-    from IPython.html.widgets import DOMWidget
+    import IPython
+    if IPython.version_info[0] <= 3:
+        from IPython.html.widgets import DOMWidget
+        import IPython.utils.traitlets as traitlets
+    else:
+        from ipywidgets import DOMWidget
+        import traitlets
     from IPython.display import display
-    import IPython.utils.traitlets as traitlets
 else:
     DOMWidget = object
 
 
 def load_ipython_extension(ipython):
-    IPythonProgressWidget.load_frontend()
-    if rc.get('progress', 'progress_bar') == 'auto':
+    if has_ipynb_widgets() and rc.get('progress', 'progress_bar') == 'auto':
+        IPythonProgressWidget.load_frontend(ipython)
         rc.set('progress', 'progress_bar', '.'.join((
             __name__, IPython2ProgressBar.__name__)))
 
@@ -49,6 +54,8 @@ class IPythonProgressWidget(DOMWidget):
 
       var NengoProgressBar = widget.DOMWidgetView.extend({
         render: function() {
+          // Work-around for messed up CSS in IPython 4
+          $('.widget-subarea').css({flex: '2 1 0%'});
           // $el is the DOM of the widget
           this.$el.css({width: '100%', marginBottom: '0.5em'});
           this.$el.html([
@@ -86,9 +93,9 @@ class IPythonProgressWidget(DOMWidget):
     });'''
 
     @classmethod
-    def load_frontend(cls):
+    def load_frontend(cls, ipython):
         """Loads the JavaScript front-end code required by then widget."""
-        get_ipython().run_cell_magic('javascript', '', cls.FRONTEND)
+        ipython.run_cell_magic('javascript', '', cls.FRONTEND)
 
 
 class IPython2ProgressBar(ProgressBar):

--- a/nengo/ipynb.py
+++ b/nengo/ipynb.py
@@ -1,0 +1,22 @@
+"""IPython extension that activates special IPython notebook features of Nengo.
+
+At the moment this only activates the improved progress bar.
+
+Use ``%load_ext nengo.ipynb`` in an IPython notebook to load the extension.
+
+Note
+----
+
+This IPython extension cannot be unloaded.
+"""
+
+from nengo.rc import rc
+from nengo.utils.progress import IPython2ProgressBar, IPythonProgressWidget
+
+
+def load_ipython_extension(ipython):
+    IPythonProgressWidget.load_frontend()
+    if rc.get('progress', 'progress_bar') == 'auto':
+        rc.set('progress', 'progress_bar', '.'.join((
+            'nengo.utils.progress',
+            IPython2ProgressBar.__name__)))

--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -37,7 +37,11 @@ RC_DEFAULTS = {
         'enabled': True,
         'readonly': False,
         'size': '512 MB',
-        'path': nengo.utils.paths.decoder_cache_dir
+        'path': nengo.utils.paths.decoder_cache_dir,
+    },
+    'progress': {
+        'updater': 'auto',
+        'progress_bar': 'auto',
     }
 }
 

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -50,6 +50,9 @@ for subdir, _, files in os.walk(examples_dir):
 
 
 def assert_noexceptions(nb_file, tmpdir, plt):
+    plt.saveas = None  # plt used to ensure figures are closed, but don't save
+    pytest.importorskip("IPython", minversion="1.0")
+    pytest.importorskip("jinja2")
     from nengo.utils.ipython import export_py, load_notebook
     nb_path = os.path.join(examples_dir, "%s.ipynb" % nb_file)
     nb = load_notebook(nb_path)
@@ -57,16 +60,12 @@ def assert_noexceptions(nb_file, tmpdir, plt):
         tmpdir.join(os.path.splitext(os.path.basename(nb_path))[0]))
     export_py(nb, pyfile)
     execfile(pyfile, {})
-    # Note: plt imported but not used to ensure figures are closed
-    plt.saveas = None
 
 
 @pytest.mark.example
 @pytest.mark.parametrize('nb_file', fast_examples)
 def test_fast_noexceptions(nb_file, tmpdir, plt):
     """Ensure that no cells raise an exception."""
-    pytest.importorskip("IPython", minversion="1.0")
-    pytest.importorskip("jinja2")
     assert_noexceptions(nb_file, tmpdir, plt)
 
 
@@ -75,8 +74,6 @@ def test_fast_noexceptions(nb_file, tmpdir, plt):
 @pytest.mark.parametrize('nb_file', slow_examples)
 def test_slow_noexceptions(nb_file, tmpdir, plt):
     """Ensure that no cells raise an exception."""
-    pytest.importorskip("IPython", minversion="1.0")
-    pytest.importorskip("jinja2")
     assert_noexceptions(nb_file, tmpdir, plt)
 
 

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -68,31 +68,6 @@ except ImportError:
         return None
 
 
-def in_ipynb():
-    """Determines if code is executed in an IPython notebook.
-
-    Returns
-    -------
-    bool
-       ``True`` if the code is executed in an IPython notebook, otherwise
-       ``False``.
-
-    Notes
-    -----
-    It is possible to connect to a kernel started from an IPython notebook
-    from outside of the notebook. Thus, this function might return ``True``
-    even though the code is not running in an IPython notebook.
-    """
-    if get_ipython() is not None:
-        cfg = get_ipython().config
-        app_key = 'IPKernelApp'
-        if 'parent_appname' not in cfg[app_key]:
-            app_key = 'KernelApp'  # was used by old IPython versions
-        if cfg[app_key].get('parent_appname') == 'ipython-notebook':
-            return True
-    return False
-
-
 def has_ipynb_widgets():
     """Determines whether IPython widgets are available.
 

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -167,6 +167,9 @@ def export_py(nb, dest_path=None):
     # We'll remove %matplotlib inline magic, but leave the rest
     body = body.replace("get_ipython().magic(u'matplotlib inline')\n", "")
     body = body.replace("get_ipython().magic('matplotlib inline')\n", "")
+    # Also remove the IPython notebook extension
+    body = body.replace("get_ipython().magic(u'load_ext nengo.ipynb')\n", "")
+    body = body.replace("get_ipython().magic('load_ext nengo.ipynb')\n", "")
     if dest_path is not None:
         with open(dest_path, 'w') as f:
             f.write(body)

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -43,9 +43,14 @@ import numpy as np
 try:
     import IPython
     from IPython import get_ipython
-    from IPython.config import Config
     from IPython.display import HTML
-    from IPython.nbconvert import HTMLExporter, PythonExporter
+
+    if IPython.version_info[0] <= 3:
+        from IPython.config import Config
+        from IPython.nbconvert import HTMLExporter, PythonExporter
+    else:
+        from traitlets.config import Config
+        from nbconvert import HTMLExporter, PythonExporter
 
     # nbformat.current deprecated in IPython 3.0
     if IPython.version_info[0] <= 2:
@@ -56,9 +61,14 @@ try:
         def read_nb(fp):
             return current.read(fp, 'json')
     else:
-        from IPython import nbformat
-        from IPython.nbformat import write as write_nb
-        from IPython.nbformat import NotebookNode
+        if IPython.version_info[0] == 3:
+            from IPython import nbformat
+            from IPython.nbformat import write as write_nb
+            from IPython.nbformat import NotebookNode
+        else:
+            import nbformat
+            from nbformat import write as write_nb
+            from nbformat import NotebookNode
 
         def read_nb(fp):
             # Have to load as version 4 or running notebook fails
@@ -77,10 +87,14 @@ def has_ipynb_widgets():
         ``True`` if IPython widgets are available, otherwise ``False``.
     """
     try:
-        import IPython.html.widgets
-        import IPython.utils.traitlets
-        assert IPython.html.widgets
-        assert IPython.utils.traitlets
+        if IPython.version_info[0] <= 3:
+            from IPython.html import widgets as ipywidgets
+            from IPython.utils import traitlets
+        else:
+            import ipywidgets
+            import traitlets
+        assert ipywidgets
+        assert traitlets
     except ImportError:
         return False
     else:

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division
 
 from datetime import timedelta
+import importlib
 import os
 import sys
 import time
@@ -10,15 +11,17 @@ import warnings
 
 import numpy as np
 
+from ..rc import rc
 from .stdlib import get_terminal_size
-from .ipython import in_ipynb, has_ipynb_widgets
+from .ipython import get_ipython, has_ipynb_widgets
 
 
 if has_ipynb_widgets():
-    from IPython import get_ipython
-    from IPython.html import widgets
+    from IPython.html.widgets import DOMWidget
     from IPython.display import display
     import IPython.utils.traitlets as traitlets
+else:
+    DOMWidget = object
 
 
 class MemoryLeakWarning(UserWarning):
@@ -30,6 +33,12 @@ warnings.filterwarnings('once', category=MemoryLeakWarning)
 
 def _timestamp2timedelta(timestamp):
     return timedelta(seconds=np.ceil(timestamp))
+
+
+def _load_class(name):
+    mod_name, cls_name = name.rsplit('.', 1)
+    mod = importlib.import_module(mod_name)
+    return getattr(mod, cls_name)
 
 
 class Progress(object):
@@ -174,21 +183,6 @@ class TerminalProgressBar(ProgressBar):
 
     def __init__(self, task="Simulation"):
         super(TerminalProgressBar, self).__init__(task)
-        if in_ipynb():
-            warnings.warn(MemoryLeakWarning((
-                "The {cls}, if used in an IPython notebook,"
-                " will continuously adds invisible content to the "
-                "IPython notebook which may lead to excessive memory usage "
-                "and ipynb files which cannot be opened anymore. Please "
-                "consider doing one of the following:{cr}{cr}"
-                "  * Wrap {cls} in an UpdateEveryN class. This reduces the "
-                "memory consumption, but does not solve the problem "
-                "completely.{cr}"
-                "  * Disable the progress bar.{cr}"
-                "  * Use IPython 2.0 or later and the IPython2ProgressBar "
-                "(this is the default behavior from IPython 2.0 onwards).{cr}"
-                ).format(cls=self.__class__.__name__, cr=os.linesep)))
-            sys.stderr.flush()  # Show warning immediately.
 
     def update(self, progress):
         if progress.finished:
@@ -207,7 +201,7 @@ class TerminalProgressBar(ProgressBar):
         progress_width = max(0, width - len(line))
         progress_str = (
             int(progress_width * progress.progress) * "#").ljust(
-            progress_width)
+                progress_width)
 
         percent_pos = (len(progress_str) - len(percent_str)) // 2
         if percent_pos > 0:
@@ -225,70 +219,66 @@ class TerminalProgressBar(ProgressBar):
         return '\r' + line + os.linesep
 
 
-if has_ipynb_widgets():
-    class IPythonProgressWidget(widgets.DOMWidget):
-        """IPython widget for displaying a progress bar."""
+class IPythonProgressWidget(DOMWidget):
+    """IPython widget for displaying a progress bar."""
 
-        # pylint: disable=too-many-public-methods
-        _view_name = traitlets.Unicode('NengoProgressBar', sync=True)
-        progress = traitlets.Float(0., sync=True)
-        text = traitlets.Unicode(u'', sync=True)
+    # pylint: disable=too-many-public-methods
+    _view_name = traitlets.Unicode('NengoProgressBar', sync=True)
+    progress = traitlets.Float(0., sync=True)
+    text = traitlets.Unicode(u'', sync=True)
 
-        FRONTEND = '''
-        require(["widgets/js/widget", "widgets/js/manager"],
-            function(widget, manager) {
-          if (typeof widget.DOMWidgetView == 'undefined') {
-            widget = IPython;
-          }
-          if (typeof manager.WidgetManager == 'undefined') {
-            manager = IPython;
-          }
+    FRONTEND = '''
+    require(["widgets/js/widget", "widgets/js/manager"],
+        function(widget, manager) {
+      if (typeof widget.DOMWidgetView == 'undefined') {
+        widget = IPython;
+      }
+      if (typeof manager.WidgetManager == 'undefined') {
+        manager = IPython;
+      }
 
-          var NengoProgressBar = widget.DOMWidgetView.extend({
-            render: function() {
-              // $el is the DOM of the widget
-              this.$el.css({width: '100%', marginBottom: '0.5em'});
-              this.$el.html([
-                '<div style="',
-                    'width: 100%;',
-                    'border: 1px solid #cfcfcf;',
-                    'border-radius: 4px;',
-                    'text-align: center;',
-                    'position: relative;">',
-                  '<div class="pb-text" style="',
-                      'position: absolute;',
-                      'width: 100%;">',
-                    '0%',
-                  '</div>',
-                  '<div class="pb-bar" style="',
-                      'background-color: #bdd2e6;',
-                      'width: 0%;',
-                      'transition: width 0.1s linear;">',
-                    '&nbsp;',
-                  '</div>',
-                '</div>'].join(''));
-            },
+      var NengoProgressBar = widget.DOMWidgetView.extend({
+        render: function() {
+          // $el is the DOM of the widget
+          this.$el.css({width: '100%', marginBottom: '0.5em'});
+          this.$el.html([
+            '<div style="',
+                'width: 100%;',
+                'border: 1px solid #cfcfcf;',
+                'border-radius: 4px;',
+                'text-align: center;',
+                'position: relative;">',
+              '<div class="pb-text" style="',
+                  'position: absolute;',
+                  'width: 100%;">',
+                '0%',
+              '</div>',
+              '<div class="pb-bar" style="',
+                  'background-color: #bdd2e6;',
+                  'width: 0%;',
+                  'transition: width 0.1s linear;">',
+                '&nbsp;',
+              '</div>',
+            '</div>'].join(''));
+        },
 
-            update: function() {
-              this.$el.css({width: '100%', marginBottom: '0.5em'});
-              var progress = 100 * this.model.get('progress');
-              var text = this.model.get('text');
-              this.$el.find('div.pb-bar').width(progress.toString() + '%');
-              this.$el.find('div.pb-text').text(text);
-            },
-          });
+        update: function() {
+          this.$el.css({width: '100%', marginBottom: '0.5em'});
+          var progress = 100 * this.model.get('progress');
+          var text = this.model.get('text');
+          this.$el.find('div.pb-bar').width(progress.toString() + '%');
+          this.$el.find('div.pb-text').text(text);
+        },
+      });
 
-          manager.WidgetManager.register_widget_view(
-            'NengoProgressBar', NengoProgressBar);
-        });'''
+      manager.WidgetManager.register_widget_view(
+        'NengoProgressBar', NengoProgressBar);
+    });'''
 
-        @classmethod
-        def load_frontend(cls):
-            """Loads the JavaScript front-end code required by then widget."""
-            get_ipython().run_cell_magic('javascript', '', cls.FRONTEND)
-
-    if in_ipynb():
-        IPythonProgressWidget.load_frontend()
+    @classmethod
+    def load_frontend(cls):
+        """Loads the JavaScript front-end code required by then widget."""
+        get_ipython().run_cell_magic('javascript', '', cls.FRONTEND)
 
 
 class IPython2ProgressBar(ProgressBar):
@@ -517,10 +507,26 @@ def get_default_progressbar():
     -------
     :class:`ProgressBar`
     """
-    if in_ipynb() and has_ipynb_widgets():  # IPython notebook >= 2.0
-        return AutoProgressBar(IPython2ProgressBar())
-    else:  # IPython notebook < 2.0 or any other environment
+    try:
+        pbar = rc.getboolean('progress', 'progress_bar')
+        if pbar:
+            return AutoProgressBar(TerminalProgressBar())
+        else:
+            return NoProgressBar()
+    except ValueError:
+        pass
+
+    pbar = rc.get('progress', 'progress_bar')
+    if pbar.lower() == 'auto':
         return AutoProgressBar(TerminalProgressBar())
+    if pbar.lower() == 'none':
+        return NoProgressBar()
+
+    try:
+        return _load_class(pbar)()
+    except Exception as e:
+        warnings.warn(str(e))
+        return NoProgressBar()
 
 
 def get_default_progressupdater(progress_bar):
@@ -537,10 +543,19 @@ def get_default_progressupdater(progress_bar):
     -------
     :class:`ProgressUpdater`
     """
-    if in_ipynb() and not isinstance(progress_bar, IPython2ProgressBar):
-        return UpdateN
+    updater = rc.get('progress', 'updater')
+
+    if updater.lower() == 'auto':
+        if get_ipython() is None or isinstance(
+                progress_bar, IPython2ProgressBar):
+            return UpdateEveryT
+        else:
+            return UpdateN
     else:
-        return UpdateEveryT
+        try:
+            return _load_class(updater)
+        except Exception as e:
+            warnings.warn(str(e))
 
 
 def wrap_with_progressupdater(progress_bar=True):

--- a/requirements-test-py26.txt
+++ b/requirements-test-py26.txt
@@ -2,6 +2,7 @@ matplotlib>=1.4
 IPython==1.2.1
 jinja2
 counter
+importlib
 ordereddict
 pygments
 pytest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 matplotlib>=1.4
-IPython[nbconvert]>=2.3
+jupyter
 pytest
 pytest-xdist


### PR DESCRIPTION
* Add RC option to set progress bar.
* Remove IPython notebook detection (cannot be done with IPython
  notebook >3 aka Jupyter)
* Add `activate_ipynb_features()` function.

Todo:
* [x] Document new RC options
* [x] Document `activate_ipynb_features()`
* [x] Add `activate_ipynb_features()` to examples?
* [ ] Document how to run `activate_ipynb_features()` automatically when a kernel in a notebook is started.

We are still deploying the progress bar front-end code in IPython notebook in the non-recommended way:

> If you distribute your custom widget, you may be using display and Javascript to publish the widget’s Javascript to the front-end. That is no longer the recommended way of distributing widget Javascript. Instead have the user install the Javascript to his/her nbextension directory or their profile’s static directory.

This is for backwards compatibility (the recommended way does not work prior to IPython 3). It would be possible to deploy the code in the recommended way for IPython 3 only and in the old way otherwise. But that might require some code duplication. Thus, I would vote to keep it how it is at the moment and switch over at a later point when we drop support for older IPython versions. The downsides of the old way are:
* Front-end code might not be loaded in time (and progress bar shows not up)
* Progress bar might break when the page is reloaded.