### PR TITLE
Fix networks

### DIFF
--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -106,7 +106,7 @@ class EnsembleArray(nengo.Network):
         sizes = np.zeros(self.n_ensembles, dtype=int)
 
         if is_iterable(function) and all(callable(f) for f in function):
-            if len(function) != self.n_ensembles:
+            if len(list(function)) != self.n_ensembles:
                 raise ValueError("Must have one function per ensemble")
 
             for i, func in enumerate(function):


### PR DESCRIPTION
Some minor fixes to EnsembleArray and Product. The first commit removes an unused node in Product, and allows any iterable of functions to be used in `EnsembleArray.add_output`.

The second commit might be a bit more controversial. It just removes the passthrough input nodes in Product and replaces them with ObjViews.