### PR TITLE
Combined decoders and transform

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,12 @@ Release History
   This was only used for learning rules to this point, and has been removed
   in favor of connecting directly to the learning rule.
   (`#642 <https://github.com/nengo/nengo/pull/642>`_)
+- Connection weights can now be probed with ``nengo.Probe(conn, 'weights')``,
+  and these are always the weights that will change with learning
+  regardless of the type of connection. Previously, either ``decoders`` or
+  ``transform`` may have changed depending on the type of connection;
+  it is now no longer possible to probe ``decoders`` or ``transform``.
+  (`#729 <https://github.com/nengo/nengo/pull/729>`_)
 
 **Behavioural changes**
 

--- a/examples/learning/learn_communication_channel.ipynb
+++ b/examples/learning/learn_communication_channel.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "learn_communication_channel",
-  "signature": "sha256:f556121632879361056af69de250aa084b7cfcf67b0a245c3546933a203470b1"
+  "signature": "sha256:f8a20d622b813a84ad4e3c6a6580cf79a3779a2a1f78eb121482093f2266b32f"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -319,7 +319,7 @@
      "collapsed": false,
      "input": [
       "with model:\n",
-      "    dec_p = nengo.Probe(conn, 'decoders', synapse=0.01, sample_every=0.01)"
+      "    weights_p = nengo.Probe(conn, 'weights', synapse=0.01, sample_every=0.01)"
      ],
      "language": "python",
      "metadata": {},
@@ -354,7 +354,7 @@
       "plt.ylabel(\"Dimension 2\")\n",
       "plt.legend(loc='best')\n",
       "plt.subplot(3, 1, 3)\n",
-      "plt.plot(sim.trange(dt=0.01), sim.data[dec_p][..., 10])\n",
+      "plt.plot(sim.trange(dt=0.01), sim.data[weights_p][..., 10])\n",
       "plt.ylabel(\"Decoding weight\")\n",
       "plt.legend((\"Decoder 10[0]\", \"Decoder 10[1]\"), loc='best');"
      ],
@@ -369,8 +369,7 @@
       "from nengo.solvers import LstsqL2\n",
       "with model:\n",
       "    # Change the connection to use connection weights instead of decoders\n",
-      "    conn.solver = LstsqL2(weights=True)\n",
-      "    trans_p = nengo.Probe(conn, 'transform', synapse=0.01, sample_every=0.01)"
+      "    conn.solver = LstsqL2(weights=True)"
      ],
      "language": "python",
      "metadata": {},
@@ -405,7 +404,7 @@
       "plt.ylabel(\"Dimension 2\")\n",
       "plt.legend(loc='best')\n",
       "plt.subplot(3, 1, 3)\n",
-      "plt.plot(sim.trange(dt=0.01), sim.data[trans_p][..., 10])\n",
+      "plt.plot(sim.trange(dt=0.01), sim.data[weights_p][..., 10])\n",
       "plt.ylabel(\"Connection weight\");"
      ],
      "language": "python",

--- a/examples/learning/learn_unsupervised.ipynb
+++ b/examples/learning/learn_unsupervised.ipynb
@@ -13,7 +13,7 @@
    "version": "2.7.5"
   },
   "name": "",
-  "signature": "sha256:e28c3728259f59d751722e679da0f64965dc19718bdca1da0e451f5144db5cda"
+  "signature": "sha256:a5e1df2986e3c7c1b1e924e3a0483fb80f143fa0d2da5d21ad6cd6b507781e35"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -138,7 +138,7 @@
      "input": [
       "conn.learning_rule_type = nengo.BCM(learning_rate=5e-10)\n",
       "with model:\n",
-      "    trans_p = nengo.Probe(conn, 'transform', synapse=0.01, sample_every=0.01)"
+      "    weights_p = nengo.Probe(conn, 'weights', synapse=0.01, sample_every=0.01)"
      ],
      "language": "python",
      "metadata": {},
@@ -168,8 +168,8 @@
       "plt.legend(loc=\"lower left\")\n",
       "plt.subplot(2, 1, 2)\n",
       "# Find weight row with max variance\n",
