### PR TITLE
Fix #704.

### DIFF
--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -190,26 +190,6 @@ def pytest_generate_tests(metafunc):
             "nl_nodirect", [LIF, LIFRate, RectifiedLinear, Sigmoid])
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        '--plots', nargs='?', default=False, const=True,
-        help='Save plots (can optionally specify a directory for plots).')
-    parser.addoption(
-        '--analytics', nargs='?', default=False, const=True,
-        help='Save analytics (can optionally specify a directory for data).')
-    parser.addoption(
-        '--compare', nargs=2,
-        help='Compare analytics results (specify directories to compare).')
-    parser.addoption(
-        '--logs', nargs='?', default=False, const=True,
-        help='Save logs (can optionally specify a directory for logs).')
-    parser.addoption('--noexamples', action='store_false', default=True,
-                     help='Do not run examples')
-    parser.addoption(
-        '--slow', action='store_true', default=False,
-        help='Also run slow tests.')
-
-
 def pytest_runtest_setup(item):
     for mark, option, message in [
             ('example', 'noexamples', "examples not requested"),

--- a/nengo/tests/options.py
+++ b/nengo/tests/options.py
@@ -1,0 +1,18 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        '--plots', nargs='?', default=False, const=True,
+        help='Save plots (can optionally specify a directory for plots).')
+    parser.addoption(
+        '--analytics', nargs='?', default=False, const=True,
+        help='Save analytics (can optionally specify a directory for data).')
+    parser.addoption(
+        '--compare', nargs=2,
+        help='Compare analytics results (specify directories to compare).')
+    parser.addoption(
+        '--logs', nargs='?', default=False, const=True,
+        help='Save logs (can optionally specify a directory for logs).')
+    parser.addoption('--noexamples', action='store_false', default=True,
+                     help='Do not run examples')
+    parser.addoption(
+        '--slow', action='store_true', default=False,
+        help='Also run slow tests.')

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ ignore = E123,E133,E226,E241,E242,E731,W503
 max-complexity = 10
 
 [pytest]
+addopts = -p nengo.tests.options
 norecursedirs = .* *.egg build dist docs
 markers =
     example: Mark a test as an example.

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ setenv =
 deps =
     -rrequirements.txt
     -rrequirements-test.txt
-commands = py.test {posargs}
+commands = py.test {posargs} {envsitepackagesdir}/nengo
 
 [testenv:py26]
 deps =


### PR DESCRIPTION
The conftest.py file is not discovered in a subdirectory if that
directory is not passed as argument to py.test. It is recommended to
keep it in the project root (or top level test) directory:
http://pytest.org/latest/plugins.html#plugin-discovery-order-at-tool-startup