### PR TITLE
Faster config system using getattr

### DIFF
--- a/nengo/config.py
+++ b/nengo/config.py
@@ -27,9 +27,12 @@ class ClassParams(object):
     """
 
     def __init__(self, configures):
-        self._extraparams = {}
-        self._configures = configures
         assert inspect.isclass(configures)
+        self._configures = configures
+        self._extraparams = {}
+        self._default_params = tuple(
+            attr for attr in dir(self._configures)
+            if is_param(getattr(self._configures, attr)))
 
     def __contains__(self, key):
         return self in self.get_param(key)
@@ -62,7 +65,7 @@ class ClassParams(object):
     def __str__(self):
         name = self._configures.__name__
         lines = ["Parameters configured for %s:" % name]
-        for attr in list(self.default_params) + list(self.extra_params):
+        for attr in self.params:
             if self in self.get_param(attr):
                 lines.append("  %s: %s" % (attr, getattr(self, attr)))
         if len(lines) > 1:
@@ -105,16 +108,15 @@ class ClassParams(object):
 
     @property
     def default_params(self):
-        return (attr for attr in dir(self._configures)
-                if is_param(getattr(self._configures, attr)))
+        return self._default_params
 
     @property
     def extra_params(self):
-        return list(self._extraparams)
+        return tuple(self._extraparams)
 
     @property
     def params(self):
-        return list(self.default_params) + list(self.extra_params)
+        return self.default_params + self.extra_params
 
 
 class InstanceParams(object):

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -135,7 +135,10 @@ class InstanceParams(object):
 
     def __getattr__(self, key):
         if key in self._clsparams.default_params:
-            raise AttributeError()
+            raise AttributeError(
+                "Cannot configure the built-in parameter '%s' on an instance "
+                "of '%s'. Please get the attribute directly from the object."
+                % (key, self._configures.__class__.__name__))
         param = self._clsparams.get_param(key)
         if self in param:
             return param.__get__(self, self.__class__)
@@ -147,8 +150,10 @@ class InstanceParams(object):
             super(InstanceParams, self).__setattr__(key, value)
         elif key in dir(self._configures):
             # Disallow configuring attributes the instance already has
-            raise AttributeError("'%s' object has no attribute '%s'"
-                                 % (self.__class__.__name__, key))
+            raise AttributeError(
+                "Cannot configure the built-in parameter '%s' on an instance "
+                "of '%s'. Please set the attribute directly on the object."
+                % (key, self._configures.__class__.__name__))
         else:
             self._clsparams.get_param(key).__set__(self, value)
 
@@ -157,8 +162,10 @@ class InstanceParams(object):
             super(InstanceParams, self).__delattr__(key)
         elif key in dir(self._configures):
             # Disallow configuring attributes the instance already has
-            raise AttributeError("'%s' object has no attribute '%s'"
-                                 % (self.__class__.__name__, key))
+            raise AttributeError(
+                "Cannot configure the built-in parameter '%s' on an instance "
+                "of '%s'. Please delete the attribute directly on the object."
+                % (key, self._configures.__class__.__name__))
         else:
             self._clsparams.get_param(key).__delete__(self)
 

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -87,10 +87,8 @@ class ClassParams(object):
     def get_param(self, key):
         if key in self._extraparams:
             return self._extraparams[key]
-        elif key in dir(self._configures):
-            return getattr(self._configures, key)
-        else:
-            raise AttributeError("Unknown config parameter '%s'" % key)
+
+        return getattr(self._configures, key)
 
     def set_param(self, key, value):
         if not is_param(value):


### PR DESCRIPTION
By overloading `__getattr__` instead of `__getattribute__` in the
config system, we avoid throwing and catching AttributeErrors all
the time. Since `__getattr__` is only called if the attribute is
not found normally, it is actually what makes sense in our situation
since we were overloading `__getattribute__` to do exactly this.

Addresses #720.