-      "neuron = np.argmax(np.mean(np.var(sim.data[trans_p], axis=0), axis=1))\n",
-      "plt.plot(sim.trange(dt=0.01), sim.data[trans_p][..., neuron])\n",
+      "neuron = np.argmax(np.mean(np.var(sim.data[weights_p], axis=0), axis=1))\n",
+      "plt.plot(sim.trange(dt=0.01), sim.data[weights_p][..., neuron])\n",
       "plt.ylabel(\"Connection weight\");"
      ],
      "language": "python",
@@ -203,8 +203,8 @@
       "    summation = np.sum((v / l1norm) * ((n - k + 0.5) / n))\n",
       "    return 1 - 2 * summation\n",
       "\n",
-      "print(\"Starting sparsity: {0}\".format(sparsity_measure(sim.data[trans_p][0])))\n",
-      "print(\"Ending sparsity: {0}\".format(sparsity_measure(sim.data[trans_p][-1])))"
+      "print(\"Starting sparsity: {0}\".format(sparsity_measure(sim.data[weights_p][0])))\n",
+      "print(\"Ending sparsity: {0}\".format(sparsity_measure(sim.data[weights_p][-1])))"
      ],
      "language": "python",
      "metadata": {},
@@ -251,11 +251,11 @@
       "plt.legend(loc=\"lower left\")\n",
       "plt.subplot(2, 1, 2)\n",
       "# Find weight row with max variance\n",
-      "neuron = np.argmax(np.mean(np.var(sim.data[trans_p], axis=0), axis=1))\n",
-      "plt.plot(sim.trange(dt=0.01), sim.data[trans_p][..., neuron])\n",
+      "neuron = np.argmax(np.mean(np.var(sim.data[weights_p], axis=0), axis=1))\n",
+      "plt.plot(sim.trange(dt=0.01), sim.data[weights_p][..., neuron])\n",
       "plt.ylabel(\"Connection weight\")\n",
-      "print(\"Starting sparsity: {0}\".format(sparsity_measure(sim.data[trans_p][0])))\n",
-      "print(\"Ending sparsity: {0}\".format(sparsity_measure(sim.data[trans_p][-1])))"
+      "print(\"Starting sparsity: {0}\".format(sparsity_measure(sim.data[weights_p][0])))\n",
+      "print(\"Ending sparsity: {0}\".format(sparsity_measure(sim.data[weights_p][-1])))"
      ],
      "language": "python",
      "metadata": {},
@@ -312,11 +312,11 @@
       "plt.legend(loc=\"lower left\")\n",
       "plt.subplot(2, 1, 2)\n",
       "# Find weight row with max variance\n",
-      "neuron = np.argmax(np.mean(np.var(sim.data[trans_p], axis=0), axis=1))\n",
-      "plt.plot(sim.trange(dt=0.01), sim.data[trans_p][..., neuron])\n",
+      "neuron = np.argmax(np.mean(np.var(sim.data[weights_p], axis=0), axis=1))\n",
+      "plt.plot(sim.trange(dt=0.01), sim.data[weights_p][..., neuron])\n",
       "plt.ylabel(\"Connection weight\")\n",
-      "print(\"Starting sparsity: {0}\".format(sparsity_measure(sim.data[trans_p][0])))\n",
-      "print(\"Ending sparsity: {0}\".format(sparsity_measure(sim.data[trans_p][-1])))"
+      "print(\"Starting sparsity: {0}\".format(sparsity_measure(sim.data[weights_p][0])))\n",
+      "print(\"Ending sparsity: {0}\".format(sparsity_measure(sim.data[weights_p][-1])))"
      ],
      "language": "python",
      "metadata": {},

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -6,19 +6,19 @@ import nengo.utils.numpy as npext
 from nengo.builder.builder import Builder
 from nengo.builder.ensemble import gen_eval_points, get_activities
 from nengo.builder.node import SimPyFunc
