### PR TITLE
Fix full_transform for 1D vector

### DIFF
--- a/nengo/utils/builder.py
+++ b/nengo/utils/builder.py
@@ -36,7 +36,10 @@ def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
             # transform is already full, so return a copy
             return np.array(transform)
         elif transform.size == 1 and allow_scalars:
-            return np.array(transform)
+            if transform.ndim == 1:
+                return np.array(transform[0])
+            else:
+                return np.array(transform)
 
     # Create the new transform matching the pre/post dimensions
     func_size = conn.function_info.size

--- a/nengo/utils/tests/test_builder.py
+++ b/nengo/utils/tests/test_builder.py
@@ -87,6 +87,11 @@ def test_full_transform():
                                                        [0, 0, 3],
                                                        [0, 1, 0]]))
 
+        # using vector 1D
+        conn = nengo.Connection(ens1, ens1, transform=[5])
+        assert full_transform(conn).ndim != 1
+        assert np.all(full_transform(conn) == 5)
+
         # using vector and lists
         conn = nengo.Connection(ens3[[1, 0, 2]], ens3[[2, 0, 1]],
                                 transform=[1, 2, 3])


### PR DESCRIPTION
`full_transform` should never return a vector, but in one specific case this was possible.

```python
>>> conn = nengo.Connection(ens1, ens1, transform=[1])
>>> full_transform(conn)
np.array([ 1.])
```

This commit fixes this by identifying this special case and returning a scalar instead.

Fixes #750.