### PR TITLE
Vector Oja unsupervised encoder learning rule

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -135,6 +135,10 @@ Release History
   `#862 <https://github.com/nengo/nengo/pull/862>`_)
 - Added SPA wrapper for circular convolution networks, ``spa.Bind``
   (`#849 <https://github.com/nengo/nengo/pull/849>`_)
+- Added the ``Voja`` (Vector Oja) learning rule type, which updates an
+  ensemble's encoders to fire selectively for its inputs. (see
+  ``examples/learning/learn_associations.ipynb``).
+  (`#727 <https://github.com/nengo/nengo/issues/727>`_)
 
 **Bug fixes**
 

--- a/examples/learning/learn_associations.ipynb
+++ b/examples/learning/learn_associations.ipynb
@@ -1,0 +1,330 @@
+{
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.3"
+  },
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# Nengo Example: Learning new associations\n",
+      "\n",
+      "Being able to learn an input-output mapping (or a _heteroassociative memory_) is useful for storing and recalling associations. This is also a task required by more complicated models that require some notion of long-term memory.\n",
+      "\n",
+      "In a perfect world, the PES rule could be applied to learn this mapping from examples. However, when two distinct inputs cause the same neurons to fire, their decoded values will depend on one another. This leads to difficulty when trying to store multiple indpendent associations in the same memory.\n",
+      "\n",
+      "To solve this problem, a vector-space analog of Oja's rule, dubbed Vector-Oja's rule (or simply _Voja's rule_) was proposed. In essence, this unsupervised learning rule makes neurons fire selectively in response to their input. When used in conjunction with properly-chosen intercepts (corresponding to the largest dot-product between pairs of inputs), this approach makes it possible to scalably learn new associations in a spiking network.\n",
+      "\n",
+      "Voja's rule works by moving the encoders of the active neurons toward the current input. This can be stated succinctly as,\n",
+      "\n",
+      "$$\n",
+      "\\Delta e_i = \\kappa a_i (x - e_i)\n",
+      "$$\n",
+      "\n",
+      "where $e_i$ is the encoder of the $i^{th}$ neuron, $\\kappa$ is a modulatory learning rate (positive to move towards, and negative to move away), $a_i$ is the filtered activity of the $i^{th}$ neuron, and $x$ is the input vector encoded by each neuron. To see how this is related to Oja's rule, substituting $e_i$ with the row of weights $W_i$, $x$ for the pre-synaptic activity vector $b$, and letting $s = 1 / a_i$ be a dynamic normalizing factor, gives\n",
+      "\n",
+      "$$\n",
+      "\\Delta W_i = \\kappa a_i (b - s a_i W_i)\n",
+      "$$\n",
+      "\n",
+      "which is the update rule for a single row using Oja. For more details, see [Learning large-scale heteroassociative memories in spiking neurons](http://compneuro.uwaterloo.ca/publications/voelker2014a.html).\n",
+      "\n",
+      "This notebook will lead the reader through a basic example of building a network that can store and recall new associations."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Step 1: Configure some example data\n",
+      "\n",
+      "First, we will setup some keys (inputs) and values (outputs) for our network to store and recall."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import numpy as np\n",
+      "import matplotlib.pyplot as plt\n",
+      "%matplotlib inline\n",
+      "\n",
+      "import nengo"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "num_items = 5\n",
+      "\n",
+      "d_key = 2\n",
+      "d_value = 4\n",
+      "\n",
+      "rng = np.random.RandomState(seed=7)\n",
+      "keys = nengo.dists.UniformHypersphere(surface=True).sample(num_items, d_key, rng=rng)\n",
+      "values = nengo.dists.UniformHypersphere(surface=False).sample(num_items, d_value, rng=rng)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "An important quantity is the largest dot-product between all pairs of keys, since a neuron's intercept should not go below this value if it's positioned between these two keys. Otherwise, the neuron will move back and forth between encoding those two inputs."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "intercept = (np.dot(keys, keys.T) - np.eye(num_items)).flatten().max()\n",
+      "print(\"Intercept: %s\" % intercept)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Step 2: Build the model\n",
+      "\n",
+      "We define a helper function that is useful for creating nodes that cycle through keys/values."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def cycle_array(x, period, dt=0.001):\n",
+      "    \"\"\"Cycles through the elements\"\"\"\n",
+      "    i_every = int(round(period/dt))\n",
+      "    if i_every != period/dt:\n",
+      "        raise ValueError(\"dt (%s) does not divide period (%s)\" % (dt, period))\n",
+      "    def f(t):\n",
+      "        i = int(round((t - dt)/dt))  # t starts at dt\n",
+      "        return x[(i/i_every)%len(x)]\n",
+      "    return f"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We create three inputs: the keys, the values, and a modulatory learning signal. The model is run continuously in two phases: the first half learns the set of associations, and the second tests recall.\n",
+      "\n",
+      "The learning signal will be set to 0 to allow learning during the first phase, and -1 to inhibit learning during the second phase.\n",
+      "\n",
+      "The memory is confined to a single ensemble. Roughly speaking, its encoders will hold the keys, and its decoders will hold the values. "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# Model constants\n",
+      "n_neurons = 200\n",
+      "dt = 0.001\n",
+      "period = 0.3\n",
+      "T = period*num_items*2\n",
+      "\n",
+      "# Model network\n",
+      "model = nengo.Network()\n",
+      "with model:\n",
+      "    \n",
+      "    # Create the inputs/outputs\n",
+      "    stim_keys = nengo.Node(output=cycle_array(keys, period, dt))\n",
+      "    stim_values = nengo.Node(output=cycle_array(values, period, dt))\n",
+      "    learning = nengo.Node(output=lambda t: -int(t>=T/2))\n",
+      "    recall = nengo.Node(size_in=d_value)\n",
+      "    \n",
+      "    # Create the memory\n",
+      "    memory = nengo.Ensemble(n_neurons, d_key, intercepts=[intercept]*n_neurons)\n",
+      "    \n",
+      "    # Learn the encoders/keys\n",
+      "    voja = nengo.Voja(post_tau=None, learning_rate=5e-2)\n",
+      "    conn_in = nengo.Connection(stim_keys, memory, synapse=None,\n",
+      "                               learning_rule_type=voja)\n",
+      "    nengo.Connection(learning, conn_in.learning_rule, synapse=None)\n",
+      "    \n",
+      "    # Learn the decoders/values, initialized to a null function\n",
+      "    conn_out = nengo.Connection(memory, recall, learning_rule_type=nengo.PES(1e-3),\n",
+      "                                function=lambda x: np.zeros(d_value))\n",
+      "    \n",
+      "    # Create the error population\n",
+      "    error = nengo.Ensemble(n_neurons, d_value)\n",
+      "    nengo.Connection(learning, error.neurons, transform=[[10.0]]*n_neurons,\n",
+      "                     synapse=None)\n",
+      "    \n",
+      "    # Calculate the error and use it to drive the PES rule\n",
+      "    nengo.Connection(stim_values, error, transform=-1, synapse=None)\n",
+      "    nengo.Connection(recall, error, synapse=None)\n",
+      "    nengo.Connection(error, conn_out.learning_rule)\n",
+      "    \n",
+      "    # Setup probes\n",
+      "    p_keys = nengo.Probe(stim_keys, synapse=None)\n",
+      "    p_values = nengo.Probe(stim_values, synapse=None)\n",
+      "    p_learning = nengo.Probe(learning, synapse=None)\n",
+      "    p_error = nengo.Probe(error, synapse=0.005)\n",
+      "    p_recall = nengo.Probe(recall, synapse=None)\n",
+      "    p_encoders = nengo.Probe(conn_in.learning_rule, 'scaled_encoders')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Step 3: Running the model"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "sim = nengo.Simulator(model, dt=dt)\n",
+      "sim.run(T)\n",
+      "t = sim.trange()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Step 4: Plotting simulation output\n",
+      "\n",
+      "We first start by checking the keys, values, and learning signals."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "plt.figure()\n",
+      "plt.title(\"Keys\")\n",
+      "plt.plot(t, sim.data[p_keys])\n",
+      "plt.ylim(-1, 1)\n",
+      "\n",
+      "plt.figure()\n",
+      "plt.title(\"Values\")\n",
+      "plt.plot(t, sim.data[p_values])\n",
+      "plt.ylim(-1, 1)\n",
+      "\n",
+      "plt.figure()\n",
+      "plt.title(\"Learning\")\n",
+      "plt.plot(t, sim.data[p_learning])\n",
+      "plt.ylim(-1.2, 0.2);"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Next, we look at the error during training and testing. In the top figure, the error being minimized by PES goes to zero for each association during the training phase. In the bottom figure, the recall error is close to zero, with momentary spikes each time a new key is presented."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "train = t<=T/2\n",
+      "test = ~train\n",
+      "\n",
+      "plt.figure()\n",
+      "plt.title(\"Value Error During Training\")\n",
+      "plt.plot(t[train], sim.data[p_error][train])\n",
+      "\n",
+      "plt.figure()\n",
+      "plt.title(\"Value Error During Recall\")\n",
+      "plt.plot(t[test], sim.data[p_recall][test] - sim.data[p_values][test]);"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Step 5: Examining encoder changes\n",
+      "\n",
+      "We can also plot the two-dimensional encoders before and after training. Initially, they are uniformly distributed around the unit circle. Afterward, we see that each key has attracted all of its nearby neurons. Notably, almost all neurons are participating in the representation of a unique association."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "scale = (sim.model.params[memory].gain / memory.radius)[:, np.newaxis]\n",
+      "\n",
+      "def plot_2d(text, xy):\n",
+      "    plt.figure()\n",
+      "    plt.title(text)\n",
+      "    plt.scatter(xy[:, 0], xy[:, 1], label=\"Encoders\")\n",
+      "    plt.scatter(keys[:, 0], keys[:, 1], c='red', s=150, alpha=0.6, label=\"Keys\")\n",
+      "    plt.xlim(-1.5, 1.5)\n",
+      "    plt.ylim(-1.5, 2)\n",
+      "    plt.legend()\n",
+      "    plt.axes().set_aspect('equal')\n",
+      "\n",
+      "plot_2d(\"Before\", sim.data[p_encoders][0].copy() / scale)\n",
+      "plot_2d(\"After\", sim.data[p_encoders][-1].copy() / scale)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -23,7 +23,7 @@ from .node import Node
 from .neurons import (AdaptiveLIF, AdaptiveLIFRate, Direct, Izhikevich, LIF,
                       LIFRate, RectifiedLinear, Sigmoid)
 from .network import Network