-from nengo.builder.operator import DotInc, ElementwiseInc, PreserveValue, Reset
+from nengo.builder.operator import (
+    DotInc, ElementwiseInc, PreserveValue, Reset, SlicedCopy)
 from nengo.builder.signal import Signal
 from nengo.builder.synapses import filtered_signal
 from nengo.connection import Connection
 from nengo.ensemble import Ensemble, Neurons
 from nengo.neurons import Direct
 from nengo.node import Node
-from nengo.utils.builder import full_transform
 from nengo.utils.compat import is_iterable, itervalues
 
 
 BuiltConnection = collections.namedtuple(
-    'BuiltConnection', ['decoders', 'eval_points', 'transform', 'solver_info'])
+    'BuiltConnection', ['eval_points', 'solver_info', 'weights'])
 
 
 def get_eval_points(model, conn, rng):
@@ -54,6 +54,29 @@ def build_linear_system(model, conn, rng):
     return eval_points, activities, targets
 
 
+def multiply(x, y):
+    if x.ndim <= 2 and y.ndim < 2:
+        return x * y
+    elif x.ndim < 2 and y.ndim == 2:
+        return x.reshape(-1, 1) * y
+    elif x.ndim == 2 and y.ndim == 2:
+        return np.dot(x, y)
+    else:
+        raise ValueError("Tensors not supported (x.ndim = %d, y.ndim = %d)"
+                         % (x.ndim, y.ndim))
+
+
+def slice_signal(model, signal, sl):
+    assert signal.ndim == 1
+    if isinstance(sl, slice) and (sl.step is None or sl.step == 1):
+        return signal[sl]
+    else:
+        size = np.arange(signal.size)[sl].size
+        sliced_signal = Signal(np.zeros(size), name="%s.sliced" % signal.name)
+        model.add_op(SlicedCopy(signal, sliced_signal, a_slice=sl))
+        return sliced_signal
+
+
 @Builder.register(Connection)  # noqa: C901
 def build_connection(model, conn):
     # Create random number generator
@@ -78,27 +101,29 @@ def build_connection(model, conn):
     model.sig[conn]['in'] = get_prepost_signal(is_pre=True)
     model.sig[conn]['out'] = get_prepost_signal(is_pre=False)
 
-    decoders = None
+    weights = None
     eval_points = None
     solver_info = None
-    transform = full_transform(conn, slice_pre=False)
+    signal_size = conn.size_out
+    post_slice = conn.post_slice
 
     # Figure out the signal going across this connection
+    in_signal = model.sig[conn]['in']
     if (isinstance(conn.pre_obj, Node) or
             (isinstance(conn.pre_obj, Ensemble) and
              isinstance(conn.pre_obj.neuron_type, Direct))):
         # Node or Decoded connection in directmode
-        if (conn.function is None and isinstance(conn.pre_slice, slice) and
-                (conn.pre_slice.step is None or conn.pre_slice.step == 1)):
-            signal = model.sig[conn]['in'][conn.pre_slice]
-        else:
-            signal = Signal(np.zeros(conn.size_mid), name='%s.func' % conn)
-            fn = ((lambda x: x[conn.pre_slice]) if conn.function is None else
-                  (lambda x: conn.function(x[conn.pre_slice])))
+        sliced_in = slice_signal(model, in_signal, conn.pre_slice)
+
+        if conn.function is not None:
+            in_signal = Signal(np.zeros(conn.size_mid), name='%s.func' % conn)
             model.add_op(SimPyFunc(
-                output=signal, fn=fn, t_in=False, x=model.sig[conn]['in']))
-    elif isinstance(conn.pre_obj, Ensemble):
-        # Normal decoded connection
+                output=in_signal, fn=conn.function,
+                t_in=False, x=sliced_in))
+        else:
+            in_signal = sliced_in
+
+    elif isinstance(conn.pre_obj, Ensemble):  # Normal decoded connection
         eval_points, activities, targets = build_linear_system(
             model, conn, rng)
 
@@ -107,83 +132,51 @@ def build_connection(model, conn):
 
         if conn.solver.weights:
             # include transform in solved weights
