### PR TITLE
Fixed tests for seed bug in numpy 1.8.0

### DIFF
--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -157,7 +157,10 @@ def function_seed(function, mod=0):
     hash_list = os.path.normpath(path).split(os.path.sep) + [c.co_name]
     hash_string = ensure_bytes('/'.join(hash_list))
     i = int(hashlib.md5(hash_string).hexdigest()[:15], 16)
-    return (i + mod) % npext.maxint
+    s = (i + mod) % npext.maxint
+    int_s = int(s)  # numpy 1.8.0 bug when RandomState on long type inputs
+    assert type(int_s) == int  # should not still be a long because < maxint
+    return int_s
 
 
 @pytest.fixture


### PR DESCRIPTION
Got some weirdness on my Windows 64-bit Python install:

    >>> seed = function_seed(function_seed)
    >>> seed
    581567418L
    >>> seed > npext.maxint
    False
    >>> np.random.RandomState(seed)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "mtrand.pyx", line 564, in mtrand.RandomState.__init__(numpy\random\mtrand\mtrand.c:5217)
      File "mtrand.pyx", line 600, in mtrand.RandomState.seed (numpy\random\mtrand\mtrand.c:5468)
    ValueError: object of too small depth for desired array
    >>> np.random.RandomState(int(seed))
    <mtrand.RandomState object at 0x0000000005D3B030>
    >>> int(seed) == seed
    True
    >>> np.__version__
    '1.8.0'

Basically, you can't pass longs to `RandomState`, even if they are `< npext.maxint`. This breaks most of the tests on my box atm. The fix is to cast it to `int`. 