-from .learning_rules import PES, BCM, Oja
+from .learning_rules import PES, BCM, Oja, Voja
 from .params import Default
 from .probe import Probe
 from .rc import rc, RC_DEFAULTS

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -210,14 +210,20 @@ def build_connection(model, conn):
 
     # Build learning rules
     if conn.learning_rule is not None:
-        model.add_op(PreserveValue(model.sig[conn]['weights']))
-
         rule = conn.learning_rule
-        if is_iterable(rule):
-            for r in itervalues(rule) if isinstance(rule, dict) else rule:
-                model.build(r)
-        elif rule is not None:
-            model.build(rule)
+        rule = [rule] if not is_iterable(rule) else rule
+        targets = []
+        for r in itervalues(rule) if isinstance(rule, dict) else rule:
+            model.build(r)
+            targets.append(r.modifies)
+
+        if 'encoders' in targets:
+            model.add_op(PreserveValue(model.sig[conn.post_obj]['encoders']))
+        if 'decoders' in targets or 'weights' in targets:
+            if weights.ndim < 2:
+                raise ValueError(
+                    "'transform' must be a 2-dimensional array for learning")
+            model.add_op(PreserveValue(model.sig[conn]['weights']))
 
     model.params[conn] = BuiltConnection(eval_points=eval_points,
                                          solver_info=solver_info,

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -190,9 +190,6 @@ def build_connection(model, conn):
         gain = model.params[conn.post_obj.ensemble].gain[post_slice]
         weights = multiply(gain, weights)
 
-    if conn.learning_rule is not None and weights.ndim < 2:
-        raise ValueError("Learning connection must have full transform matrix")
-
     model.sig[conn]['weights'] = Signal(weights, name="%s.weights" % conn)
     signal = Signal(np.zeros(signal_size), name="%s.weighted" % conn)
     model.add_op(Reset(signal))

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -5,7 +5,7 @@ from nengo.builder.operator import DotInc, ElementwiseInc, Operator, Reset
 from nengo.builder.signal import Signal
 from nengo.connection import LearningRule
 from nengo.ensemble import Ensemble, Neurons
-from nengo.learning_rules import BCM, Oja, PES
+from nengo.learning_rules import BCM, Oja, PES, Voja
 from nengo.node import Node
 from nengo.synapses import Lowpass
 
@@ -83,6 +83,59 @@ class SimOja(Operator):
         return step_simoja
 
 
+class SimVoja(Operator):
+    """Simulates a simplified version of Oja's rule in the vector space.
+
+    See `examples/learning/learn_associations.ipynb` for details.
+
+    Parameters
+    ----------
+    pre_decoded : Signal
+        Decoded activity from pre-synaptic ensemble, `np.dot(d, a)`.
+    post_filtered : Signal
+        Filtered post-synaptic activity signal.
+    scaled_encoders : Signal
+        2d array of encoders, multiplied by `scale`.
+    delta : Signal
+        The change to the encoders. Updated by the rule.
+    scale : np.ndarray
+        The length of each encoder.
+    learning_signal : Signal
+        Scalar signal to be multiplied by the learning_rate. Expected to range
+        between 0 and 1 to turn learning off or on, respectively.
+    learning_rate : float
+        Scalar applied to the delta.
+    """
+
+    def __init__(self, post_filtered, scaled_encoders, scale, x,
+                 learning_signal, learning_rate):
+        self.post_filtered = post_filtered
+        self.scaled_encoders = scaled_encoders
+        self.scale = scale
+        self.x = x
+        self.learning_signal = learning_signal
+        self.learning_rate = learning_rate
+
+        self.reads = [post_filtered, x, learning_signal]
+        self.updates = [scaled_encoders]
+        self.sets = []
+        self.incs = []
+
+    def make_step(self, signals, dt, rng):
+        post_filtered = signals[self.post_filtered]
+        scaled_encoders = signals[self.scaled_encoders]
+        x = signals[self.x]
+        learning_signal = signals[self.learning_signal]
+        learning_rate = self.learning_rate * dt
+        scale = self.scale[:, np.newaxis]
+
+        def step_simvoja():
+            scaled_encoders[...] += learning_rate * learning_signal * (
+                scale * np.outer(post_filtered, x) -
+                post_filtered[:, np.newaxis] * scaled_encoders)
+        return step_simvoja
+
+
 def get_pre_ens(conn):
     return (conn.pre_obj if isinstance(conn.pre_obj, Ensemble)
             else conn.pre_obj.ensemble)
@@ -97,26 +150,23 @@ def get_post_ens(conn):
 def build_learning_rule(model, rule):
     conn = rule.connection
     rule_type = rule.learning_rule_type
-    pre = get_pre_ens(conn)
-    post = get_post_ens(conn)
 
     # --- Set up delta signal and += transform / decoders
-    if not conn.is_decoded:
-        delta = Signal(np.zeros((post.n_neurons, pre.n_neurons)), name='Delta')
-        tag = "omega += delta"
-    elif isinstance(conn.pre_obj, Neurons):
-        delta = Signal(np.zeros((rule.size_in, pre.n_neurons)), name='Delta')
-        tag = "omega += delta"
-    else:
-        delta = Signal(np.zeros((rule.size_in, pre.n_neurons)), name='Delta')
-        tag = "decoders += delta"
+    if rule_type.modifies != 'encoders':
+        pre = get_pre_ens(conn)
+        if not conn.is_decoded:
+            post = get_post_ens(conn)
+            delta = Signal(
+                np.zeros((post.n_neurons, pre.n_neurons)), name='Delta')
+        else:
+            delta = Signal(
+                np.zeros((rule.size_in, pre.n_neurons)), name='Delta')
+        model.add_op(ElementwiseInc(
+            model.sig['common'][1], delta, model.sig[conn]['weights'],
+            tag="omega += delta"))
+        model.sig[rule]['delta'] = delta
 
-    model.add_op(ElementwiseInc(model.sig['common'][1],
-                                delta,
-                                model.sig[conn]['weights'],
-                                tag=tag))
-    model.sig[rule]['delta'] = delta
-    model.build(rule_type, rule)  # Updates delta
+    model.build(rule_type, rule)
 
 
 @Builder.register(BCM)
@@ -164,6 +214,47 @@ def build_oja(model, oja, rule):
     model.params[rule] = None  # no build-time info to return
 
 
+@Builder.register(Voja)
+def build_voja(model, voja, rule):
+    conn = rule.connection
+
+    # Filtered post activity
+    post = conn.post_obj
+    if voja.post_tau is not None:
+        post_filtered = model.build(
+            Lowpass(voja.post_tau), model.sig[post]['out'])
+    else:
+        post_filtered = model.sig[post]['out']
+
+    # Learning signal, defaults to 1 in case no connection is made
+    # and multiplied by the learning_rate * dt
+    learning = Signal(np.zeros(rule.size_in), name="Voja:learning")
+    assert rule.size_in == 1
+    model.add_op(Reset(learning, value=1.0))
+    model.sig[rule]['in'] = learning  # optional connection will attach here
+
+    encoders = model.sig[post]['encoders']  # scaled encoders
+    # The gain and radius are folded into the encoders during the ensemble
+    # build process, so we need to make sure that the deltas are proportional
+    # to this scaling factor
+    encoder_scale = Signal(
+        model.params[post].gain / post.radius, name="Voja:encoder_scale")
+    assert post_filtered.shape == encoder_scale.shape
+
+    model.operators.append(
+        SimVoja(post_filtered=post_filtered,
+                scaled_encoders=model.sig[conn.post]['encoders'],
+                scale=model.params[post].gain / post.radius,
+                x=model.sig[conn]['out'],
+                learning_signal=learning,
+                learning_rate=voja.learning_rate))
+
+    model.sig[rule]['scaled_encoders'] = encoders
+    model.sig[rule]['post_filtered'] = post_filtered
+
+    model.params[rule] = None  # no build-time info to return
+
+
 @Builder.register(PES)
 def build_pes(model, pes, rule):
     conn = rule.connection
@@ -174,11 +265,11 @@ def build_pes(model, pes, rule):
     model.sig[rule]['in'] = error  # error connection will attach here
 
     acts = model.build(Lowpass(pes.pre_tau), model.sig[conn.pre_obj]['out'])
-    acts_view = acts.reshape((1, acts.size))
+    acts_view = acts.row()
 
     # Compute the correction, i.e. the scaled negative error
     correction = Signal(np.zeros(error.shape), name="PES:correction")
-    local_error = correction.reshape((error.size, 1))
+    local_error = correction.column()
     model.add_op(Reset(correction))
 
     # correction = -learning_rate * (dt / n_neurons) * error
@@ -197,7 +288,7 @@ def build_pes(model, pes, rule):
         encoded = Signal(np.zeros(weights.shape[0]), name="PES:encoded")
         model.add_op(Reset(encoded))
         model.add_op(DotInc(encoders, correction, encoded, tag="PES:encode"))
-        local_error = encoded.reshape((encoded.size, 1))
+        local_error = encoded.column()
     elif not isinstance(conn.pre_obj, (Ensemble, Neurons)):
         raise ValueError("'pre' object '%s' not suitable for PES learning"
                          % (conn.pre_obj))

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -101,9 +101,7 @@ def build_learning_rule(model, rule):
     post = get_post_ens(conn)
 
     # --- Set up delta signal and += transform / decoders
-    if conn.solver.weights or (
-            isinstance(conn.pre_obj, Neurons) and
-            isinstance(conn.post_obj, Neurons)):
+    if not conn.is_decoded:
         delta = Signal(np.zeros((post.n_neurons, pre.n_neurons)), name='Delta')
         tag = "omega += delta"
     elif isinstance(conn.pre_obj, Neurons):
@@ -190,9 +188,7 @@ def build_pes(model, pes, rule):
                     name="PES:learning_rate")
     model.add_op(DotInc(lr_sig, error, correction, tag="PES:correct"))
 