-            targets = np.dot(targets, transform.T)
-            transform = np.array(1., dtype=np.float64)
-
-            decoders, solver_info = solver(
-                activities, targets, rng=rng,
-                E=model.params[conn.post_obj].scaled_encoders.T)
+            targets = multiply(targets, conn.transform.T)
+            E = model.params[conn.post_obj].scaled_encoders.T[post_slice]
+            decoders, solver_info = solver(activities, targets, rng=rng, E=E)
             model.sig[conn]['out'] = model.sig[conn.post_obj.neurons]['in']
-            signal_size = model.sig[conn]['out'].size
+            signal_size = conn.post_obj.neurons.size_in
+            post_slice = Ellipsis  # don't apply slice later
+            weights = decoders.T
         else:
             decoders, solver_info = solver(activities, targets, rng=rng)
-            signal_size = conn.size_mid
-
-        # Add operator for decoders
-        decoders = decoders.T
-
-        model.sig[conn]['decoders'] = Signal(
-            decoders, name="%s.decoders" % conn)
-        signal = Signal(np.zeros(signal_size), name=str(conn))
-        model.add_op(Reset(signal))
-        model.add_op(DotInc(model.sig[conn]['decoders'],
-                            model.sig[conn]['in'],
-                            signal,
-                            tag="%s decoding" % conn))
+            weights = multiply(conn.transform, decoders.T)
     else:
-        # Direct connection
-        signal = model.sig[conn]['in']
+        in_signal = slice_signal(model, in_signal, conn.pre_slice)
+
+    # Add operator for applying weights
+    if weights is None:
+        weights = np.array(conn.transform)
+
+    if isinstance(conn.post_obj, Neurons):
+        gain = model.params[conn.post_obj.ensemble].gain[post_slice]
+        weights = multiply(gain, weights)
+
+    if conn.learning_rule is not None and weights.ndim < 2:
+        raise ValueError("Learning connection must have full transform matrix")
+
+    model.sig[conn]['weights'] = Signal(weights, name="%s.weights")
+    signal = Signal(np.zeros(signal_size), name="%s.weighted")
+    model.add_op(Reset(signal))
+    op = ElementwiseInc if weights.ndim < 2 else DotInc
+    model.add_op(op(model.sig[conn]['weights'],
+                    in_signal,
+                    signal,
+                    tag="%s.weights_elementwiseinc" % conn))
 
     # Add operator for filtering
     if conn.synapse is not None:
         signal = filtered_signal(model, conn, signal, conn.synapse)
 
-    # Add operator for transform
-    if isinstance(conn.post_obj, Neurons):
-        if not model.has_built(conn.post_obj.ensemble):
-            # Since it hasn't been built, it wasn't added to the Network,
-            # which is most likely because the Neurons weren't associated
-            # with an Ensemble.
-            raise RuntimeError("Connection '%s' refers to Neurons '%s' "
-                               "that are not a part of any Ensemble." % (
-                                   conn, conn.post_obj))
-
-        if conn.post_slice != slice(None):
-            raise NotImplementedError(
-                "Post-slices on connections to neurons are not implemented")
-
-        gain = model.params[conn.post_obj.ensemble].gain[conn.post_slice]
-        if transform.ndim < 2:
-            transform = transform * gain
-        else:
-            transform *= gain[:, np.newaxis]
-
-    model.sig[conn]['transform'] = Signal(transform,
-                                          name="%s.transform" % conn)
-    if transform.ndim < 2:
-        model.add_op(ElementwiseInc(model.sig[conn]['transform'],
-                                    signal,
-                                    model.sig[conn]['out'],
-                                    tag=str(conn)))
-    else:
-        model.add_op(DotInc(model.sig[conn]['transform'],
-                            signal,
-                            model.sig[conn]['out'],
-                            tag=str(conn)))
+    # Copy to the proper slice
+    model.add_op(SlicedCopy(
+        signal, model.sig[conn]['out'], b_slice=post_slice,
+        inc=True, tag="%s.gain" % conn))
 
     # Build learning rules
