### PR TITLE
fixed product network layout

### DIFF
--- a/nengo/networks/product.py
+++ b/nengo/networks/product.py
@@ -26,7 +26,8 @@ def Product(n_neurons, dimensions, input_magnitude=1, config=None, net=None):
                                     radius=input_magnitude * np.sqrt(2))
         nengo.Connection(net.A, net.product.input[::2], synapse=None)
         nengo.Connection(net.B, net.product.input[1::2], synapse=None)
-        net.output = net.product.add_output('product', lambda x: x[0] * x[1])
+        net.product.add_output('product', lambda x: x[0] * x[1])
+        nengo.Connection(net.product.product, net.output, synapse=None)
 
     return net
 


### PR DESCRIPTION
While trying to fix the `spa.Compare` network I noticed that the `Product` network displayed really weirdly in the `nengo_gui` so I fixed it. Basically all this does is remove this lonely node hanging around and make it more graphically logical to connect to the `Product` network. I thought it would affect more stuff, but apparently not.

Test with the following code:
```
import nengo
import numpy as np

model = nengo.Network()
D = 8
n_neurons = 20

with model:
    model.out = nengo.Node(size_in=D)
    model.ens_out = nengo.Node(size_in=16)

    model.prod = nengo.networks.Product(n_neurons, D)

    nengo.Connection(model.prod.output, model.out)
    nengo.Connection(model.prod.product.output, model.ens_out)
```

Before:
![before_prod_fix](https://cloud.githubusercontent.com/assets/1918825/8580076/87e1e01e-2586-11e5-8693-8984fe245c84.png)

After:
![after_prod_fix](https://cloud.githubusercontent.com/assets/1918825/8580082/8d33683a-2586-11e5-8a19-1521384bb0e6.png)

