### PR TITLE
Add clipped exponential distribution.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,9 @@ Release History
   ensemble's encoders to fire selectively for its inputs. (see
   ``examples/learning/learn_associations.ipynb``).
   (`#727 <https://github.com/nengo/nengo/issues/727>`_)
+- Added a clipped exponential distribution useful for thresholding, in
+  particular in the AssociativeMemory.
+  (`#582 <https://github.com/nengo/nengo/pull/779>`_)
 
 **Bug fixes**
 

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -143,6 +143,31 @@ class Gaussian(Distribution):
         return rng.normal(loc=self.mean, scale=self.std, size=shape)
 
 
+class Exponential(Distribution):
+    """An exponential distribution where high values are clipped.
+
+    Parameters
+    ----------
+    scale : float
+        The scale parameter (inverse of the rate parameter lambda).
+    shift : float, optional
+        Amount to shift the distribution by. There will be no values smaller
+        than this shift when sampling from the distribution.
+    high : float, optional
+        All values larger than this value will be clipped to this value.
+    """
+    def __init__(self, scale, shift=0., high=np.inf):
+        self.scale = scale
+        self.shift = shift
+        self.high = high
+
+    def sample(self, n, d=None, rng=np.random):
+        shape = (n,) if d is None else (n, d)
+        return np.clip(
+            rng.exponential(self.scale, shape) + self.shift,
+            self.shift, self.high)
+
+
 class UniformHypersphere(Distribution):
     """Distributions over an n-dimensional unit hypersphere.
 

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -163,9 +163,10 @@ class Exponential(Distribution):
 
     def sample(self, n, d=None, rng=np.random):
         shape = (n,) if d is None else (n, d)
-        return np.clip(
-            rng.exponential(self.scale, shape) + self.shift,
-            self.shift, self.high)
+        exp_val = rng.exponential(self.scale, shape) + self.shift
+        high = np.nextafter(self.high,
+                            np.asarray(-np.inf, dtype=exp_val.dtype))
+        return np.clip(exp_val, self.shift, high)
 
 
 class UniformHypersphere(Distribution):

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -54,6 +54,20 @@ def test_gaussian(mean, std, rng):
         assert abs(np.std(samples) - std) < 0.25  # using chi2 for n=100
 
 
+@pytest.mark.parametrize("scale,shift,high", [
+    (1., 0., np.inf), (10., 0., 1.), (0.1, 0.3, 1.0)])
+def test_exponential(scale, shift, high, rng):
+    n = 100
+    dist = dists.Exponential(scale, shift=shift, high=high)
+    samples = dist.sample(n, rng=rng)
+    assert np.all(samples >= shift)
+    assert np.all(samples <= high)
+    # approximation of 95% confidence interval
+    ci = scale * 1.96 / np.sqrt(n)
+    if scale + ci < high:
+        assert abs(np.mean(samples - shift) - scale) < ci
+
+
 @pytest.mark.parametrize("dimensions", [0, 1, 2, 5])
 def test_hypersphere(dimensions, rng):
     n = 150 * dimensions


### PR DESCRIPTION
This distribution is useful for thresholding in ensembles. It performs better than a uniform distribution of intercepts or setting all intercepts exactly to the threshold.

![download](https://cloud.githubusercontent.com/assets/850157/8605689/fb72e784-2654-11e5-966d-33c5ed13c7a2.png)
blue: fixed intercepts
green: uniform
red: exponential distribution
The ideal function would be a step function going from 0 to 1 at 0.3 (plus synaptic filtering).

I am planning to update the `AssociativeMemory` to use this distribution and maybe implement a thresholding network.

