### PR TITLE
Spa thalamus routing fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,8 @@ Release History
 - Fixed issue when probing scalar transforms.
   (`#667 <https://github.com/nengo/nengo/issues/667>`_,
   `#671 <https://github.com/nengo/nengo/pull/671>`_)
+- Fix for SPA actions that route to a module with multiple inputs.
+  (`#714 <https://github.com/nengo/nengo/pull/714>`_)
 
 2.0.1 (January 27, 2015)
 ========================

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -88,7 +88,11 @@ class SPA(nengo.Network):
 
     def get_module(self, name):
         """Return the module for the given name."""
-        return self._modules[name]
+        if name in self._modules:
+            return self._modules[name]
+        elif '_' in name:
+            module, name = name.rsplit('_', 1)
+            return self._modules[module]
 
     def get_default_vocab(self, dimensions):
         """Return a Vocabulary with the desired dimensions.

--- a/nengo/spa/thalamus.py
+++ b/nengo/spa/thalamus.py
@@ -176,6 +176,7 @@ class Thalamus(Module):
             source, source_vocab = self.spa.get_module_output(source_name)
 
             target_module = self.spa.get_module(target_name)
+            source_module = self.spa.get_module(source_name)
 
             # build a communication channel between the source and target
             dim = target_vocab.dimensions
@@ -188,6 +189,8 @@ class Thalamus(Module):
             subdim = self.subdim_channel
             if isinstance(target_module, nengo.spa.Buffer):
                 subdim = target_module.state.dimensions_per_ensemble
+            elif isinstance(source_module, nengo.spa.Buffer):
+                subdim = source_module.state.dimensions_per_ensemble
             elif dim < subdim:
                 subdim = dim
             elif dim % subdim != 0:


### PR DESCRIPTION
spa.Actions that caused routing to a module that has multiple inputs didn't work.  For example:

```python
spa.Actions('dot(buffer, A) --> cmp_A=A, cmp_B=B')
```

This was just due to ```spa.get_module``` not handling this case.  This PR fixes it and adds a test to make sure it works.