### PR TITLE
Support slicing with numpy arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,8 @@ Release History
 - Added ``[progress]`` section to ``nengorc`` which allows setting
   ``progress_bar`` and ``updater``.
   (`#693 <https://github.com/nengo/nengo/pull/693>`_)
+- Numpy arrays can now be used as indices for slicing objects.
+  (`#754 <https://github.com/nengo/nengo/pull/754>`_)
 
 **Bug fixes**
 

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from nengo.config import Config
 from nengo.params import Default, is_param, Parameter, Unconfigurable
-from nengo.utils.compat import with_metaclass
+from nengo.utils.compat import is_integer, with_metaclass
 
 
 class NetworkMember(type):
@@ -89,15 +89,15 @@ class ObjView(object):
     """Container for a slice with respect to some object.
 
     This is used by the __getitem__ of Neurons, Node, and Ensemble, in order
-    to pass slices of those objects to Connect. This is a notational
-    convenience for creating transforms. See Connect for details.
+    to pass slices of those objects to Connection. This is a notational
+    convenience for creating transforms. See Connection for details.
 
     Does not currently support any other view-like operations.
     """
 
     def __init__(self, obj, key=slice(None)):
         self.obj = obj
-        if isinstance(key, int):
+        if is_integer(key):
             # single slices of the form [i] should be cast into
             # slice objects for convenience
             if key == -1:
@@ -131,16 +131,15 @@ class ObjView(object):
 
     @property
     def _slice_string(self):
-        if isinstance(self.slice, list):
-            sl_str = self.slice
-        else:
+        if isinstance(self.slice, slice):
             sl_start = "" if self.slice.start is None else self.slice.start
             sl_stop = "" if self.slice.stop is None else self.slice.stop
             if self.slice.step is None:
-                sl_str = "%s:%s" % (sl_start, sl_stop)
+                return "%s:%s" % (sl_start, sl_stop)
             else:
-                sl_str = "%s:%s:%s" % (sl_start, sl_stop, self.slice.step)
-        return str(sl_str)
+                return "%s:%s:%s" % (sl_start, sl_stop, self.slice.step)
+        else:
+            return str(self.slice)
 
     def __str__(self):
         return "%s[%s]" % (self.obj, self._slice_string)

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -3,7 +3,7 @@ import weakref
 
 import numpy as np
 
-from nengo.utils.compat import is_integer, is_ndarray, is_number, is_string
+from nengo.utils.compat import is_array, is_integer, is_number, is_string
 from nengo.utils.numpy import compare
 from nengo.utils.stdlib import checked_call
 
@@ -132,7 +132,7 @@ class NumberParam(Parameter):
         super(NumberParam, self).__init__(default, optional, readonly)
 
     def __set__(self, instance, value):
-        if is_ndarray(value) and value.shape == ():
+        if is_array(value) and value.shape == ():
             value = value.item()  # convert scalar array to Python object
         super(NumberParam, self).__set__(instance, value)
 

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -384,7 +384,7 @@ def test_slicing(Simulator, nl, plt, seed):
     y2[s2b] = np.dot(T2, x[s2a])
 
     s3a = [2, 0]
-    s3b = [0, 2]
+    s3b = np.asarray([0, 2])  # test slicing with numpy array
     T3 = [0.5, 0.75]
     y3 = np.zeros(3)
     y3[s3b] = np.dot(np.diag(T3), x[s3a])

--- a/nengo/utils/builder.py
+++ b/nengo/utils/builder.py
@@ -31,7 +31,8 @@ def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
                  slice(None))
     post_slice = conn.post_slice if slice_post else slice(None)
 
-    if pre_slice == slice(None) and post_slice == slice(None):
+    eq_none_slice = lambda s: isinstance(s, slice) and s == slice(None)
+    if eq_none_slice(pre_slice) and eq_none_slice(post_slice):
         if transform.ndim == 2:
             # transform is already full, so return a copy
             return np.array(transform)

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -83,11 +83,6 @@ def is_iterable(obj):
     return isinstance(obj, collections.Iterable)
 
 
-def is_ndarray(obj):
-    # np.generic allows us to return true for scalars as well as true arrays
-    return isinstance(obj, (np.ndarray, np.generic))
-
-
 def is_number(obj, check_complex=False):
     types = ((float, complex, np.number) if check_complex else
              (float, np.floating))
@@ -99,7 +94,8 @@ def is_string(obj):
 
 
 def is_array(obj):
-    return isinstance(obj, np.ndarray)
+    # np.generic allows us to return true for scalars as well as true arrays
+    return isinstance(obj, (np.ndarray, np.generic))
 
 
 def is_array_like(obj):


### PR DESCRIPTION
Previously if you tried to slice with a numpy array, you got some obscure error about needing `any()` or `all()` to compare the slice to `slice(None)`. This should make it work now.

Branched off #753.