-    if conn.learning_rule:
-        if isinstance(conn.pre_obj, Ensemble):
-            model.add_op(PreserveValue(model.sig[conn]['decoders']))
-        else:
-            model.add_op(PreserveValue(model.sig[conn]['transform']))
-
-        if isinstance(conn.pre_obj, Ensemble) and conn.solver.weights:
-            # TODO: make less hacky.
-            # Have to do this because when a weight_solver
-            # is provided, then learning rules should operate on
-            # "decoders" which is really the weight matrix.
-            model.sig[conn]['transform'] = model.sig[conn]['decoders']
+    if conn.learning_rule is not None:
+        model.add_op(PreserveValue(model.sig[conn]['weights']))
 
         rule = conn.learning_rule
         if is_iterable(rule):
@@ -192,7 +185,6 @@ def build_connection(model, conn):
         elif rule is not None:
             model.build(rule)
 
-    model.params[conn] = BuiltConnection(decoders=decoders,
-                                         eval_points=eval_points,
-                                         transform=transform,
-                                         solver_info=solver_info)
+    model.params[conn] = BuiltConnection(eval_points=eval_points,
+                                         solver_info=solver_info,
+                                         weights=weights)

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -177,20 +177,18 @@ class Reset(Operator):
 class Copy(Operator):
     """Assign the value of one signal to another."""
 
-    def __init__(self, dst, src, as_update=False, tag=None):
+    def __init__(self, dst, src, tag=None):
         self.dst = dst
         self.src = src
-        self.as_update = as_update
         self.tag = tag
 
-        self.sets = [] if as_update else [dst]
+        self.sets = [dst]
         self.incs = []
         self.reads = [src]
-        self.updates = [dst] if as_update else []
+        self.updates = []
 
     def __str__(self):
-        return 'Copy(%s -> %s, as_update=%s)' % (
-            str(self.src), str(self.dst), self.as_update)
+        return 'Copy(%s -> %s)' % (self.src, self.dst)
 
     def make_step(self, signals, dt, rng):
         dst = signals[self.dst]
