### PR TITLE
Added function to evaluate connection's decoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,9 @@ Release History
   of semantic pointer elements.
   (`#414 <https://github.com/nengo/nengo/issues/414>`_,
   `#430 <https://github.com/nengo/nengo/pull/430>`_)
+- Added ``utils.connection.eval_point_decoding`` function, which
+  provides a connection's static decoding of a list of evaluation points.
+  (`#700 https://github.com/nengo/nengo/pull/700`_)
 
 **Bug fixes**
 

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import nengo.utils.numpy as npext
 from nengo.builder.builder import Builder
-from nengo.builder.ensemble import gen_eval_points
+from nengo.builder.ensemble import gen_eval_points, get_activities
 from nengo.builder.node import build_pyfunc
 from nengo.builder.operator import DotInc, ElementwiseInc, PreserveValue, Reset
 from nengo.builder.signal import Signal
@@ -20,26 +20,16 @@ BuiltConnection = collections.namedtuple(
     'BuiltConnection', ['decoders', 'eval_points', 'transform', 'solver_info'])
 
 
-def build_linear_system(model, conn, rng):
-    encoders = model.params[conn.pre_obj].encoders
-    gain = model.params[conn.pre_obj].gain
-    bias = model.params[conn.pre_obj].bias
-
+def get_eval_points(model, conn, rng):
     if conn.eval_points is None:
-        eval_points = npext.array(
+        return npext.array(
             model.params[conn.pre_obj].eval_points, min_dims=2)
     else:
-        eval_points = gen_eval_points(
+        return gen_eval_points(
             conn.pre_obj, conn.eval_points, rng, conn.scale_eval_points)
 
-    x = np.dot(eval_points, encoders.T / conn.pre_obj.radius)
-    activities = conn.pre_obj.neuron_type.rates(x, gain, bias)
-    if np.count_nonzero(activities) == 0:
-        raise RuntimeError(
-            "Building %s: 'activites' matrix is all zero for %s. "
-            "This is because no evaluation points fall in the firing "
-            "ranges of any neurons." % (conn, conn.pre_obj))
 
+def get_targets(model, conn, eval_points):
     if conn.function is None:
         targets = eval_points[:, conn.pre_slice]
     else:
@@ -47,6 +37,19 @@ def build_linear_system(model, conn, rng):
         for i, ep in enumerate(eval_points[:, conn.pre_slice]):
             targets[i] = conn.function(ep)
 
+    return targets
+
+
+def build_linear_system(model, conn, rng):
+    eval_points = get_eval_points(model, conn, rng)
+    activities = get_activities(model, conn.pre_obj, eval_points)
+    if np.count_nonzero(activities) == 0:
+        raise RuntimeError(
+            "Building %s: 'activites' matrix is all zero for %s. "
+            "This is because no evaluation points fall in the firing "
+            "ranges of any neurons." % (conn, conn.pre_obj))
+
+    targets = get_targets(model, conn, eval_points)
     return eval_points, activities, targets
 
 

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -42,6 +42,12 @@ def gen_eval_points(ens, eval_points, rng, scale_eval_points=True):
     return eval_points
 
 
+def get_activities(model, ens, eval_points):
+    x = np.dot(eval_points, model.params[ens].encoders.T / ens.radius)
+    return ens.neuron_type.rates(
+        x, model.params[ens].gain, model.params[ens].bias)
+
+
 @Builder.register(Ensemble)  # noqa: C901
 def build_ensemble(model, ens):
     # Create random number generator


### PR DESCRIPTION
This required a minor change to the builder, ~~which may break derivative builders~~.

Also fixed a bug in `nengo.utils.ensemble.tuning_curves` to avoid input points being modified.

EDIT: I refactored this to keep the `build_linear_system` function, so that nothing should break in other builders.