-    if conn.solver.weights or (
-            isinstance(conn.pre_obj, Neurons) and
-            isinstance(conn.post_obj, Neurons)):
+    if not conn.is_decoded:
         post = get_post_ens(conn)
         weights = model.sig[conn]['weights']
         encoders = model.sig[post]['encoders']

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -123,6 +123,14 @@ class SignalView(object):
                           elemstrides=elemstrides,
                           offset=self.offset)
 
+    def column(self):
+        """Reshape into a column vector."""
+        return self.reshape((self.size, 1))
+
+    def row(self):
+        """Reshape into a row vector."""
+        return self.reshape((1, self.size))
+
     def transpose(self, neworder=None):
         if neworder:
             raise NotImplementedError()

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -26,9 +26,6 @@ class LearningRuleType(object):
     probeable = []
 
     def __init__(self, learning_rate=1e-6):
-        if learning_rate >= 1.0:
-            warnings.warn("This learning rate is very high, and can result "
-                          "in floating point errors from too much current.")
         self.learning_rate = learning_rate
 
     @property
@@ -70,6 +67,9 @@ class PES(LearningRuleType):
     probeable = ['error', 'correction', 'activities', 'delta']
 
     def __init__(self, learning_rate=1e-4, pre_tau=0.005):
+        if learning_rate >= 1.0:
+            warnings.warn("This learning rate is very high, and can result "
+                          "in floating point errors from too much current.")
         self.pre_tau = pre_tau
         super(PES, self).__init__(learning_rate)
 