@@ -310,7 +308,7 @@ class DotInc(Operator):
     with NengoOCL.
     """
 
-    def __init__(self, A, X, Y, as_update=False, tag=None):
+    def __init__(self, A, X, Y, tag=None):
         if X.ndim >= 2 and any(d > 1 for d in X.shape[1:]):
             raise ValueError("X must be a column vector")
         if Y.ndim >= 2 and any(d > 1 for d in Y.shape[1:]):
@@ -319,13 +317,12 @@ class DotInc(Operator):
         self.A = A
         self.X = X
         self.Y = Y
-        self.as_update = as_update
         self.tag = tag
 
         self.sets = []
-        self.incs = [] if as_update else [Y]
+        self.incs = [Y]
         self.reads = [A, X]
-        self.updates = [Y] if as_update else []
+        self.updates = []
 
     def __str__(self):
         return 'DotInc(%s, %s -> %s "%s")' % (

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -201,6 +201,41 @@ class Copy(Operator):
         return step
 
 
+class SlicedCopy(Operator):
+    """Copy from `a` to `b` with slicing: `b[b_slice] = a[a_slice]`"""
+    def __init__(self, a, b, a_slice=Ellipsis, b_slice=Ellipsis,
+                 inc=False, tag=None):
+        self.a = a
+        self.b = b
+        self.a_slice = a_slice
+        self.b_slice = b_slice
+        self.inc = inc
+        self.tag = tag
+
+        self.sets = [] if inc else [b]
+        self.incs = [b] if inc else []
+        self.reads = [a]
+        self.updates = []
+
+    def __str__(self):
+        return 'SlicedCopy(%s[%s] -> %s[%s], inc=%s)' % (
+            self.a, self.a_slice, self.b, self.b_slice, self.inc)
+
+    def make_step(self, signals, dt, rng):
+        a = signals[self.a]
+        b = signals[self.b]
+        a_slice = self.a_slice
+        b_slice = self.b_slice
+        inc = self.inc
+
+        def step():
+            if inc:
+                b[b_slice] += a[a_slice]
+            else:
+                b[b_slice] = a[a_slice]
+        return step
+
+
 class ElementwiseInc(Operator):
     """Increment signal Y by A * X (with broadcasting)"""
 

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -53,11 +53,11 @@ class ConnectionSolverParam(SolverParam):
     def validate(self, conn, solver):
         super(ConnectionSolverParam, self).validate(conn, solver)
         if solver is not None:
-            if solver.weights and not isinstance(conn.pre, Ensemble):
+            if solver.weights and not isinstance(conn.pre_obj, Ensemble):
                 raise ValueError(
                     "weight solvers only work for connections from ensembles "
                     "(got '%s')" % conn.pre.__class__.__name__)
-            if solver.weights and not isinstance(conn.post, Ensemble):
+            if solver.weights and not isinstance(conn.post_obj, Ensemble):
                 raise ValueError(
                     "weight solvers only work for connections to ensembles "
                     "(got '%s')" % conn.post.__class__.__name__)
@@ -271,11 +271,7 @@ class Connection(NengoObject):
 
     @property
     def probeable(self):
-        probeables = ["output", "input", "transform"]
-        if isinstance(self.pre, Ensemble):
-            probeables += ["decoders"]
-
-        return probeables
+        return ['output', 'input', 'weights']
 
     @property
     def pre_obj(self):

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -370,7 +370,7 @@ class LearningRule(object):
             if isinstance(self.connection.pre_obj, Neurons):
                 return self.connection.pre_obj.ensemble.dimensions
             elif isinstance(self.connection.pre_obj, Ensemble):
-                return self.connection.size_mid
+                return self.connection.size_out
             else:
                 raise ValueError("Cannot learn on '%s' type" % (
                     self.connection.pre_obj.__class__.__name__))

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -49,7 +49,7 @@ def test_seeding(RefSimulator):
     compare_objs(As[0], As[2], ens_attrs, equal=False)
     compare_objs(Bs[0], Bs[2], ens_attrs, equal=False)
 
-    conn_attrs = ('decoders', 'eval_points')  # transform is static, unchecked
+    conn_attrs = ('eval_points', 'weights')
     Cs = [mi[C] for mi in [m1, m2, m3]]
     compare_objs(Cs[0], Cs[1], conn_attrs)
     compare_objs(Cs[0], Cs[2], conn_attrs, equal=False)

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -6,7 +6,7 @@ import pytest
 import nengo
 from nengo.builder import Model
 from nengo.builder.ensemble import BuiltEnsemble
-from nengo.builder.operator import DotInc
+from nengo.builder.operator import DotInc, PreserveValue
 from nengo.builder.signal import Signal, SignalDict
 from nengo.utils.compat import itervalues
 
@@ -120,8 +120,8 @@ def test_signal_init_values(RefSimulator):
     array = Signal([1, 2, 3])
 
     m = Model(dt=0)
-    m.operators += [DotInc(zero, zero, five, as_update=True),
-                    DotInc(zeroarray, one, array, as_update=True)]
+    m.operators += [PreserveValue(five), PreserveValue(array),
+                    DotInc(zero, zero, five), DotInc(zeroarray, one, array)]
 
     sim = RefSimulator(None, model=m)
     assert sim.signals[zero][0] == 0

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -42,8 +42,7 @@ def _test_pes(Simulator, nl, plt, seed,
         b_p = nengo.Probe(bslice, synapse=0.03)
         e_p = nengo.Probe(e, synapse=0.03)
 
-        target = 'transform' if pre_neurons or weight_solver else 'decoders'
-        weights_p = nengo.Probe(conn, target, sample_every=0.01)
+        weights_p = nengo.Probe(conn, 'weights', sample_every=0.01)
         corr_p = nengo.Probe(conn.learning_rule, 'correction', synapse=0.03)
 
     sim = Simulator(model)
@@ -126,7 +125,7 @@ def test_unsupervised(Simulator, learning_rule_type, seed, rng, plt):
                                 transform=initial_weights,
                                 learning_rule_type=learning_rule_type)
         inp_p = nengo.Probe(u)
-        trans_p = nengo.Probe(conn, 'transform', sample_every=0.01)
+        weights_p = nengo.Probe(conn, 'weights', sample_every=0.01)
 
         ap = nengo.Probe(a, synapse=0.03)
         up = nengo.Probe(b, synapse=0.03)
@@ -141,11 +140,11 @@ def test_unsupervised(Simulator, learning_rule_type, seed, rng, plt):
     plt.plot(t, sim.data[up], label="Post")
     plt.legend(loc="best", fontsize="x-small")
     plt.subplot(2, 1, 2)
-    plt.plot(sim.trange(dt=0.01), sim.data[trans_p][..., 4])
+    plt.plot(sim.trange(dt=0.01), sim.data[weights_p][..., 4])
     plt.xlabel("Time (s)")
-    plt.ylabel("Transform weight")
+    plt.ylabel("Weights")
 
-    assert not np.all(sim.data[trans_p][0] == sim.data[trans_p][-1])
+    assert not np.all(sim.data[weights_p][0] == sim.data[weights_p][-1])
 
 
 def learning_net(learning_rule, net, rng):
@@ -165,8 +164,8 @@ def learning_net(learning_rule, net, rng):
             nengo.Connection(err, conn.learning_rule)
 
         activity_p = nengo.Probe(pre.neurons, synapse=0.01)
-        trans_p = nengo.Probe(conn, 'transform', synapse=.01, sample_every=.01)
-    return net, activity_p, trans_p
+        weights_p = nengo.Probe(conn, 'weights', synapse=.01, sample_every=.01)
+    return net, activity_p, weights_p
 
 
 @pytest.mark.parametrize('learning_rule', [nengo.PES, nengo.BCM, nengo.Oja])

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -2,9 +2,6 @@ import numpy as np
 
 import nengo
 import nengo.simulator
-from nengo.builder import Model
-from nengo.builder.operator import Copy, Reset, DotInc
-from nengo.builder.signal import Signal
 
 
 def test_steps(RefSimulator):
@@ -46,34 +43,6 @@ def test_trange_with_probes(Simulator):
     sim.run(0.333)
     for i, p in enumerate(periods):
         assert len(sim.trange(p)) == len(sim.data[probes[i]])
-
-
-def test_signal_indexing_1(RefSimulator):
-    one = Signal(np.zeros(1), name="a")
-    two = Signal(np.zeros(2), name="b")
-    three = Signal(np.zeros(3), name="c")
-    tmp = Signal(np.zeros(3), name="tmp")
-
-    m = Model(dt=0.001)
-    m.operators += [
-        Reset(one), Reset(two), Reset(tmp),
-        DotInc(Signal(1, name="A1"), three[:1], one),
-        DotInc(Signal(2.0, name="A2"), three[1:], two),
-        DotInc(
-            Signal([[0, 0, 1], [0, 1, 0], [1, 0, 0]], name="A3"), three, tmp),
-        Copy(src=tmp, dst=three, as_update=True),
-    ]
-
-    sim = RefSimulator(None, model=m)
-    sim.signals[three] = np.asarray([1, 2, 3])
-    sim.step()
-    assert np.all(sim.signals[one] == 1)
-    assert np.all(sim.signals[two] == [4, 6])
-    assert np.all(sim.signals[three] == [3, 2, 1])
-    sim.step()
-    assert np.all(sim.signals[one] == 3)
-    assert np.all(sim.signals[two] == [4, 2])
-    assert np.all(sim.signals[three] == [1, 2, 3])
 
 
 def test_probedict():

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -95,11 +95,8 @@ def eval_point_decoding(conn, sim, eval_points=None):
     else:
         eval_points = np.asarray(eval_points)
 
-    decoders = sim.data[conn].decoders
-    if decoders is None:
-        raise ValueError("Connection must have decoders")
-
+    weights = sim.data[conn].weights
     activities = get_activities(sim.model, conn.pre_obj, eval_points)
-    decoded = np.dot(activities, decoders.T)
+    decoded = np.dot(activities, weights.T)
     targets = get_targets(sim.model, conn, eval_points)
     return eval_points, targets, decoded


### PR DESCRIPTION
I combined `decoders` and `transform` in the connection builder. This makes things a lot cleaner, and it should be easier for users too, since they don't have to decide between probing 'transform' or 'decoders' when doing learning (right now it depends on the type of connection).

I also improved slicing, so we support slicing on neuron-to-neuron connections.