### PR TITLE
Unsupported backend features attribute

### DIFF
--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -55,6 +55,15 @@ class ProbeDict(Mapping):
 class Simulator(object):
     """Reference simulator for Nengo models."""
 
+    # 'unsupported' defines features unsupported by a simulator.
+    # The format is a list of tuples of the form `(test, reason)` with `test`
+    # being a string with wildcards (*, ?, [abc], [!abc]) matched against Nengo
+    # test paths and names, and `reason` is a string describing why the feature
+    # is not supported by the backend. For example:
+    #     unsupported = [('test_pes*', 'PES rule not implemented')]
+    # would skip all test whose names start with 'test_pes'.
+    unsupported = []
+
     def __init__(self, network, dt=0.001, seed=None, model=None):
         """Initialize the simulator with a network and (optionally) a model.
 


### PR DESCRIPTION
(Based on PR #706 and #709.)

Adds the `unsupported` class attribute to `Simulator` as a standardized way to define unsupported features and skip those tests automatically.

See #705 for related discussion.

(This PR "conflicts" #710.)