### PR TITLE
Prune fixture output directories in pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ max-complexity = 10
 
 [pytest]
 addopts = -p nengo.tests.options
-norecursedirs = .* *.egg build dist docs
+norecursedirs = .* *.egg build dist docs *.analytics *.logs *.plots
 markers =
     example: Mark a test as an example.
     noassertions: Mark a test without assertions. It will only be run if plots or analytics data are produced.


### PR DESCRIPTION
I had a problem running #706, and it turned out to be because I had logs saved in a `nengo.simulator.logs` directory. Apparently `pytest` has the ability to run doctests from ReST files, and it think that .txts could contain ReST, which is fair. In any case, I added the output directories we make in test running to the `norecursedirs` list in `setup.cfg`, so now running `py.test` in the toplevel Nengo directory works when you have logs saved.