@@ -195,6 +195,41 @@ class Oja(LearningRuleType):
         if self.learning_rate != 1e-6:
             args.append("learning_rate=%g" % self.learning_rate)
         return args
+
+
+class Voja(LearningRuleType):
+    """Vector Oja's learning rule.
+
+    Modifies an ensemble's encoders to be selective to its inputs.
+
+    A connection to the learning rule will provide a scalar weight for the
+    learning rate (minus 1). For instance, 0 is normal learning, -1 is no
+    learning, and less than -1 causes anti-learning or "forgetting".
+
+    Parameters
+    ----------
+    learning_rate : float, optional
+        A scalar indicating the rate at which encoders will be adjusted.
+        Defaults to 1e-2.
+    post_tau : float, optional
+        Filter constant on activities of neurons in post population.
+
+    Attributes
+    ----------
+    learning_rate : float
+        The given learning rate.
+    post_tau : float
+        Filter constant on activities of neurons in post population.
+    """
+
+    post_tau = NumberParam(low=0, low_open=True, optional=True)
+    modifies = 'encoders'
+    probeable = ['post_filtered', 'scaled_encoders', 'delta']
+    error_type = 'scalar'
+
+    def __init__(self, post_tau=0.005, learning_rate=1e-2):
+        self.post_tau = post_tau
+        super(Voja, self).__init__(learning_rate)
 
 
 class LearningRuleTypeParam(Parameter):

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -22,7 +22,7 @@ class LearningRuleType(object):
 
     learning_rate = NumberParam(low=0, low_open=True)
     error_type = 'none'
