### PR TITLE
Pytest simulator and neuron argument

### DIFF
--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -30,6 +30,7 @@ class TestConfig(object):
     test_seed = 0  # changing this will change seeds for all tests
     Simulator = nengo.Simulator
     RefSimulator = nengo.Simulator
+    neuron_types = [Direct, LIF, LIFRate, RectifiedLinear, Sigmoid]
 
 
 def pytest_configure(config):
@@ -40,6 +41,10 @@ def pytest_configure(config):
     if config.getoption('ref_simulator'):
         refsim = config.getoption('ref_simulator')[0]
         TestConfig.RefSimulator = load_class(refsim)
+
+    if config.getoption('neurons'):
+        ntypes = config.getoption('neurons')[0].split(',')
+        TestConfig.neuron_types = [load_class(n) for n in ntypes]
 
 
 def load_class(fully_qualified_name):
@@ -211,11 +216,10 @@ def seed(request):
 
 def pytest_generate_tests(metafunc):
     if "nl" in metafunc.funcargnames:
-        metafunc.parametrize(
-            "nl", [Direct, LIF, LIFRate, RectifiedLinear, Sigmoid])
+        metafunc.parametrize("nl", TestConfig.neuron_types)
     if "nl_nodirect" in metafunc.funcargnames:
-        metafunc.parametrize(
-            "nl_nodirect", [LIF, LIFRate, RectifiedLinear, Sigmoid])
+        nodirect = [n for n in TestConfig.neuron_types if n is not Direct]
+        metafunc.parametrize("nl_nodirect", nodirect)
 
 
 def pytest_runtest_setup(item):

--- a/nengo/tests/options.py
+++ b/nengo/tests/options.py
@@ -3,6 +3,8 @@ def pytest_addoption(parser):
                      help='Specify simulator under test.')
     parser.addoption('--ref-simulator', nargs=1, type=str, default=None,
                      help='Specify reference simulator under test.')
+    parser.addoption('--neurons', nargs=1, type=str, default=None,
+                     help='Neuron types under test (comma separated).')
     parser.addoption(
         '--plots', nargs='?', default=False, const=True,
         help='Save plots (can optionally specify a directory for plots).')

--- a/nengo/tests/options.py
+++ b/nengo/tests/options.py
@@ -1,4 +1,8 @@
 def pytest_addoption(parser):
+    parser.addoption('--simulator', nargs=1, type=str, default=None,
+                     help='Specify simulator under test.')
+    parser.addoption('--ref-simulator', nargs=1, type=str, default=None,
+                     help='Specify reference simulator under test.')
     parser.addoption(
         '--plots', nargs='?', default=False, const=True,
         help='Save plots (can optionally specify a directory for plots).')

--- a/nengo/tests/test_pytest.py
+++ b/nengo/tests/test_pytest.py
@@ -1,8 +1,8 @@
 import nengo.utils.numpy as npext
-from nengo.conftest import test_seed
+from nengo.conftest import TestConfig
 
 
 def test_seed_fixture(seed):
     """The seed should be the same on all machines"""
-    i = (seed - test_seed) % npext.maxint
+    i = (seed - TestConfig.test_seed) % npext.maxint
     assert i == 1832276344


### PR DESCRIPTION
(Based on PR #706.)

Adds `--simulator`, `--ref-simulator`, and `--neurons` arguments to py.test. They set the simulator, reference simulator, and neuron types under test.

Should the reference simulator be settable? Shouldn't it be always nengo.Simulator? [But nengo_ocl seems to set it to OclSimulator.](https://github.com/nengo/nengo_ocl/blob/master/nengo_ocl/tests/test_sim_ocl.py#L39)

This is a step towards less boiler plate code to run other backends against the Nengo tests. A PR for nengo_ocl will follow once #705 is resolved.