-    modifies = []
+    modifies = None
     probeable = []
 
     def __init__(self, learning_rate=1e-6):
@@ -66,7 +66,7 @@ class PES(LearningRuleType):
 
     pre_tau = NumberParam(low=0, low_open=True)
     error_type = 'decoder'
-    modifies = ['transform', 'decoders']
+    modifies = 'weights'
     probeable = ['error', 'correction', 'activities', 'delta']
 
     def __init__(self, learning_rate=1e-4, pre_tau=0.005):
@@ -116,7 +116,7 @@ class BCM(LearningRuleType):
     post_tau = NumberParam(low=0, low_open=True)
     theta_tau = NumberParam(low=0, low_open=True)
     error_type = 'none'
-    modifies = ['transform']
+    modifies = 'transform'
     probeable = ['theta', 'pre_filtered', 'post_filtered', 'delta']
 
     def __init__(self, pre_tau=0.005, post_tau=None, theta_tau=1.0,
@@ -173,7 +173,7 @@ class Oja(LearningRuleType):
     post_tau = NumberParam(low=0, low_open=True)
     beta = NumberParam(low=0)
     error_type = 'none'
-    modifies = ['transform']
+    modifies = 'transform'
     probeable = ['pre_filtered', 'post_filtered', 'delta']
 
     def __init__(self, pre_tau=0.005, post_tau=None, beta=1.0,

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -149,11 +149,10 @@ def test_unsupervised(Simulator, learning_rule_type, seed, rng, plt):
     with m:
         u = nengo.Node(WhiteSignal(0.5, high=5), size_out=2)
         a = nengo.Ensemble(n, dimensions=2)
-        b = nengo.Ensemble(n, dimensions=2)
+        b = nengo.Ensemble(n+1, dimensions=2)
 
         initial_weights = rng.uniform(
-            high=1e-3,
-            size=(a.n_neurons, b.n_neurons))
+            high=1e-3, size=(b.n_neurons, a.n_neurons))
 
         nengo.Connection(u, a)
         conn = nengo.Connection(a.neurons, b.neurons,


### PR DESCRIPTION
This is a rewritten implementation based on code from the `voja` branch, commit 0e9ddabe4f0f8a084918d1e0e87f88981260f591. 

The above branch/rule appeared in [A spiking neural model of episodic memory encoding and replay in hippocampus](http://compneuro.uwaterloo.ca/publications/trujillo2014a.html), and exists here without any significant changes.

One difference is this now uses the unmodulated learning syntax. Another difference is the implementation is done with pure signals and ops. Lastly, it's invariant under `dt` (so previously used learning rates need to be adjusted).

The PR includes some unit tests and an example notebook to demonstrate use and correctness. Currently waiting on #642 (`learning-unmodulated` branch).