### PR TITLE
Make Nengo-specific Exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ Release History
   (`#857 <https://github.com/nengo/nengo/issues/857`_,
   `#739 <https://github.com/nengo/nengo/issues/739>`_,
   `#859 <https://github.com/nengo/nengo/pull/859>`_)
+- Most exceptions that Nengo can raise are now custom exception classes
+  that can be found in the ``nengo.exceptions`` module.
+  (`#781 <https://github.com/nengo/nengo/pull/781>`_)
 
 **Behavioural changes**
 

--- a/examples/usage/config.ipynb
+++ b/examples/usage/config.ipynb
@@ -550,7 +550,7 @@
       "# memory_location must be a positive integer\n",
       "my_config[nengo.Ensemble].set_param(\n",
       "    'memory_location',\n",
-      "    nengo.params.IntParam(default=None, optional=True, low=0))"
+      "    nengo.params.IntParam('memory_location', default=None, optional=True, low=0))"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/usage/exceptions.ipynb
+++ b/examples/usage/exceptions.ipynb
@@ -1,0 +1,548 @@
+{
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  },
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "collapsed": true
+     },
+     "source": [
+      "# Exceptions\n",
+      "\n",
+      "This should be an exhaustive list of the exceptions\n",
+      "that can be raised by Nengo,\n",
+      "and how they appear when they occur.\n",
+      "\n",
+      "The exceptions are ordered roughly by how commonly\n",
+      "we expect them to occur."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import traceback\n",
+      "import nengo\n",
+      "import nengo.spa\n",
+      "from nengo.rc import RC_DEFAULTS\n",
+      "%load_ext nengo.ipynb\n",
+      "\n",
+      "def print_exc(func):\n",
+      "    try:\n",
+      "        func()\n",
+      "    except:\n",
+      "        traceback.print_exc()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ValidationError in NengoObject (simplified)"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def nengo_obj():\n",
+      "    with nengo.Network():\n",
+      "        ens = nengo.Ensemble(n_neurons=0, dimensions=1)\n",
+      "nengo.rc.set('exceptions', 'simplified', str(True))\n",
+      "print_exc(nengo_obj)\n",
+      "nengo.rc.set('exceptions', 'simplified', str(RC_DEFAULTS['exceptions']['simplified']))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ValidationError in NengoObject (full)"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def nengo_obj():\n",
+      "    with nengo.Network():\n",
+      "        ens = nengo.Ensemble(n_neurons=0, dimensions=1)\n",
+      "nengo.rc.set('exceptions', 'simplified', str(False))\n",
+      "print_exc(nengo_obj)\n",
+      "nengo.rc.set('exceptions', 'simplified', str(RC_DEFAULTS['exceptions']['simplified']))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ValidationError in non-NengoObject"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def dist():\n",
+      "    nengo.dists.PDF(x=[1, 1], p=[0.1, 0.2])\n",
+      "print_exc(dist)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ReadonlyError in NengoObject (simplified)"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def nengo_obj():\n",
+      "    with nengo.Network():\n",
+      "        ens = nengo.Ensemble(n_neurons=10, dimensions=1)\n",
+      "        p = nengo.Probe(ens)\n",
+      "        p.target = ens\n",
+      "nengo.rc.set('exceptions', 'simplified', str(True))\n",
+      "print_exc(nengo_obj)\n",
+      "nengo.rc.set('exceptions', 'simplified', str(RC_DEFAULTS['exceptions']['simplified']))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ReadonlyError in NengoObject (full)"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def nengo_obj():\n",
+      "    with nengo.Network():\n",
+      "        ens = nengo.Ensemble(n_neurons=10, dimensions=1)\n",
+      "        p = nengo.Probe(ens)\n",
+      "        p.target = ens\n",
+      "nengo.rc.set('exceptions', 'simplified', str(False))\n",
+      "print_exc(nengo_obj)\n",
+      "nengo.rc.set('exceptions', 'simplified', str(RC_DEFAULTS['exceptions']['simplified']))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ReadonlyError in non-NengoObject"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def ensemble():\n",
+      "    with nengo.Network():\n",
+      "        ens = nengo.Ensemble(n_neurons=10, dimensions=1)\n",
+      "        ens.neurons = None\n",
+      "print_exc(ensemble)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def param():\n",
+      "    class Frozen(nengo.params.FrozenObject):\n",
+      "        p = nengo.params.Parameter('p', readonly=False)\n",
+      "    f = Frozen()\n",
+      "print_exc(param)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "SimulatorClosed"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def simclose():\n",
+      "    with nengo.Network() as net:\n",
+      "        e = nengo.Ensemble(10, 1)\n",
+      "    with nengo.Simulator(net) as sim:\n",
+      "        sim.run(0.01)\n",
+      "    sim.run(0.01)\n",
+      "print_exc(simclose)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "BuildtimeError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def builderror():\n",
+      "    model = nengo.builder.Model()\n",
+      "    nengo.builder.Builder.build(model, \"\")\n",
+      "print_exc(builderror)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ZeroActivityError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def zeroactivity():\n",
+      "    with nengo.Network() as net:\n",
+      "        e = nengo.Ensemble(1, 1, gain=[0], bias=[-1], encoders=[[1]])\n",
+      "        nengo.Connection(e, e)\n",
+      "    with nengo.Simulator(net):\n",
+      "        pass\n",
+      "print_exc(zeroactivity)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "SpaParseError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def spaparse():\n",
+      "    vocab = nengo.spa.Vocabulary(16)\n",
+      "    vocab['a']\n",
+      "print_exc(spaparse)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "SpaModuleError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def spamodule():\n",
+      "    with nengo.spa.SPA() as net:\n",
+      "        st = nengo.spa.State(1)\n",
+      "print_exc(spamodule)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ObsoleteError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def obsolete():\n",
+      "    with nengo.Network() as net:\n",
+      "        e = nengo.Ensemble(10, 1)\n",
+      "        c = nengo.Connection(e, e)\n",
+      "        p = nengo.Probe(c, 'decoders')\n",
+      "print_exc(obsolete)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "ConfigError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def config():\n",
+      "    nengo.Network().config[object]\n",
+      "print_exc(config)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "SimulationError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def simerror():\n",
+      "    with nengo.Network() as net:\n",
+      "        n = nengo.Node(lambda t: None if t > 0.002 else 1.0)\n",
+      "    with nengo.Simulator(net) as sim:\n",
+      "        sim.run(0.003)\n",
+      "print_exc(simerror)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "NetworkContextError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def context():\n",
+      "    with nengo.Network():\n",
+      "        nengo.Network.context.append(\"bad\")\n",
+      "        ens = nengo.Ensemble(10, 1)\n",
+      "print_exc(context)\n",
+      "nengo.Network.context.clear()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "NeuronTypeError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def direct():\n",
+      "    d = nengo.neurons.Direct()\n",
+      "    d.step_math(None, None, None)\n",
+      "print_exc(direct)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "FingerprintError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def fingerprint():\n",
+      "    nengo.cache.Fingerprint(lambda x: x)\n",
+      "print_exc(fingerprint)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "CacheIOError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def cacheio():\n",
+      "    from nengo.utils.compat import StringIO\n",
+      "    sio = StringIO(\"a\" * 40)\n",
+      "    nengo.utils.nco.read(sio)\n",
+      "print_exc(cacheio)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Unconvertible"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def unconvertible():\n",
+      "    with nengo.Network() as net:\n",
+      "        n = nengo.Node(output=None, size_in=1)\n",
+      "        nengo.Connection(n, n, synapse=None)\n",
+      "    nengo.utils.builder.remove_passthrough_nodes(net.nodes, net.connections)\n",
+      "print_exc(unconvertible)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "SignalError"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def signal():\n",
+      "    s = nengo.builder.signal.Signal([1])\n",
+      "    s.initial_value = 0\n",
+      "print_exc(signal)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/nengo-data/nengorc
+++ b/nengo-data/nengorc
@@ -61,3 +61,13 @@
 # nengo.utils.progress.ProgressUpdater interface (e.g.,
 # 'nengo.utils.progress.UpdateEveryT').
 #updater: auto
+
+
+# Settings for error messages due to exceptions
+[exceptions]
+
+# Use simplified exceptions. In most cases, simplified exceptions will be
+# easier to read and more useful for model development. However,
+# developers of Nengo internals or tools extending Nengo
+# may benefit from full exception tracebacks.
+#simplified: True

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -30,7 +30,7 @@ from .rc import rc, RC_DEFAULTS
 from .simulator import Simulator
 from .synapses import Alpha, LinearFilter, Lowpass
 from .utils.logging import log
-from . import dists, networks, processes, utils
+from . import dists, exceptions, networks, processes, utils
 
 logger = logging.getLogger(__name__)
 try:

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from nengo.builder.signal import Signal, SignalDict
 from nengo.cache import NoDecoderCache
+from nengo.exceptions import BuildError
 
 
 class Model(object):
@@ -76,7 +77,7 @@ class Builder(object):
             if obj_cls in cls.builders:
                 break
         else:
-            raise TypeError("Cannot build object of type '%s'." %
-                            obj.__class__.__name__)
+            raise BuildError(
+                "Cannot build object of type %r" % obj.__class__.__name__)
 
         return cls.builders[obj_cls](model, obj, *args, **kwargs)

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -10,14 +10,29 @@ from nengo.builder.operator import (
 from nengo.builder.signal import Signal
 from nengo.connection import Connection
 from nengo.ensemble import Ensemble, Neurons
-from nengo.exceptions import BuildError
+from nengo.exceptions import BuildError, ObsoleteError
 from nengo.neurons import Direct
 from nengo.node import Node
 from nengo.utils.compat import is_iterable, itervalues
 
 
-BuiltConnection = collections.namedtuple(
+BuiltConnection_ = collections.namedtuple(
     'BuiltConnection', ['eval_points', 'solver_info', 'weights'])
+
+
+class BuiltConnection(BuiltConnection_):
+    """Subclassing the namedtuple to provide better error messages."""
+    @property
+    def decoders(self):
+        raise ObsoleteError("decoders are now part of 'weights'. "
+                            "Access BuiltConnection.weights instead.",
+                            since="v2.1.0")
+
+    @property
+    def transform(self):
+        raise ObsoleteError("transform is now part of 'weights'. "
+                            "Access BuiltConnection.weights instead.",
+                            since="v2.1.0")
 
 
 def get_eval_points(model, conn, rng):

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -5,6 +5,7 @@ from nengo.builder.operator import DotInc, ElementwiseInc, Operator, Reset
 from nengo.builder.signal import Signal
 from nengo.connection import LearningRule
 from nengo.ensemble import Ensemble, Neurons
+from nengo.exceptions import BuildError
 from nengo.learning_rules import BCM, Oja, PES, Voja
 from nengo.node import Node
 from nengo.synapses import Lowpass
@@ -175,7 +176,7 @@ def build_learning_rule(model, rule):
             delta = Signal(
                 np.zeros((rule.size_in, pre.n_neurons)), name='Delta')
     else:
-        raise ValueError("Unknown target %r" % rule.modifies)
+        raise BuildError("Unknown target %r" % rule.modifies)
 
     assert delta.shape == target.shape
     model.add_op(
@@ -305,7 +306,7 @@ def build_pes(model, pes, rule):
     elif isinstance(conn.pre_obj, (Ensemble, Neurons)):
         local_error = correction
     else:
-        raise ValueError("'pre' object '%s' not suitable for PES learning"
+        raise BuildError("'pre' object '%s' not suitable for PES learning"
                          % (conn.pre_obj))
 
     # delta = local_error * activities

--- a/nengo/builder/node.py
+++ b/nengo/builder/node.py
@@ -3,6 +3,7 @@ import numpy as np
 from nengo.builder.builder import Builder
 from nengo.builder.signal import Signal
 from nengo.builder.operator import Reset, SimPyFunc
+from nengo.exceptions import BuildError
 from nengo.node import Node
 from nengo.processes import Process
 from nengo.utils.compat import is_array_like
@@ -31,8 +32,8 @@ def build_node(model, node):
     elif is_array_like(node.output):
         sig_out = Signal(node.output, name="%s.out" % node)
     else:
-        raise ValueError("Invalid node output type '%s'" % (
-            node.output.__class__.__name__))
+        raise BuildError(
+            "Invalid node output type %r" % node.output.__class__.__name__)
 
     model.sig[node]['in'] = sig_in
     model.sig[node]['out'] = sig_out

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import numpy as np
 
 import nengo.utils.numpy as npext
-from nengo.exceptions import BuildError
+from nengo.exceptions import BuildError, SimulationError
 
 
 class Operator(object):
@@ -393,11 +393,12 @@ class SimPyFunc(Operator):
             y = fn(t_sig.item(), *args) if t_in else fn(*args)
             if output is not None:
                 if y is None:  # required since Numpy turns None into NaN
-                    raise ValueError("Function %r returned None" % fn.__name__)
+                    raise SimulationError(
+                        "Function %r returned None" % fn.__name__)
                 try:
                     output[...] = y
                 except ValueError:
-                    raise ValueError("Function %r returned invalid value %r"
-                                     % (fn.__name__, y))
+                    raise SimulationError("Function %r returned invalid value "
+                                          "%r" % (fn.__name__, y))
 
         return step_simpyfunc

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import numpy as np
 
 import nengo.utils.numpy as npext
+from nengo.exceptions import BuildError
 
 
 class Operator(object):
@@ -284,7 +285,7 @@ class ElementwiseInc(Operator):
         assert all(len(s) == 2 for s in [Ashape, Xshape, Yshape])
         for da, dx, dy in zip(Ashape, Xshape, Yshape):
             if not (da in [1, dy] and dx in [1, dy] and max(da, dx) == dy):
-                raise ValueError("Incompatible shapes in ElementwiseInc: "
+                raise BuildError("Incompatible shapes in ElementwiseInc: "
                                  "Trying to do %s += %s * %s" %
                                  (Yshape, Ashape, Xshape))
 
@@ -314,8 +315,8 @@ def reshape_dot(A, X, Y, tag=None):
         incshape = ashape[:-1] + xshape[:-2] + xshape[-1:]
 
     if (badshape or incshape != Y.shape) and incshape != ():
-        raise ValueError('shape mismatch in %s: %s x %s -> %s' % (
-            tag, A.shape, X.shape, Y.shape))
+        raise BuildError("shape mismatch in %s: %s x %s -> %s"
+                         % (tag, A.shape, X.shape, Y.shape))
 
     # Reshape to handle case when np.dot(A, X) and Y are both scalars
     return (np.dot(A, X)).size == Y.size == 1
@@ -330,9 +331,9 @@ class DotInc(Operator):
 
     def __init__(self, A, X, Y, tag=None):
         if X.ndim >= 2 and any(d > 1 for d in X.shape[1:]):
-            raise ValueError("X must be a column vector")
+            raise BuildError("X must be a column vector")
         if Y.ndim >= 2 and any(d > 1 for d in Y.shape[1:]):
-            raise ValueError("Y must be a column vector")
+            raise BuildError("Y must be a column vector")
 
         self.A = A
         self.X = X

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -5,6 +5,7 @@ from nengo.builder.operator import Reset
 from nengo.builder.signal import Signal
 from nengo.connection import Connection, LearningRule
 from nengo.ensemble import Ensemble, Neurons
+from nengo.exceptions import BuildError
 from nengo.node import Node
 from nengo.probe import Probe
 from nengo.utils.compat import iteritems
@@ -35,8 +36,8 @@ def signal_probe(model, key, probe):
     try:
         sig = model.sig[probe.obj][key]
     except IndexError:
-        raise ValueError("Attribute '%s' is not probeable on %s."
-                         % (key, probe.obj))
+        raise BuildError(
+            "Attribute %r is not probeable on %s." % (key, probe.obj))
 
     if probe.slice is not None:
         sig = sig[probe.slice]
@@ -68,7 +69,8 @@ def build_probe(model, probe):
         if isinstance(probe.obj, nengotype):
             break
     else:
-        raise ValueError("Type '%s' is not probeable" % type(probe.obj))
+        raise BuildError(
+            "Type %r is not probeable" % probe.obj.__class__.__name__)
 
     key = probeables[probe.attr] if probe.attr in probeables else probe.attr
     if key is None:

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -5,6 +5,7 @@ from __future__ import division
 import numpy as np
 
 import nengo.utils.numpy as npext
+from nengo.exceptions import SignalError
 from nengo.utils.compat import StringIO, is_integer
 
 
@@ -62,7 +63,7 @@ class Signal(object):
 
     @initial_value.setter
     def initial_value(self, val):
-        raise RuntimeError("Cannot change initial value after initialization")
+        raise SignalError("Cannot change initial value after initialization")
 
     @property
     def is_view(self):
@@ -116,7 +117,7 @@ class Signal(object):
             item = (item,)
 
         if not all(is_integer(i) or isinstance(i, slice) for i in item):
-            raise ValueError("Can only index or slice into signals")
+            raise SignalError("Can only index or slice into signals")
 
         if all(map(is_integer, item)):
             # turn one index into slice to get a view from numpy
@@ -185,7 +186,7 @@ class SignalDict(dict):
     def init(self, signal):
         """Set up a permanent mapping from signal -> ndarray."""
         if signal in self:
-            raise ValueError("Cannot add signal twice")
+            raise SignalError("Cannot add signal twice")
 
         x = signal.initial_value
         if signal.is_view:

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -8,6 +8,7 @@ import struct
 
 import numpy as np
 
+from nengo.exceptions import FingerprintError
 from nengo.rc import rc
 from nengo.utils.cache import byte_align, bytes2human, human2bytes
 from nengo.utils.compat import is_string, pickle, PY2
@@ -60,9 +61,8 @@ class Fingerprint(object):
         self.fingerprint = hashlib.sha1()
         try:
             self.fingerprint.update(pickle.dumps(obj, pickle.HIGHEST_PROTOCOL))
-        except (pickle.PicklingError, TypeError) as err:
-            raise ValueError("Cannot create fingerprint: {msg}".format(
-                msg=str(err)))
+        except Exception as err:
+            raise FingerprintError(str(err))
 
     def __str__(self):
         return self.fingerprint.hexdigest()

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -19,7 +19,7 @@ test_seed = 0  # changing this will change seeds for all tests
 
 def pytest_configure(config):
     rc.reload_rc([])
-    rc.set('decoder_cache', 'enabled', 'false')
+    rc.set('decoder_cache', 'enabled', 'False')
 
 
 @pytest.fixture(scope="session")

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -50,30 +50,36 @@ class Ensemble(NengoObject):
         A name for the ensemble. Used for debugging and visualization.
     """
 
-    n_neurons = IntParam(default=None, low=1)
-    dimensions = IntParam(default=None, low=1)
-    radius = NumberParam(default=1.0, low=1e-10)
-    neuron_type = NeuronTypeParam(default=LIF())
-    encoders = DistOrArrayParam(default=UniformHypersphere(surface=True),
+    n_neurons = IntParam('n_neurons', default=None, low=1)
+    dimensions = IntParam('dimensions', default=None, low=1)
+    radius = NumberParam('radius', default=1.0, low=1e-10)
+    neuron_type = NeuronTypeParam('neuron_type', default=LIF())
+    encoders = DistOrArrayParam('encoders',
+                                default=UniformHypersphere(surface=True),
                                 sample_shape=('n_neurons', 'dimensions'))
-    intercepts = DistOrArrayParam(default=Uniform(-1.0, 1.0),
+    intercepts = DistOrArrayParam('intercepts',
+                                  default=Uniform(-1.0, 1.0),
                                   optional=True,
                                   sample_shape=('n_neurons',))
-    max_rates = DistOrArrayParam(default=Uniform(200, 400),
+    max_rates = DistOrArrayParam('max_rates',
+                                 default=Uniform(200, 400),
                                  optional=True,
                                  sample_shape=('n_neurons',))
-    n_eval_points = IntParam(default=None, optional=True)
-    eval_points = DistOrArrayParam(default=UniformHypersphere(),
+    n_eval_points = IntParam('n_eval_points', default=None, optional=True)
+    eval_points = DistOrArrayParam('eval_points',
+                                   default=UniformHypersphere(),
                                    sample_shape=('*', 'dimensions'))
-    bias = DistOrArrayParam(default=None,
+    bias = DistOrArrayParam('bias',
+                            default=None,
                             optional=True,
                             sample_shape=('n_neurons',))
-    gain = DistOrArrayParam(default=None,
+    gain = DistOrArrayParam('gain',
+                            default=None,
                             optional=True,
                             sample_shape=('n_neurons',))
-    noise = ProcessParam(default=None, optional=True)
-    seed = IntParam(default=None, optional=True)
-    label = StringParam(default=None, optional=True)
+    noise = ProcessParam('noise', default=None, optional=True)
+    seed = IntParam('seed', default=None, optional=True)
+    label = StringParam('label', default=None, optional=True)
 
     def __init__(self, n_neurons, dimensions, radius=Default, encoders=Default,
                  intercepts=Default, max_rates=Default, eval_points=Default,

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -2,6 +2,7 @@ import weakref
 
 from nengo.base import NengoObject, ObjView
 from nengo.dists import DistOrArrayParam, Uniform, UniformHypersphere
+from nengo.exceptions import ReadonlyError
 from nengo.neurons import LIF, NeuronTypeParam, Direct
 from nengo.params import (
     Default, IntParam, NumberParam, StringParam)
@@ -114,7 +115,7 @@ class Ensemble(NengoObject):
 
     @neurons.setter
     def neurons(self, dummy):
-        raise AttributeError("neurons cannot be overwritten.")
+        raise ReadonlyError(attr="neurons", obj=self)
 
     @property
     def probeable(self):

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -74,3 +74,7 @@ class SimulationError(NengoException, RuntimeError):
 
 class SignalError(NengoException, ValueError):
     """An error dealing with Signals in the builder."""
+
+
+class FingerprintError(NengoException, ValueError):
+    """An error in fingerprinting an object for cache identification."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -34,3 +34,7 @@ class ReadonlyError(ValidationError):
         if msg is None:
             msg = "%s is read-only and cannot be changed" % attr
         super(ReadonlyError, self).__init__(msg, attr, obj)
+
+
+class BuildError(NengoException, ValueError):
+    """A ValueError encountered during the build process."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -1,0 +1,27 @@
+import inspect
+
+
+class NengoException(Exception):
+    """Base class for Nengo exceptions.
+
+    NengoException instances should not be created; this base class exists so
+    that all exceptions raised by Nengo can be caught in a try / except block.
+    """
+
+
+class ValidationError(NengoException, ValueError):
+    """A ValueError encountered during validation of a parameter."""
+
+    def __init__(self, msg, attr, obj=None):
+        self.attr = attr
+        self.obj = obj
+        super(ValidationError, self).__init__(msg)
+
+    def __str__(self):
+        if self.obj is None:
+            return "{}: {}".format(
+                self.attr, super(ValidationError, self).__str__())
+        klassname = (self.obj.__name__ if inspect.isclass(self.obj)
+                     else self.obj.__class__.__name__)
+        return "{}.{}: {}".format(
+            klassname, self.attr, super(ValidationError, self).__str__())

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -54,3 +54,7 @@ class ObsoleteError(NengoException):
             super(ObsoleteError, self).__str__(),
             "\nFor more information, please visit %s" % self.url
             if self.url is not None else "")
+
+
+class ConfigError(NengoException, ValueError):
+    """A ValueError encountered in the config system."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -78,3 +78,7 @@ class SignalError(NengoException, ValueError):
 
 class FingerprintError(NengoException, ValueError):
     """An error in fingerprinting an object for cache identification."""
+
+
+class NetworkContextError(NengoException, RuntimeError):
+    """An error with the Network context stack."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -25,3 +25,12 @@ class ValidationError(NengoException, ValueError):
                      else self.obj.__class__.__name__)
         return "{}.{}: {}".format(
             klassname, self.attr, super(ValidationError, self).__str__())
+
+
+class ReadonlyError(ValidationError):
+    """A ValidationError occurring because a parameter is read-only."""
+
+    def __init__(self, attr, obj=None, msg=None):
+        if msg is None:
+            msg = "%s is read-only and cannot be changed" % attr
+        super(ReadonlyError, self).__init__(msg, attr, obj)

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -62,3 +62,7 @@ class ConfigError(NengoException, ValueError):
 
 class SpaParseError(NengoException, ValueError):
     """An error encountered while parsing a SPA expression."""
+
+
+class SimulatorClosed(NengoException):
+    """Raised when attempting to run a closed simulator."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -70,3 +70,7 @@ class SimulatorClosed(NengoException):
 
 class SimulationError(NengoException, RuntimeError):
     """An error encountered during simulation of the model."""
+
+
+class SignalError(NengoException, ValueError):
+    """An error dealing with Signals in the builder."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -58,3 +58,7 @@ class ObsoleteError(NengoException):
 
 class ConfigError(NengoException, ValueError):
     """A ValueError encountered in the config system."""
+
+
+class SpaParseError(NengoException, ValueError):
+    """An error encountered while parsing a SPA expression."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -66,3 +66,7 @@ class SpaParseError(NengoException, ValueError):
 
 class SimulatorClosed(NengoException):
     """Raised when attempting to run a closed simulator."""
+
+
+class SimulationError(NengoException, RuntimeError):
+    """An error encountered during simulation of the model."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -38,3 +38,19 @@ class ReadonlyError(ValidationError):
 
 class BuildError(NengoException, ValueError):
     """A ValueError encountered during the build process."""
+
+
+class ObsoleteError(NengoException):
+    """A feature that has been removed in a backwards-incompatible way."""
+
+    def __init__(self, msg, since=None, url=None):
+        self.since = since
+        self.url = url
+        super(ObsoleteError, self).__init__(msg)
+
+    def __str__(self):
+        return "Obsolete%s: %s%s" % (
+            "" if self.since is None else " since %s" % self.since,
+            super(ObsoleteError, self).__str__(),
+            "\nFor more information, please visit %s" % self.url
+            if self.url is not None else "")

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -82,3 +82,7 @@ class FingerprintError(NengoException, ValueError):
 
 class NetworkContextError(NengoException, RuntimeError):
     """An error with the Network context stack."""
+
+
+class Unconvertible(NengoException, ValueError):
+    """Raised a requested network conversion cannot be done."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -86,3 +86,7 @@ class NetworkContextError(NengoException, RuntimeError):
 
 class Unconvertible(NengoException, ValueError):
     """Raised a requested network conversion cannot be done."""
+
+
+class CacheIOError(NengoException, IOError):
+    """An IO error in reading from or writing to the decoder cache."""

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -60,6 +60,10 @@ class ConfigError(NengoException, ValueError):
     """A ValueError encountered in the config system."""
 
 
+class SpaModuleError(NengoException, ValueError):
+    """An error in how SPA keeps track of modules."""
+
+
 class SpaParseError(NengoException, ValueError):
     """An error encountered while parsing a SPA expression."""
 

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -1,6 +1,7 @@
 import warnings
 
 from nengo.base import NengoObjectParam
+from nengo.exceptions import ValidationError
 from nengo.params import FrozenObject, NumberParam, Parameter
 from nengo.utils.compat import is_iterable, itervalues
 
@@ -9,7 +10,8 @@ class ConnectionParam(NengoObjectParam):
     def validate(self, instance, conn):
         from nengo.connection import Connection
         if not isinstance(conn, Connection):
-            raise ValueError("'%s' is not a Connection" % conn)
+            raise ValidationError("'%s' is not a Connection" % conn,
+                                  attr=self.name, obj=instance)
         super(ConnectionParam, self).validate(instance, conn)
 
 
@@ -33,7 +35,7 @@ class LearningRuleType(FrozenObject):
         on full weight matrices).
     """
 
-    learning_rate = NumberParam(low=0, low_open=True)
+    learning_rate = NumberParam('learning_rate', low=0, low_open=True)
 
     error_type = 'none'
     modifies = None
@@ -76,7 +78,7 @@ class PES(LearningRuleType):
         The modulatory connection created to project the error signal.
     """
 
-    pre_tau = NumberParam(low=0, low_open=True)
+    pre_tau = NumberParam('pre_tau', low=0, low_open=True)
 
     error_type = 'decoded'
     modifies = 'decoders'
@@ -128,9 +130,9 @@ class BCM(LearningRuleType):
         Filter constant on activities of neurons in post population.
     """
 
-    pre_tau = NumberParam(low=0, low_open=True)
-    post_tau = NumberParam(low=0, low_open=True)
-    theta_tau = NumberParam(low=0, low_open=True)
+    pre_tau = NumberParam('pre_tau', low=0, low_open=True)
+    post_tau = NumberParam('post_tau', low=0, low_open=True)
+    theta_tau = NumberParam('theta_tau', low=0, low_open=True)
 
     error_type = 'none'
     modifies = 'weights'
@@ -186,9 +188,9 @@ class Oja(LearningRuleType):
         Filter constant on activities of neurons in post population.
     """
 
-    pre_tau = NumberParam(low=0, low_open=True)
-    post_tau = NumberParam(low=0, low_open=True)
-    beta = NumberParam(low=0)
+    pre_tau = NumberParam('pre_tau', low=0, low_open=True)
+    post_tau = NumberParam('post_tau', low=0, low_open=True)
+    beta = NumberParam('beta', low=0)
 
     error_type = 'none'
     modifies = 'weights'
@@ -240,7 +242,7 @@ class Voja(LearningRuleType):
         Filter constant on activities of neurons in post population.
     """
 
-    post_tau = NumberParam(low=0, low_open=True, optional=True)
+    post_tau = NumberParam('post_tau', low=0, low_open=True, optional=True)
 
     error_type = 'scalar'
     modifies = 'encoders'
@@ -262,9 +264,13 @@ class LearningRuleTypeParam(Parameter):
 
     def validate_rule(self, instance, rule):
         if not isinstance(rule, LearningRuleType):
-            raise ValueError("'%s' must be a learning rule type or a dict or "
-                             "list of such types." % rule)
+            raise ValidationError(
+                "'%s' must be a learning rule type or a dict or "
+                "list of such types." % rule, attr=self.name, obj=instance)
         if rule.error_type not in ('none', 'scalar', 'decoded', 'neuron'):
-            raise ValueError("Unrecognized error type %r" % rule.error_type)
+            raise ValidationError(
+                "Unrecognized error type %r" % rule.error_type,
+                attr=self.name, obj=instance)
         if rule.modifies not in ('encoders', 'decoders', 'weights'):
-            raise ValueError("Unrecognized target %r" % rule.modifies)
+            raise ValidationError("Unrecognized target %r" % rule.modifies,
+                                  attr=self.name, obj=instance)

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -3,7 +3,7 @@ import collections
 from nengo.config import Config
 from nengo.connection import Connection
 from nengo.ensemble import Ensemble
-from nengo.exceptions import ReadonlyError
+from nengo.exceptions import ConfigError, ReadonlyError
 from nengo.node import Node
 from nengo.probe import Probe
 
@@ -190,9 +190,9 @@ class Network(object):
 
         config = Config.context[-1]
         if config is not self._config:
-            raise RuntimeError("Config.context in bad state; was expecting "
-                               "current context to be '%s' but instead got "
-                               "'%s'." % (self._config, config))
+            raise ConfigError("Config.context in bad state; was expecting "
+                              "current context to be '%s' but instead got "
+                              "'%s'." % (self._config, config))
 
         network = Network.context.pop()
         if network is not self:

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -3,6 +3,7 @@ import collections
 from nengo.config import Config
 from nengo.connection import Connection
 from nengo.ensemble import Ensemble
+from nengo.exceptions import ReadonlyError
 from nengo.node import Node
 from nengo.probe import Probe
 
@@ -172,8 +173,7 @@ class Network(object):
 
     @config.setter
     def config(self, dummy):
-        raise AttributeError("config cannot be overwritten. See help("
-                             "nengo.Config) for help on modifying configs.")
+        raise ReadonlyError(attr='config', obj=self)
 
     def __contains__(self, obj):
         return type(obj) in self.objects and obj in self.objects[type(obj)]

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -5,6 +5,7 @@ import numpy as np
 import nengo
 from .ensemblearray import EnsembleArray
 from nengo.dists import Choice, Exponential, Uniform
+from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_iterable, range
 from nengo.utils.network import with_self
 
@@ -61,14 +62,16 @@ class AssociativeMemory(nengo.Network):
             output_vectors = np.array(output_vectors, ndmin=2)
 
         if input_vectors.shape[0] == 0:
-            raise ValueError('Number of input vectors cannot be 0.')
+            raise ValidationError("Number of input vectors cannot be 0.",
+                                  attr='input_vectors', obj=self)
         elif input_vectors.shape[0] != output_vectors.shape[0]:
             # Fail if number of input items and number of output items don't
             # match
-            raise ValueError(
-                'Number of input vectors does not match number of output '
-                'vectors. %d != %d'
-                % (input_vectors.shape[0], output_vectors.shape[0]))
+            raise ValidationError(
+                "Number of input vectors does not match number of output "
+                "vectors. %d != %d"
+                % (input_vectors.shape[0], output_vectors.shape[0]),
+                attr='input_vectors', obj=self.__class__)
 
         # Handle possible different threshold / input_scale values for each
         # element in the associative memory
@@ -80,13 +83,15 @@ class AssociativeMemory(nengo.Network):
         # --- Check preconditions
         self.n_items = input_vectors.shape[0]
         if self.n_items != output_vectors.shape[0]:
-            raise ValueError(
+            raise ValidationError(
                 "Number of input vectors (%d) does not match number of output "
-                "vectors (%d)" % (self.n_items, output_vectors.shape[0]))
+                "vectors (%d)" % (self.n_items, output_vectors.shape[0]),
+                attr='input_vectors', obj=self)
         if threshold.shape[0] != self.n_items:
-            raise ValueError(
+            raise ValidationError(
                 "Number of threshold values (%d) does not match number of "
-                "input vectors (%d)." % (threshold.shape[0], self.n_items))
+                "input vectors (%d)." % (threshold.shape[0], self.n_items),
+                attr='threshold', obj=self)
 
         # --- Set parameters
         self.out_conns = []  # Used in `add_threshold_to_output`
@@ -200,12 +205,13 @@ class AssociativeMemory(nengo.Network):
 
         # --- Check some preconditions
         if input_scales.shape[1] != n_vectors:
-            raise ValueError("Number of input_scale values (%d) does not "
-                             "match number of input vectors (%d)."
-                             % (input_scales.shape[1], n_vectors))
+            raise ValidationError("Number of input_scale values (%d) does not "
+                                  "match number of input vectors (%d)."
+                                  % (input_scales.shape[1], n_vectors),
+                                  attr='input_scales')
         if hasattr(self, name):
-            raise NameError("Name '%s' already exists as a node in the "
-                            "associative memory." % name)
+            raise ValidationError("Name '%s' already exists as a node in the "
+                                  "associative memory." % name, attr='name')
 
         # --- Finally, make the input node and connect it
         in_node = nengo.Node(size_in=d_vectors, label=name)
@@ -237,8 +243,8 @@ class AssociativeMemory(nengo.Network):
 
         # --- Check preconditions
         if hasattr(self, name):
-            raise NameError("Name '%s' already exists as a node in the "
-                            "associative memory." % name)
+            raise ValidationError("Name '%s' already exists as a node in the "
+                                  "associative memory." % name, attr='name')
 
         # --- Make the output node and connect it
         output = nengo.Node(size_in=output_vectors.shape[1], label=name)

--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.networks.product import Product
 from nengo.utils.compat import range
 from nengo.utils.magic import memoize
@@ -34,7 +35,7 @@ def transform_in(dims, align, invert):
         Whether to reverse the order of elements.
     """
     if align not in ('A', 'B'):
-        raise ValueError("'align' must be either 'A' or 'B'")
+        raise ValidationError("'align' must be either 'A' or 'B'", 'align')
 
     dims2 = 4 * (dims // 2 + 1)
     tr = np.zeros((dims2, dims))

--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_iterable, range
 from nengo.utils.network import with_self
 
@@ -47,10 +48,11 @@ class EnsembleArray(nengo.Network):
                  neuron_nodes=False, label=None, seed=None,
                  add_to_container=None, **ens_kwargs):
         if "dimensions" in ens_kwargs:
-            raise TypeError(
+            raise ValidationError(
                 "'dimensions' is not a valid argument to EnsembleArray. "
                 "To set the number of ensembles, use 'n_ensembles'. To set "
-                "the number of dimensions per ensemble, use 'ens_dimensions'.")
+                "the number of dimensions per ensemble, use 'ens_dimensions'.",
+                attr='dimensions', obj=self)
 
         super(EnsembleArray, self).__init__(label, seed, add_to_container)
 
@@ -107,8 +109,10 @@ class EnsembleArray(nengo.Network):
             return self.neuron_input
 
         if isinstance(self.ea_ensembles[0].neuron_type, nengo.Direct):
-            raise TypeError("Ensembles use Direct neuron type. "
-                            "Cannot give neuron input to Direct neurons.")
+            raise ValidationError(
+                "Ensembles use Direct neuron type. "
+                "Cannot give neuron input to Direct neurons.",
+                attr='ea_ensembles[0].neuron_type', obj=self)
 
         self.neuron_input = nengo.Node(
             size_in=self.n_neurons * self.n_ensembles, label="neuron_input")
@@ -134,8 +138,10 @@ class EnsembleArray(nengo.Network):
             return self.neuron_output
 
         if isinstance(self.ea_ensembles[0].neuron_type, nengo.Direct):
-            raise TypeError("Ensembles use Direct neuron type. "
-                            "Cannot get neuron output from Direct neurons.")
+            raise ValidationError(
+                "Ensembles use Direct neuron type. "
+                "Cannot get neuron output from Direct neurons.",
+                attr='ea_ensembles[0].neuron_type', obj=self)
 
         self.neuron_output = nengo.Node(
             size_in=self.n_neurons * self.n_ensembles, label="neuron_output")
@@ -156,7 +162,8 @@ class EnsembleArray(nengo.Network):
 
         if is_iterable(function) and all(callable(f) for f in function):
             if len(list(function)) != self.n_ensembles:
-                raise ValueError("Must have one function per ensemble")
+                raise ValidationError(
+                    "Must have one function per ensemble", attr='function')
 
             for i, func in enumerate(function):
                 sizes[i] = np.asarray(func(np.zeros(dims_per_ens))).size
@@ -167,8 +174,8 @@ class EnsembleArray(nengo.Network):
             sizes[:] = dims_per_ens
             function = [None] * self.n_ensembles
         else:
-            raise ValueError(
-                "'function' must be a callable, list of callables, or 'None'")
+            raise ValidationError("'function' must be a callable, list of "
+                                  "callables, or None", attr='function')
 
         output = nengo.Node(output=None, size_in=sizes.sum(), label=name)
         setattr(self, name, output)

--- a/nengo/networks/tests/test_ensemblearray.py
+++ b/nengo/networks/tests/test_ensemblearray.py
@@ -3,6 +3,7 @@ import pytest
 
 import nengo
 from nengo.dists import Choice
+from nengo.exceptions import ValidationError
 from nengo.utils.compat import range
 
 
@@ -197,7 +198,7 @@ def test_matrix_mul(Simulator, plt, seed):
 
 def test_arguments():
     """Make sure EnsembleArray accepts the right arguments."""
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         nengo.networks.EnsembleArray(nengo.LIF(10), 1, dimensions=2)
 
 
@@ -206,9 +207,9 @@ def test_directmode_errors():
         net.config[nengo.Ensemble].neuron_type = nengo.Direct()
 
         ea = nengo.networks.EnsembleArray(10, 2)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             ea.add_neuron_input()
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             ea.add_neuron_output()
 
 

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -4,7 +4,7 @@ import logging
 
 import numpy as np
 
-from nengo.exceptions import ValidationError
+from nengo.exceptions import SimulationError, ValidationError
 from nengo.params import Parameter, NumberParam, FrozenObject
 from nengo.utils.compat import range
 from nengo.utils.neurons import settled_firingrate
@@ -111,7 +111,7 @@ class Direct(NeuronType):
         return None, None
 
     def step_math(self, dt, J, output):
-        raise TypeError("Direct mode neurons shouldn't be simulated.")
+        raise SimulationError("Direct mode neurons shouldn't be simulated.")
 
 # TODO: class BasisFunctions or Population or Express;
 #       uses non-neural basis functions to emulate neuron saturation,

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -3,7 +3,7 @@ import inspect
 
 import numpy as np
 
-from nengo.exceptions import ReadonlyError, ValidationError
+from nengo.exceptions import ObsoleteError, ReadonlyError, ValidationError
 from nengo.utils.compat import (
     is_array, is_integer, is_number, is_string, itervalues)
 from nengo.utils.numpy import array_hash, compare
@@ -153,10 +153,7 @@ class ObsoleteParam(Parameter):
             self.raise_error()
 
     def raise_error(self):
-        raise ValueError("This parameter is no longer supported. %s%s" % (
-            self.short_msg,
-            "\nFor more information, please visit %s" % self.url
-            if self.url is not None else ""))
+        raise ObsoleteError(self.short_msg, since=self.since, url=self.url)
 
 
 class BoolParam(Parameter):

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -3,7 +3,8 @@ import inspect
 
 import numpy as np
 
-from nengo.exceptions import ObsoleteError, ReadonlyError, ValidationError
+from nengo.exceptions import (
+    ConfigError, ObsoleteError, ReadonlyError, ValidationError)
 from nengo.utils.compat import (
     is_array, is_integer, is_number, is_string, itervalues)
 from nengo.utils.numpy import array_hash, compare
@@ -96,7 +97,7 @@ class Parameter(object):
 
     def set_default(self, obj, value):
         if not self.configurable:
-            raise ValueError("Parameter '%s' is not configurable" % self)
+            raise ConfigError("Parameter '%s' is not configurable" % self)
         self.validate(obj, value)
         self._defaults[obj] = value
 

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -1,7 +1,7 @@
 from nengo.base import NengoObject, NengoObjectParam, ObjView
 from nengo.config import Config
 from nengo.connection import Connection, LearningRule
-from nengo.exceptions import ValidationError
+from nengo.exceptions import ObsoleteError, ValidationError
 from nengo.params import (
     Default, ConnectionDefault, IntParam, NumberParam, StringParam)
 from nengo.solvers import SolverParam
@@ -24,6 +24,10 @@ class TargetParam(NengoObjectParam):
 class AttributeParam(StringParam):
     def validate(self, probe, attr):
         super(AttributeParam, self).validate(probe, attr)
+        if attr in ('decoders', 'transform'):
+            raise ObsoleteError("'decoders' and 'transform' are now combined "
+                                "into 'weights'. Probe 'weights' instead.",
+                                since="v2.1.0")
         if attr not in probe.obj.probeable:
             raise ValidationError("Attribute %r is not probeable on %s."
                                   % (attr, probe.obj),

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import nengo.utils.numpy as npext
 from nengo.dists import DistributionParam, Gaussian
+from nengo.exceptions import ValidationError
 from nengo.params import (
     BoolParam, IntParam, NdarrayParam, NumberParam, Parameter, FrozenObject)
 from nengo.synapses import LinearFilter, LinearFilterParam, Lowpass
@@ -27,10 +28,10 @@ class Process(FrozenObject):
     seed : int, optional
         Random number seed. Ensures noise will be the same each run.
     """
-    default_size_in = IntParam(low=0)
-    default_size_out = IntParam(low=0)
-    default_dt = NumberParam(low=0, low_open=True)
-    seed = IntParam(low=0, high=npext.maxint, optional=True)
+    default_size_in = IntParam('default_size_in', low=0)
+    default_size_out = IntParam('default_size_out', low=0)
+    default_dt = NumberParam('default_dt', low=0, low_open=True)
+    seed = IntParam('seed', low=0, high=npext.maxint, optional=True)
 
     def __init__(self, default_size_in=0, default_size_out=1, seed=None):
         super(Process, self).__init__()
@@ -106,8 +107,8 @@ class WhiteNoise(Process):
        Uhlenbeck process and its integral. Phys. Rev. E 54, pp. 2084-91.
     """
 
-    dist = DistributionParam()
-    scale = BoolParam()
+    dist = DistributionParam('dist')
+    scale = BoolParam('scale')
 
     def __init__(self, dist=Gaussian(mean=0, std=1), scale=True, seed=None):
         super(WhiteNoise, self).__init__(seed=seed)
@@ -155,9 +156,9 @@ class FilteredNoise(Process):
         Random number seed. Ensures noise will be the same each run.
     """
 
-    synapse = LinearFilterParam()
-    dist = DistributionParam()
-    scale = BoolParam()
+    synapse = LinearFilterParam('synapse')
+    dist = DistributionParam('dist')
+    scale = BoolParam('scale')
 
     def __init__(self, synapse=Lowpass(tau=0.005), synapse_kwargs={},
                  dist=Gaussian(mean=0, std=1), scale=True, seed=None):
@@ -236,9 +237,9 @@ class WhiteSignal(Process):
     seed : int, optional
         Random number seed. Ensures noise will be the same each run.
     """
-    period = NumberParam(low=0, low_open=True)
-    high = NumberParam(low=0, low_open=True, optional=True)
-    rms = NumberParam(low=0, low_open=True)
+    period = NumberParam('period', low=0, low_open=True)
+    high = NumberParam('high', low=0, low_open=True, optional=True)
+    rms = NumberParam('rms', low=0, low_open=True)
 
     def __init__(self, period, high=None, rms=0.5, seed=None):
         super(WhiteSignal, self).__init__(seed=seed)
@@ -288,8 +289,8 @@ class PresentInput(Process):
     presentation_time : float
         Show each input for `presentation_time` seconds.
     """
-    inputs = NdarrayParam(shape=('...',))
-    presentation_time = NumberParam(low=0, low_open=True)
+    inputs = NdarrayParam('inputs', shape=('...',))
+    presentation_time = NumberParam('presentation_time', low=0, low_open=True)
 
     def __init__(self, inputs, presentation_time):
         self.inputs = inputs
@@ -318,7 +319,7 @@ class ProcessParam(Parameter):
     def validate(self, instance, process):
         super(ProcessParam, self).validate(instance, process)
         if process is not None and not isinstance(process, Process):
-            raise ValueError("Must be Process (got type '%s')" % (
-                process.__class__.__name__))
-
+            raise ValidationError(
+                "Must be Process (got type %r)" % process.__class__.__name__,
+                attr=self.name, obj=instance)
         return process

--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -42,7 +42,10 @@ RC_DEFAULTS = {
     'progress': {
         'updater': 'auto',
         'progress_bar': 'auto',
-    }
+    },
+    'exceptions': {
+        'simplified': True,
+    },
 }
 
 # The RC files in the order in which they will be read.

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -15,6 +15,7 @@ import nengo.utils.numpy as npext
 from nengo.builder import Model
 from nengo.builder.signal import SignalDict
 from nengo.cache import get_default_decoder_cache
+from nengo.exceptions import ReadonlyError
 from nengo.utils.compat import range
 from nengo.utils.graphs import toposort
 from nengo.utils.progress import ProgressTracker
@@ -143,9 +144,7 @@ class Simulator(object):
 
     @dt.setter
     def dt(self, dummy):
-        raise AttributeError("Cannot change simulator 'dt'. Please file "
-                             "an issue at http://github.com/nengo/nengo"
-                             "/issues and describe your use case.")
+        raise ReadonlyError(attr='dt', obj=self)
 
     @property
     def time(self):

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -1,8 +1,4 @@
-"""
-Simulator.py
-
-Reference simulator for nengo models.
-"""
+"""Reference simulator for nengo models."""
 
 from __future__ import print_function
 
@@ -15,7 +11,7 @@ import nengo.utils.numpy as npext
 from nengo.builder import Model
 from nengo.builder.signal import SignalDict
 from nengo.cache import get_default_decoder_cache
-from nengo.exceptions import ReadonlyError
+from nengo.exceptions import ReadonlyError, SimulatorClosed
 from nengo.utils.compat import range
 from nengo.utils.graphs import toposort
 from nengo.utils.progress import ProgressTracker
@@ -180,7 +176,7 @@ class Simulator(object):
         """Advance the simulator by `self.dt` seconds.
         """
         if self.closed:
-            raise ValueError("Simulator cannot run because it is closed.")
+            raise SimulatorClosed("Simulator cannot run because it is closed.")
 
         self.n_steps += 1
         self.signals['__time__'][...] = self.n_steps * self.dt
@@ -257,7 +253,7 @@ class Simulator(object):
             (e.g. ensembles, connections).
         """
         if self.closed:
-            raise ValueError("Simulator closed.")
+            raise SimulatorClosed("Cannot reset closed Simulator.")
 
         if seed is not None:
             self.seed = seed
@@ -283,6 +279,6 @@ class Simulator(object):
         """Closes the simulator.
 
         Any call to ``run``, ``run_steps``, ``step``, and ``reset`` on a closed
-        simulator will raise a ``ValueError``.
+        simulator will raise ``SimulatorClosed``.
         """
         self.closed = True

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -12,8 +12,9 @@ import time
 
 import numpy as np
 
-from nengo.params import Parameter
 import nengo.utils.numpy as npext
+from nengo.exceptions import ValidationError
+from nengo.params import Parameter
 from nengo.utils.compat import range, with_metaclass, iteritems
 from nengo.utils.magic import DocstringInheritor
 
@@ -278,11 +279,13 @@ class Solver(with_metaclass(DocstringInheritor)):
     def mul_encoders(self, Y, E, copy=False):
         if self.weights:
             if E is None:
-                raise ValueError("Encoders must be provided for weight solver")
+                raise ValidationError(
+                    "Encoders must be provided for weight solver", attr='E')
             return np.dot(Y, E)
         else:
             if E is not None:
-                raise ValueError("Encoders must be 'None' for decoder solver")
+                raise ValidationError(
+                    "Encoders must be 'None' for decoder solver", attr='E')
             return Y.copy() if copy else Y
 
     def __hash__(self):
@@ -297,7 +300,7 @@ class Solver(with_metaclass(DocstringInheritor)):
                     a.setflags(write=False)
                     hashes.append(hash(a))
                 else:
-                    raise ValueError("array is too large to hash")
+                    raise ValidationError("array is too large to hash", attr=k)
             elif isinstance(v, collections.Iterable):
                 hashes.append(hash(tuple(v)))
             elif isinstance(v, collections.Callable):
@@ -607,5 +610,6 @@ class NnlsL2nz(NnlsL2):
 class SolverParam(Parameter):
     def validate(self, instance, solver):
         if solver is not None and not isinstance(solver, Solver):
-            raise ValueError("'%s' is not a solver" % solver)
+            raise ValidationError("'%s' is not a solver" % solver,
+                                  attr=self.name, obj=instance)
         super(SolverParam, self).validate(instance, solver)

--- a/nengo/spa/action_objects.py
+++ b/nengo/spa/action_objects.py
@@ -1,4 +1,6 @@
 """Syntactic parsing of the subexpressions of all action expressions."""
+
+from nengo.exceptions import SpaParseError
 from nengo.utils.compat import is_number
 
 
@@ -86,7 +88,8 @@ class Source(object):
 
     def __invert__(self):
         if self.transform.symbol != '1':
-            raise ValueError("You can only invert sources without transforms")
+            raise SpaParseError(
+                "You can only invert sources without transforms")
         return Source(self.name, self.transform, not self.inverted)
 
     def __mul__(self, other):
@@ -143,14 +146,14 @@ class DotProduct(object):
         if isinstance(item2, (int, float)):
             item2 = Symbol(item2)
         if not isinstance(item1, (Source, Symbol)):
-            raise TypeError("The first item in the dot product is not a "
-                            "semantic pointer or a spa.Module output.")
+            raise SpaParseError("The first item in the dot product is not a "
+                                "semantic pointer or a spa.Module output.")
         if not isinstance(item2, (Source, Symbol)):
-            raise TypeError("The second item in the dot product is not a "
-                            "semantic pointer or a spa.Module output.")
+            raise SpaParseError("The second item in the dot product is not a "
+                                "semantic pointer or a spa.Module output.")
         if not isinstance(item1, Source) and not isinstance(item2, Source):
-            raise TypeError("One of the two terms for the dot product "
-                            "must be a spa.Module output.")
+            raise SpaParseError("One of the two terms for the dot product "
+                                "must be a spa.Module output.")
         self.item1 = item1
         self.item2 = item2
         self.scale = float(scale)

--- a/nengo/spa/basalganglia.py
+++ b/nengo/spa/basalganglia.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.spa.action_objects import DotProduct, Source
 from nengo.spa.module import Module
 from nengo.utils.compat import is_number
@@ -113,9 +114,9 @@ class BasalGanglia(Module):
         scale : float
             a scaling factor to be applied to the result
         """
-        raise NotImplementedError('Compare between two sources will never be '
-                                  'implemented as discussed in '
-                                  'https://github.com/nengo/nengo/issues/759')
+        raise NotImplementedError("Compare between two sources will never be "
+                                  "implemented as discussed in "
+                                  "https://github.com/nengo/nengo/issues/759")
 
     def add_dot_input(self, index, source, symbol, scale):
         """Make an input that is the dot product of a Source and a Symbol.
@@ -162,15 +163,15 @@ class BasalGanglia(Module):
         """
         output, _ = self.spa.get_module_output(source.name)
         if output.size_out != 1:
-            raise NotImplementedError("Only sources with a dimension"
-                                      "of 1 can be scalar inputs")
+            raise NotImplementedError(
+                "Only 1-dimensional sources can be scalar inputs")
 
         try:
             scale = float(eval(source.transform.symbol))
         except ValueError:
-            raise ValueError("Transform can only be a scalar value"
-                             " the value %s is invalid"
-                             % source.transform.symbol)
+            raise ValidationError("Transform must be scalar; got '%s'"
+                                  % source.transform.symbol,
+                                  attr='source.transform')
 
         with self.spa:
             nengo.Connection(output, self.input[index:index+1],

--- a/nengo/spa/bind.py
+++ b/nengo/spa/bind.py
@@ -1,4 +1,5 @@
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.spa.module import Module
 
 
@@ -29,9 +30,10 @@ class Bind(Module):
             # use the default vocab for this number of dimensions
             vocab = dimensions
         elif vocab.dimensions != dimensions:
-            raise ValueError('Dimensionality of given vocabulary (%d) does not'
-                             'match dimensionality of buffer (%d)' %
-                             (vocab.dimensions, dimensions))
+            raise ValidationError(
+                "Dimensionality of given vocabulary (%d) does "
+                "not match dimensionality of buffer (%d)" %
+                (vocab.dimensions, dimensions), attr='dimensions', obj=self)
 
         with self:
             self.cc = nengo.networks.CircularConvolution(

--- a/nengo/spa/buffer.py
+++ b/nengo/spa/buffer.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.spa.module import Module
 
 
@@ -37,16 +38,19 @@ class Buffer(Module):
             # use the default one for this dimensionality
             vocab = dimensions
         elif vocab.dimensions != dimensions:
-            raise ValueError('Dimensionality of given vocabulary (%d) does not'
-                             'match dimensionality of buffer (%d)' %
-                             (vocab.dimensions, dimensions))
+            raise ValidationError(
+                "Dimensionality of given vocabulary (%d) does not match "
+                "dimensionality of buffer (%d)" %
+                (vocab.dimensions, dimensions), attr='dimensions', obj=self)
 
         # Subdimensions should be at most the number of dimensions
         subdimensions = min(dimensions, subdimensions)
 
         if dimensions % subdimensions != 0:
-            raise ValueError('Number of dimensions(%d) must be divisible by '
-                             'subdimensions(%d)' % (dimensions, subdimensions))
+            raise ValidationError(
+                "Number of dimensions (%d) must be divisible by subdimensions "
+                "(%d)" % (dimensions, subdimensions),
+                attr='dimensions', obj=self)
 
         with self:
             self.state = nengo.networks.EnsembleArray(

--- a/nengo/spa/pointer.py
+++ b/nengo/spa/pointer.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_integer, is_number, range
 
 
@@ -13,17 +14,20 @@ class SemanticPointer(object):
     def __init__(self, data, rng=None):
         if is_integer(data):
             if data < 1:
-                raise Exception("number of dimensions must be a positive int")
+                raise ValidationError("Number of dimensions must be a "
+                                      "positive int", attr='data', obj=self)
+
             self.randomize(data, rng=rng)
         else:
             try:
                 len(data)
             except:
-                raise Exception("Must specify either the data or the length "
-                                "for a SemanticPointer.")
+                raise ValidationError(
+                    "Must specify either the data or the length for a "
+                    "SemanticPointer.", attr='data', obj=self)
             self.v = np.array(data, dtype=float)
             if len(self.v.shape) != 1:
-                raise Exception("data must be a vector")
+                raise ValidationError("'data' must be a vector", 'data', self)
 
     def length(self):
         """Return the L2 norm of the vector."""
@@ -76,14 +80,15 @@ class SemanticPointer(object):
     def __mul__(self, other):
         """Multiplication of two SemanticPointers is circular convolution.
 
-        If mutliplied by a scaler, we do normal multiplication.
+        If multiplied by a scalar, we do normal multiplication.
         """
         if isinstance(other, SemanticPointer):
             return self.convolve(other)
         elif is_number(other):
             return SemanticPointer(data=self.v * other)
         else:
-            raise Exception('Can only multiply by SemanticPointers or scalars')
+            raise NotImplementedError(
+                "Can only multiply by SemanticPointers or scalars")
 
     def convolve(self, other):
         """Return the circular convolution of two SemanticPointers."""
@@ -100,7 +105,8 @@ class SemanticPointer(object):
         elif is_number(other):
             return SemanticPointer(data=self.v * other)
         else:
-            raise Exception('Can only multiply by SemanticPointers or scalars')
+            raise NotImplementedError(
+                "Can only multiply by SemanticPointers or scalars")
 
     def __imul__(self, other):
         """Multiplication of two SemanticPointers is circular convolution.
@@ -113,7 +119,8 @@ class SemanticPointer(object):
         elif is_number(other):
             self.v *= other
         else:
-            raise Exception('Can only multiply by SemanticPointers or scalars')
+            raise NotImplementedError(
+                "Can only multiply by SemanticPointers or scalars")
         return self
 
     def compare(self, other):

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -163,7 +163,7 @@ class SPA(nengo.Network):
         The name will be either the same as a module, or of the form
         <module_name>_<input_name>.
         """
-        if name in self._modules:
+        if name in self._modules and 'default' in self._modules[name].inputs:
             return self._modules[name].inputs['default']
         elif '_' in name:
             module, name = name.rsplit('_', 1)

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 
 import nengo
+from nengo.exceptions import SpaModuleError
 from nengo.spa.vocab import Vocabulary
 from nengo.spa.module import Module
 from nengo.spa.utils import enable_spa_params
@@ -99,9 +100,9 @@ class SPA(nengo.Network):
         the name that all of the SPA system will use to access that module.
         """
         if hasattr(self, key) and isinstance(getattr(self, key), Module):
-            raise ValueError("Cannot re-assign module-attribute %s to %s. "
-                             "SPA module-attributes can only be assigned "
-                             "once." % (key, value))
+            raise SpaModuleError("Cannot re-assign module-attribute %s to %s. "
+                                 "SPA module-attributes can only be assigned "
+                                 "once." % (key, value))
         super(SPA, self).__setattr__(key, value)
         if isinstance(value, Module):
             if value.label is None:
@@ -129,9 +130,8 @@ class SPA(nengo.Network):
             # Since there are no attributes to distinguish what's been added
             # and what hasn't, we have to ask the network
             if isinstance(net, Module) and (net not in module_list):
-                raise ValueError("%s was not added as an attribute of "
-                                 "the SPA network and won't be detected"
-                                 % (net))
+                raise SpaModuleError("%s must be set as an attribute of "
+                                     "a SPA network" % (net))
 
     def get_module(self, name):
         """Return the module for the given name."""
@@ -141,7 +141,7 @@ class SPA(nengo.Network):
             module, name = name.rsplit('_', 1)
             if module in self._modules:
                 return self._modules[module]
-        raise KeyError('Could not find module "%s"' % name)
+        raise SpaModuleError("Could not find module %r" % name)
 
     def get_default_vocab(self, dimensions):
         """Return a Vocabulary with the desired dimensions.
@@ -171,7 +171,7 @@ class SPA(nengo.Network):
                 m = self._modules[module]
                 if name in m.inputs:
                     return m.inputs[name]
-        raise KeyError('Could not find module input "%s"' % name)
+        raise SpaModuleError("Could not find module input %r" % name)
 
     def get_module_inputs(self):
         for name, module in iteritems(self._modules):
@@ -198,7 +198,7 @@ class SPA(nengo.Network):
                 m = self._modules[module]
                 if name in m.outputs:
                     return m.outputs[name]
-        raise KeyError('Could not find module output "%s"' % name)
+        raise SpaModuleError("Could not find module output %r" % name)
 
     def get_module_outputs(self):
         for name, module in iteritems(self._modules):

--- a/nengo/spa/state.py
+++ b/nengo/spa/state.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.spa.module import Module
 from nengo.networks.ensemblearray import EnsembleArray
 
@@ -38,16 +39,18 @@ class State(Module):
             # use the default one for this dimensionality
             vocab = dimensions
         elif vocab.dimensions != dimensions:
-            raise ValueError('Dimensionality of given vocabulary (%d) does not'
-                             'match dimensionality of buffer (%d)' %
-                             (vocab.dimensions, dimensions))
+            raise ValidationError(
+                "Dimensionality of given vocabulary (%d) does not "
+                "match dimensionality of buffer (%d)" %
+                (vocab.dimensions, dimensions), attr='dimensions', obj=self)
 
         # Subdimensions should be at most the number of dimensions
         subdimensions = min(dimensions, subdimensions)
 
         if dimensions % subdimensions != 0:
-            raise ValueError("Dimensions (%d) must be divisible by sub"
-                             "dimensions (%d)" % (dimensions, subdimensions))
+            raise ValidationError(
+                "Dimensions (%d) must be divisible by subdimensions (%d)"
+                % (dimensions, subdimensions), attr='dimensions', obj=self)
 
         with self:
             self.state_ensembles = EnsembleArray(

--- a/nengo/spa/tests/test_action_objects.py
+++ b/nengo/spa/tests/test_action_objects.py
@@ -1,5 +1,6 @@
 import pytest
 
+from nengo.exceptions import SpaParseError
 from nengo.spa.action_objects import Symbol, Source, DotProduct
 
 A = Symbol('A')
@@ -90,11 +91,11 @@ def test_dotproduct():
     assert str(DotProduct(x, A)) == 'dot(x, A)'
     assert str(DotProduct(B, y)) == 'dot(B, y)'
 
-    with pytest.raises(TypeError):
+    with pytest.raises(SpaParseError):
         DotProduct(B, A)
-    with pytest.raises(TypeError):
+    with pytest.raises(SpaParseError):
         DotProduct(A, "B")
-    with pytest.raises(TypeError):
+    with pytest.raises(SpaParseError):
         DotProduct(1, A)
 
     assert str(0.5*DotProduct(x, y)) == '0.5 * dot(x, y)'

--- a/nengo/spa/tests/test_actions.py
+++ b/nengo/spa/tests/test_actions.py
@@ -1,6 +1,7 @@
 import pytest
 
 from nengo import spa
+from nengo.exceptions import SpaParseError
 from nengo.spa.actions import Expression, Effect, Action, Actions
 
 
@@ -14,7 +15,7 @@ def test_expression():
     c = Expression(['a'], '1')
     assert str(c.expression) == '1'
 
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         c = Expression(['a', 'b'], 'dot(c, C)')
 
 
@@ -54,17 +55,17 @@ def test_effect():
     e = Effect(['a', 'b'], ['foo', 'bar'], '  foo = dot(a, b)  , bar = b')
     assert str(e) == 'foo=dot(a, b), bar=b'
 
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         Effect(['a', 'b'], ['q'], 'q=z')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SpaParseError):
         Effect(['a', 'b'], ['q'], 'q=a, q=b')  # lvalue appears twice
 
 
 def test_inverted():
-    with pytest.raises(ValueError):
+    with pytest.raises(SpaParseError):
         Effect(['b'], ['a'], 'a = ~2*b')
-    with pytest.raises(ValueError):
+    with pytest.raises(SpaParseError):
         Effect(['b'], ['a'], 'a = ~2*C*b')
 
 
@@ -79,26 +80,26 @@ def test_action():
     assert a.condition is None
     assert str(a.effect) == 'motor=A * vision'
 
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         a = Action(['vision', 'memory'], ['motor', 'memory'],
                    'motor=vis*A', 'test_action')
 
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         a = Action(['vision', 'memory'], ['motor', 'memory'],
                    '0.5 --> motor=vis*A', 'test_action')
 
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         a = Action(['vision', 'memory'], ['motor', 'memory'],
                    '0.5*dot(mem, a) --> motor=B', name=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(SpaParseError):
         a = Action(['vision', 'memory'], ['motor', 'memory'],
                    '0.5*dot(memory+1, vision) --> motor=B', name='test_action')
 
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         a = Action(['vision', 'memory'], ['motor', 'memory'],
                    'motor2=B', name='test_action')
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         a = Action(['vision', 'memory'], ['motor', 'memory'],
                    'motor=A, motor2=B', name='test_action')
 

--- a/nengo/spa/tests/test_cortical.py
+++ b/nengo/spa/tests/test_cortical.py
@@ -3,6 +3,7 @@ import pytest
 
 import nengo
 from nengo import spa
+from nengo.exceptions import SpaParseError
 
 
 def test_connect(Simulator, seed):
@@ -70,7 +71,7 @@ def test_translate(Simulator, seed):
 
 def test_errors():
     # buffer2 does not exist
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         with spa.SPA() as model:
             model.buffer = spa.Buffer(dimensions=16)
             model.cortical = spa.Cortical(spa.Actions('buffer2=buffer'))

--- a/nengo/spa/tests/test_spa.py
+++ b/nengo/spa/tests/test_spa.py
@@ -2,6 +2,7 @@ import pytest
 
 import nengo
 from nengo import spa
+from nengo.exceptions import SpaModuleError
 from nengo.utils.testing import warns
 
 
@@ -41,7 +42,7 @@ def test_spa_verification(seed, plt):
             input_node = spa.Input(buf='B')
             input_node.label = "woop"
 
-    with pytest.raises(KeyError):
+    with pytest.raises(SpaModuleError):
         model = spa.SPA(seed=seed)
         # build a model that should raise an error because no buf attribute
         with model:
@@ -80,15 +81,15 @@ def test_spa_get():
     assert model.get_module_input('compare_A')[0] is model.compare.inputA
     assert model.get_module_input('compare_B')[0] is model.compare.inputB
 
-    with pytest.raises(KeyError):
+    with pytest.raises(SpaModuleError):
         model.get_module('dummy')
-    with pytest.raises(KeyError):
+    with pytest.raises(SpaModuleError):
         model.get_module_input('dummy')
-    with pytest.raises(KeyError):
+    with pytest.raises(SpaModuleError):
         model.get_module_output('dummy')
-    with pytest.raises(KeyError):
+    with pytest.raises(SpaModuleError):
         model.get_module_input('buf1_A')
-    with pytest.raises(KeyError):
+    with pytest.raises(SpaModuleError):
         model.get_module_input('compare')
 
 

--- a/nengo/spa/tests/test_thalamus.py
+++ b/nengo/spa/tests/test_thalamus.py
@@ -2,6 +2,7 @@ import pytest
 
 import nengo
 from nengo import spa
+from nengo.exceptions import SpaParseError
 
 import numpy as np
 
@@ -177,7 +178,7 @@ def test_nondefault_routing(Simulator, seed, plt):
 
 def test_errors():
     # motor does not exist
-    with pytest.raises(NameError):
+    with pytest.raises(SpaParseError):
         with spa.SPA() as model:
             model.vision = spa.Buffer(dimensions=16)
             actions = spa.Actions('0.5 --> motor=A')

--- a/nengo/spa/tests/test_vocabulary.py
+++ b/nengo/spa/tests/test_vocabulary.py
@@ -3,7 +3,7 @@ import re
 import numpy as np
 import pytest
 
-from nengo.exceptions import ValidationError
+from nengo.exceptions import SpaParseError, ValidationError
 from nengo.spa import Vocabulary
 from nengo.utils.testing import warns
 
@@ -53,7 +53,7 @@ def test_parse(rng):
 
     with pytest.raises(SyntaxError):
         v.parse('A((')
-    with pytest.raises(TypeError):
+    with pytest.raises(SpaParseError):
         v.parse('"hello"')
 
 
@@ -96,9 +96,9 @@ def test_text(rng):
 
 def test_capital(rng):
     v = Vocabulary(16, rng=rng)
-    with pytest.raises(KeyError):
+    with pytest.raises(SpaParseError):
         v.parse('a')
-    with pytest.raises(KeyError):
+    with pytest.raises(SpaParseError):
         v.parse('A+B+C+a')
 
 

--- a/nengo/spa/tests/test_vocabulary.py
+++ b/nengo/spa/tests/test_vocabulary.py
@@ -3,6 +3,7 @@ import re
 import numpy as np
 import pytest
 
+from nengo.exceptions import ValidationError
 from nengo.spa import Vocabulary
 from nengo.utils.testing import warns
 
@@ -57,11 +58,11 @@ def test_parse(rng):
 
 
 def test_invalid_dimensions():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         Vocabulary(1.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         Vocabulary(0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         Vocabulary(-1)
 
 

--- a/nengo/spa/utils.py
+++ b/nengo/spa/utils.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import nengo
 import nengo.utils.numpy as npext
+from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_iterable
 
 
@@ -46,8 +47,8 @@ def similarity(data, vocab, normalize=False):
     elif is_iterable(vocab):
         vectors = np.array(vocab, copy=False, ndmin=2)
     else:
-        raise ValueError("'%s' object is not a valid vocabulary"
-                         % (vocab.__class__.__name__))
+        raise ValidationError("%r object is not a valid vocabulary"
+                              % (vocab.__class__.__name__), attr='vocab')
 
     data = np.array(data, copy=False, ndmin=2)
     dots = np.dot(data, vectors.T)

--- a/nengo/spa/vocab.py
+++ b/nengo/spa/vocab.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 import nengo
-from nengo.exceptions import ValidationError
+from nengo.exceptions import SpaParseError, ValidationError
 from nengo.spa import pointer
 from nengo.utils.compat import is_iterable, is_number, is_integer, range
 
@@ -133,7 +133,8 @@ class Vocabulary(object):
         with a capital letter.
         """
         if not key[0].isupper():
-            raise KeyError('Semantic pointers must begin with a capital')
+            raise SpaParseError(
+                "Semantic pointers must begin with a capital letter.")
         value = self.pointers.get(key, None)
         if value is None:
             if is_iterable(self.unitary):
@@ -150,7 +151,8 @@ class Vocabulary(object):
         The pointer value can be a SemanticPointer or a vector.
         """
         if not key[0].isupper():
-            raise KeyError('Semantic pointers must begin with a capital')
+            raise SpaParseError(
+                "Semantic pointers must begin with a capital letter.")
         if not isinstance(p, pointer.SemanticPointer):
             p = pointer.SemanticPointer(p)
 
@@ -216,13 +218,14 @@ class Vocabulary(object):
         try:
             value = eval(text, {}, self)
         except NameError:
-            raise KeyError('Semantic pointers must start with a capital')
+            raise SpaParseError(
+                "Semantic pointers must start with a capital letter.")
 
         if is_number(value):
             value = value * self.identity
         if not isinstance(value, pointer.SemanticPointer):
-            raise TypeError('The result of "%s" was not a SemanticPointer' %
-                            text)
+            raise SpaParseError(
+                "The result of parsing '%s' is not a SemanticPointer" % text)
         return value
 
     @property

--- a/nengo/tests/test_base.py
+++ b/nengo/tests/test_base.py
@@ -5,16 +5,17 @@ import pytest
 
 import nengo
 from nengo.base import NengoObjectParam
+from nengo.exceptions import ValidationError
 
 
 def test_nengoobjectparam():
     """NengoObjectParam must be a Nengo object and is readonly by default."""
     class Test(object):
-        nop = NengoObjectParam()
+        nop = NengoObjectParam('nop')
     inst = Test()
 
     # Must be a Nengo object
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.nop = 'a'
 
     # Can set it once
@@ -23,15 +24,15 @@ def test_nengoobjectparam():
     assert inst.nop is a.neurons
 
     # Can't set it twice
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.nop = a
 
 
 def test_nengoobjectparam_nonzero():
     """Can check that objects have nonzero size in/out."""
     class Test(object):
-        nin = NengoObjectParam(nonzero_size_in=True)
-        nout = NengoObjectParam(nonzero_size_out=True)
+        nin = NengoObjectParam('nin', nonzero_size_in=True)
+        nout = NengoObjectParam('nout', nonzero_size_out=True)
 
     inst = Test()
     with nengo.Network():
@@ -39,11 +40,11 @@ def test_nengoobjectparam_nonzero():
         nout = nengo.Node(output=lambda t, x: None, size_in=1)
         probe = nengo.Probe(nin)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             inst.nin = nin
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             inst.nout = nout
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             inst.nout = probe
 
         inst.nin = nout

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -8,7 +8,7 @@ from nengo.builder import Model
 from nengo.builder.ensemble import BuiltEnsemble
 from nengo.builder.operator import DotInc, PreserveValue
 from nengo.builder.signal import Signal, SignalDict
-from nengo.exceptions import ObsoleteError
+from nengo.exceptions import ObsoleteError, SignalError
 from nengo.utils.compat import itervalues, range
 
 
@@ -116,7 +116,7 @@ def test_signal_values():
     assert np.allclose(two_d_view.initial_value, np.array([1]))
 
     # cannot change signal value after creation
-    with pytest.raises(RuntimeError):
+    with pytest.raises(SignalError):
         two_d.initial_value = np.array([[0.5], [-0.5]])
     with pytest.raises((ValueError, RuntimeError)):
         two_d.initial_value[...] = np.array([[0.5], [-0.5]])

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -8,6 +8,7 @@ from nengo.builder import Model
 from nengo.builder.ensemble import BuiltEnsemble
 from nengo.builder.operator import DotInc, PreserveValue
 from nengo.builder.signal import Signal, SignalDict
+from nengo.exceptions import ObsoleteError
 from nengo.utils.compat import itervalues, range
 
 
@@ -267,3 +268,15 @@ def test_commonsig_readonly(RefSimulator):
                 sim.signals[sig] = np.array([-1])
             with pytest.raises((ValueError, RuntimeError)):
                 sim.signals[sig][...] = np.array([-1])
+
+
+def test_obsolete_params(RefSimulator):
+    with nengo.Network() as net:
+        e = nengo.Ensemble(10, 1)
+        c = nengo.Connection(e, e)
+    with RefSimulator(net) as sim:
+        pass
+    with pytest.raises(ObsoleteError):
+        sim.data[c].decoders
+    with pytest.raises(ObsoleteError):
+        sim.data[c].transform

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -10,6 +10,8 @@ import pytest
 
 import nengo
 from nengo.cache import DecoderCache, Fingerprint, get_fragment_size
+from nengo.exceptions import FingerprintError
+from nengo.rc import rc, RC_DEFAULTS
 from nengo.utils.compat import int_types
 
 
@@ -253,7 +255,7 @@ def test_fingerprinting(reference, equal, different):
 
 
 def test_fails_for_lambda_expression():
-    with pytest.raises((ValueError, AttributeError)):
+    with pytest.raises(FingerprintError):
         Fingerprint(lambda x: x)
 
 
@@ -364,6 +366,12 @@ sim = nengo.Simulator(model)
 
         times = [self.time_all(self.get_args(varying_param, v))
                  for v in varying]
+
+        # Restore RC to original settings
+        default = RC_DEFAULTS['decoder_cache', 'enabled']
+        rc.set("decoder_cache", "enabled", str(default))
+        default = RC_DEFAULTS['decoder_cache', 'readonly']
+        rc.set("decoder_cache", "readonly", str(default))
 
         for i, data in enumerate(zip(*times)):
             plt.plot(varying, np.median(data, axis=1), label=self.labels[i])

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -7,9 +7,12 @@ from nengo.params import Parameter
 
 def test_config_basic():
     model = nengo.Network()
-    model.config[nengo.Ensemble].set_param('something', Parameter(None))
-    model.config[nengo.Ensemble].set_param('other', Parameter(default=0))
-    model.config[nengo.Connection].set_param('something_else', Parameter(None))
+    model.config[nengo.Ensemble].set_param('something',
+                                           Parameter('something', None))
+    model.config[nengo.Ensemble].set_param('other',
+                                           Parameter('other', default=0))
+    model.config[nengo.Connection].set_param('something_else',
+                                             Parameter('something_else', None))
 
     with pytest.raises(TypeError):
         model.config[nengo.Ensemble].set_param('fails', 1.0)
@@ -142,11 +145,11 @@ def test_config_property():
 
 def test_external_class():
     class A(object):
-        thing = Parameter(default='hey')
+        thing = Parameter('thing', default='hey')
 
     inst = A()
     config = nengo.Config(A)
-    config[A].set_param('amount', Parameter(default=1))
+    config[A].set_param('amount', Parameter('amount', default=1))
 
     # Extra param
     assert config[inst].amount == 1
@@ -165,7 +168,7 @@ def test_instance_fallthrough():
     inst1 = A()
     inst2 = A()
     config = nengo.Config(A)
-    config[A].set_param('amount', Parameter(default=1))
+    config[A].set_param('amount', Parameter('amount', default=1))
     assert config[A].amount == 1
     assert config[inst1].amount == 1
     assert config[inst2].amount == 1

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -2,6 +2,7 @@ import pytest
 
 import nengo
 import nengo.synapses
+from nengo.exceptions import ReadonlyError
 from nengo.params import Parameter
 
 
@@ -135,7 +136,7 @@ def test_configstack():
 def test_config_property():
     """Test that config can't be easily modified."""
     with nengo.Network() as net:
-        with pytest.raises(AttributeError):
+        with pytest.raises(ReadonlyError):
             net.config = nengo.config.Config()
         with pytest.raises(AttributeError):
             del net.config

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 import nengo
 import nengo.synapses
-from nengo.exceptions import ReadonlyError
+from nengo.exceptions import ConfigError, ReadonlyError
 from nengo.params import Parameter
 
 
@@ -15,7 +15,7 @@ def test_config_basic():
     model.config[nengo.Connection].set_param('something_else',
                                              Parameter('something_else', None))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ConfigError):
         model.config[nengo.Ensemble].set_param('fails', 1.0)
 
     with model:
@@ -23,8 +23,8 @@ def test_config_basic():
         b = nengo.Ensemble(90, dimensions=1)
         a2b = nengo.Connection(a, b, synapse=0.01)
 
-    with pytest.raises(ValueError):
-        model.config[a].set_param('thing', Parameter(None))
+    with pytest.raises(ConfigError):
+        model.config[a].set_param('thing', Parameter('thing', None))
 
     assert model.config[a].something is None
     assert model.config[b].something is None
@@ -46,9 +46,9 @@ def test_config_basic():
         model.config[a].something_else = 1
         model.config[a2b].something = 1
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ConfigError):
         model.config['a'].something
-    with pytest.raises(KeyError):
+    with pytest.raises(ConfigError):
         model.config[None].something
 
 
@@ -73,7 +73,7 @@ def test_network_nesting():
         assert ens1.radius == 2.0
 
         # It's an error to configure an actual param with the config
-        with pytest.raises(AttributeError):
+        with pytest.raises(ConfigError):
             net1.config[ens1].radius = 3.0
 
         with nengo.Network() as net2:
@@ -157,7 +157,7 @@ def test_external_class():
 
     # Default still works like Nengo object
     assert inst.thing == 'hey'
-    with pytest.raises(AttributeError):
+    with pytest.raises(ConfigError):
         config[inst].thing
 
 

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -5,7 +5,7 @@ import nengo
 import nengo.utils.numpy as npext
 from nengo.connection import ConnectionSolverParam
 from nengo.dists import UniformHypersphere
-from nengo.exceptions import ValidationError
+from nengo.exceptions import ObsoleteError, ValidationError
 from nengo.solvers import LstsqL2
 from nengo.utils.functions import piecewise
 from nengo.utils.testing import allclose
@@ -783,7 +783,7 @@ def test_nomodulatory():
     """Make sure you cannot set modulatory=True on connections."""
     with nengo.Network():
         a = nengo.Ensemble(10, 1)
-        with pytest.raises(ValueError):
+        with pytest.raises(ObsoleteError):
             nengo.Connection(a, a, modulatory=True)
 
 

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -3,6 +3,7 @@ import pytest
 
 import nengo.dists as dists
 import nengo.utils.numpy as npext
+from nengo.exceptions import ValidationError
 
 
 def test_pdf(rng):
@@ -244,7 +245,8 @@ def test_cosine_intercept(d, p, rng):
 def test_distorarrayparam():
     """DistOrArrayParams can be distributions or samples."""
     class Test(object):
-        dp = dists.DistOrArrayParam(default=None, sample_shape=['*', '*'])
+        dp = dists.DistOrArrayParam('dp',
+                                    default=None, sample_shape=['*', '*'])
 
     inst = Test()
     inst.dp = dists.UniformHypersphere()
@@ -261,7 +263,8 @@ def test_distorarrayparam():
 def test_distorarrayparam_sample_shape():
     """sample_shape dictates the shape of the sample that can be set."""
     class Test(object):
-        dp = dists.DistOrArrayParam(default=None, sample_shape=['d1', 10])
+        dp = dists.DistOrArrayParam(
+            'dp', default=None, sample_shape=['d1', 10])
         d1 = 4
 
     inst = Test()
@@ -271,7 +274,7 @@ def test_distorarrayparam_sample_shape():
     # Must be shape (4, 10)
     inst.dp = np.ones((4, 10))
     assert np.all(inst.dp == np.ones((4, 10)))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.dp = np.ones((10, 4))
     assert np.all(inst.dp == np.ones((4, 10)))
 

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import _pytest.capture
 
+from nengo.rc import rc
 from nengo.utils.paths import examples_dir
 from nengo.utils.stdlib import execfile
 
@@ -52,6 +53,15 @@ for subdir, _, files in os.walk(examples_dir):
 all_examples.sort()
 slow_examples.sort()
 fast_examples.sort()
+
+
+def teardown_function(function):
+    """Executed by py.test after each test in this module
+
+    Since examples might muck with the RC settings, we reset them here.
+    """
+    rc.reload_rc([])
+    rc.set('decoder_cache', 'enabled', 'False')
 
 
 def assert_noexceptions(nb_file, tmpdir, plt):

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -279,7 +279,7 @@ def test_reset(Simulator, learning_rule, plt, seed, rng):
 def test_learningruletypeparam():
     """LearningRuleTypeParam must be one or many learning rules."""
     class Test(object):
-        lrp = LearningRuleTypeParam(default=None)
+        lrp = LearningRuleTypeParam('lrp', default=None)
 
     inst = Test()
     assert inst.lrp is None

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -348,7 +348,7 @@ def test_reset(Simulator, nl_nodirect, seed, rng):
 def test_neurontypeparam():
     """NeuronTypeParam must be a neuron type."""
     class Test(object):
-        ntp = NeuronTypeParam(default=None)
+        ntp = NeuronTypeParam('ntp', default=None)
 
     inst = Test()
     inst.ntp = nengo.LIF()

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import nengo
-from nengo.exceptions import ValidationError
+from nengo.exceptions import SimulationError, ValidationError
 from nengo.utils.testing import warns
 
 
@@ -186,7 +186,7 @@ def test_none(Simulator, seed):
         nengo.Connection(u, a)
 
     with Simulator(model) as sim:
-        with pytest.raises(ValueError):
+        with pytest.raises(SimulationError):
             sim.run(0.01)
 
     # This function will pass (with a warning), because it will

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.utils.testing import warns
 
 
@@ -140,16 +141,16 @@ def test_circular(Simulator, seed):
 
 def test_function_args_error(Simulator):
     with nengo.Network() as model:
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=lambda t, x: x+1)
         nengo.Node(output=lambda t, x=[0]: t+1, size_in=1)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=lambda t: t+1, size_in=1)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=lambda t, x, y: t+1, size_in=2)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=[0], size_in=1)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=0, size_in=1)
     with Simulator(model):
         pass
@@ -157,13 +158,13 @@ def test_function_args_error(Simulator):
 
 def test_output_shape_error():
     with nengo.Network():
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=[[1, 2], [3, 4]])
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=lambda t: [[t, t+1]])
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=[[3, 1], [2, 9]], size_out=4)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             nengo.Node(output=[1, 2, 3, 4, 5], size_out=4)
 
 
@@ -253,13 +254,13 @@ def test_set_output(Simulator):
 
         # if output is an array-like...
         # size_in must be 0
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             nengo.Node(np.ones(1), size_in=1)
         # size_out must match
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             nengo.Node(np.ones(3), size_out=2)
         # must be scalar or vector, not matrix
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             nengo.Node(np.ones((2, 2)))
         # scalar gets promoted to float vector
         scalar = nengo.Node(2)
@@ -272,13 +273,13 @@ def test_set_output(Simulator):
 
         # if output is callable...
         # if size_in is 0, should only take in t
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             nengo.Node(lambda t, x: 2.0, size_in=0)
         # if size_in > 0, should take both t and x
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             nengo.Node(lambda t: t ** 2, size_in=1)
         # function must return a scalar or vector, not matrix
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             nengo.Node(lambda t: np.ones((2, 2)))
         # if we pass size_out, function should not be called
         assert len(counter) == 0

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from nengo import params
+from nengo.exceptions import ValidationError
 from nengo.utils.compat import PY2
 
 
@@ -9,7 +10,7 @@ def test_default():
     """A default value is immediately available, but can be overridden."""
 
     class Test(object):
-        p = params.Parameter(default=1)
+        p = params.Parameter('p', default=1)
 
     inst1 = Test()
     inst2 = Test()
@@ -24,11 +25,11 @@ def test_optional():
     """Optional Parameters can bet set to None."""
 
     class Test(object):
-        m = params.Parameter(default=1, optional=False)
-        o = params.Parameter(default=1, optional=True)
+        m = params.Parameter('m', default=1, optional=False)
+        o = params.Parameter('o', default=1, optional=True)
 
     inst = Test()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.m = None
     assert inst.m == 1
     inst.o = None
@@ -39,8 +40,8 @@ def test_readonly():
     """Readonly Parameters can only be set once."""
 
     class Test(object):
-        p = params.Parameter(default=1, readonly=False)
-        r = params.Parameter(default=None, readonly=True)
+        p = params.Parameter('p', default=1, readonly=False)
+        r = params.Parameter('r', default=None, readonly=True)
 
     inst = Test()
     assert inst.p == 1
@@ -50,7 +51,7 @@ def test_readonly():
     assert inst.p == 2
     assert inst.r == 'set'
     inst.p = 3
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.r = 'set again'
     assert inst.p == 3
     assert inst.r == 'set'
@@ -60,7 +61,7 @@ def test_obsoleteparam():
     """ObsoleteParams must not be set."""
 
     class Test(object):
-        ab = params.ObsoleteParam(123, "msg")
+        ab = params.ObsoleteParam('ab', "msg")
 
     inst = Test()
 
@@ -78,13 +79,13 @@ def test_boolparam():
     """BoolParams can only be booleans."""
 
     class Test(object):
-        bp = params.BoolParam(default=False)
+        bp = params.BoolParam('bp', default=False)
 
     inst = Test()
     assert not inst.bp
     inst.bp = True
     assert inst.bp
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.bp = 1
 
 
@@ -92,10 +93,10 @@ def test_numberparam():
     """NumberParams can be numbers constrained to a range."""
 
     class Test(object):
-        np = params.NumberParam(default=1.0)
-        np_l = params.NumberParam(default=1.0, low=0.0)
-        np_h = params.NumberParam(default=-1.0, high=0.0)
-        np_lh = params.NumberParam(default=1.0, low=-1.0, high=1.0)
+        np = params.NumberParam('np', default=1.0)
+        np_l = params.NumberParam('np_l', default=1.0, low=0.0)
+        np_h = params.NumberParam('np_h', default=-1.0, high=0.0)
+        np_lh = params.NumberParam('np_lh', default=1.0, low=-1.0, high=1.0)
 
     inst = Test()
 
@@ -107,9 +108,9 @@ def test_numberparam():
 
     # respect low boundaries
     inst.np = -10
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.np_l = -10
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.np_lh = -10
     assert inst.np == -10
     assert inst.np_l == 1.0
@@ -120,9 +121,9 @@ def test_numberparam():
 
     # respect high boundaries
     inst.np = 10
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.np_h = 10
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.np_lh = 10
     assert inst.np == 10
     assert inst.np_h == -1.0
@@ -136,29 +137,29 @@ def test_numberparam():
     assert inst.np == 2.0
 
     # must be a number!
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.np = 'a'
 
 
 def test_intparam():
     """IntParams are like NumberParams but must be an int."""
     class Test(object):
-        ip = params.IntParam(default=1, low=0, high=2)
+        ip = params.IntParam('ip', default=1, low=0, high=2)
 
     inst = Test()
     assert inst.ip == 1
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.ip = -1
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.ip = 3
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.ip = 'a'
 
 
 def test_stringparam():
     """StringParams must be strings (bytes or unicode)."""
     class Test(object):
-        sp = params.StringParam(default="Hi")
+        sp = params.StringParam('sp', default="Hi")
 
     inst = Test()
     assert inst.sp == "Hi"
@@ -172,13 +173,13 @@ def test_stringparam():
     assert inst.sp == u"goodbye"
 
     # Non-strings no good
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.sp = 1
 
 
 def test_enumparam():
     class Test(object):
-        ep = params.EnumParam(default='a', values=('a', 'b', 'c'))
+        ep = params.EnumParam('ep', default='a', values=('a', 'b', 'c'))
 
     inst = Test()
     assert inst.ep == 'a'
@@ -197,7 +198,7 @@ def test_enumparam():
 def test_dictparam():
     """DictParams must be dictionaries."""
     class Test(object):
-        dp = params.DictParam(default={'a': 1})
+        dp = params.DictParam('dp', default={'a': 1})
 
     inst1 = Test()
     assert inst1.dp == {'a': 1}
@@ -208,28 +209,28 @@ def test_dictparam():
     assert inst2.dp == {'a': 1, 'b': 2}
 
     # Non-dicts no good
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst2.dp = [('a', 1), ('b', 2)]
 
 
 def test_ndarrayparam():
     """NdarrayParams must be able to be made into float ndarrays."""
     class Test(object):
-        ndp = params.NdarrayParam(default=None, shape=('*',))
-        ella = params.NdarrayParam(default=None, shape=(3, '...'))
-        ellb = params.NdarrayParam(default=None, shape=(3, '...', 2))
+        ndp = params.NdarrayParam('ndp', default=None, shape=('*',))
+        ella = params.NdarrayParam('ella', default=None, shape=(3, '...'))
+        ellb = params.NdarrayParam('ellb', default=None, shape=(3, '...', 2))
 
     inst = Test()
     inst.ndp = np.ones(10)
     assert np.all(inst.ndp == np.ones(10))
     # Dimensionality too low
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.ndp = 0
     # Dimensionality too high
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.ndp = np.ones((1, 1))
     # Must be convertible to float array
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.ndp = 'a'
 
     inst.ella = np.ones((3,))
@@ -246,14 +247,14 @@ def test_ndarrayparam():
 def test_ndarrayparam_sample_shape():
     """sample_shape dictates the shape of the sample that can be set."""
     class Test(object):
-        ndp = params.NdarrayParam(default=None, shape=[10, 'd2'])
+        ndp = params.NdarrayParam('ndp', default=None, shape=[10, 'd2'])
         d2 = 3
 
     inst = Test()
     # Must be shape (4, 10)
     inst.ndp = np.ones((10, 3))
     assert np.all(inst.ndp == np.ones((10, 3)))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.ndp = np.ones((3, 10))
     assert np.all(inst.ndp == np.ones((10, 3)))
 
@@ -261,7 +262,7 @@ def test_ndarrayparam_sample_shape():
 def test_functionparam():
     """FunctionParam must be a function, and accept one scalar argument."""
     class Test(object):
-        fp = params.FunctionParam(default=None)
+        fp = params.FunctionParam('fp', default=None)
 
     inst = Test()
     assert inst.fp is None
@@ -269,8 +270,8 @@ def test_functionparam():
     assert inst.fp.function is np.sin
     assert inst.fp.size == 1
     # Not OK: requires two args
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         inst.fp = lambda x, y: x + y
     # Not OK: not a function
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         inst.fp = 0

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from nengo import params
-from nengo.exceptions import ValidationError
+from nengo.exceptions import ObsoleteError, ValidationError
 from nengo.utils.compat import PY2
 
 
@@ -66,12 +66,12 @@ def test_obsoleteparam():
     inst = Test()
 
     # cannot be read
-    with pytest.raises(ValueError):
+    with pytest.raises(ObsoleteError):
         inst.ab
 
     # can only be assigned Unconfigurable
     inst.ab = params.Unconfigurable
-    with pytest.raises(ValueError):
+    with pytest.raises(ObsoleteError):
         inst.ab = True
 
 

--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 
 import nengo
+from nengo.exceptions import ObsoleteError
 from nengo.utils.compat import range
 from nengo.utils.stdlib import Timer
 
@@ -196,3 +198,14 @@ def test_solver_defaults():
     assert d.solver is solver2
     assert e.solver is solver1
     assert f.solver is solver3
+
+
+def test_obsolete_probes():
+    with nengo.Network():
+        pre = nengo.Ensemble(10, 1)
+        post = nengo.Ensemble(10, 1)
+        conn = nengo.Connection(pre, post)
+        with pytest.raises(ObsoleteError):
+            nengo.Probe(conn, "decoders")
+        with pytest.raises(ObsoleteError):
+            nengo.Probe(conn, "transform")

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -3,6 +3,7 @@ import pytest
 
 import nengo
 import nengo.simulator
+from nengo.exceptions import SimulatorClosed
 
 
 def test_steps(RefSimulator):
@@ -62,9 +63,9 @@ def test_close_function(Simulator):
 
     sim = Simulator(m)
     sim.close()
-    with pytest.raises(ValueError):
+    with pytest.raises(SimulatorClosed):
         sim.run(1.)
-    with pytest.raises(ValueError):
+    with pytest.raises(SimulatorClosed):
         sim.reset()
 
 
@@ -76,9 +77,9 @@ def test_close_context(Simulator):
     with Simulator(m) as sim:
         sim.run(0.01)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SimulatorClosed):
         sim.run(1.)
-    with pytest.raises(ValueError):
+    with pytest.raises(SimulatorClosed):
         sim.reset()
 
 
@@ -91,16 +92,16 @@ def test_close_steps(RefSimulator):
     # test close function
     sim = RefSimulator(m)
     sim.close()
-    with pytest.raises(ValueError):
+    with pytest.raises(SimulatorClosed):
         sim.run_steps(1)
-    with pytest.raises(ValueError):
+    with pytest.raises(SimulatorClosed):
         sim.step()
 
     # test close context
     with RefSimulator(m) as sim:
         sim.run(0.01)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SimulatorClosed):
         sim.run_steps(1)
-    with pytest.raises(ValueError):
+    with pytest.raises(SimulatorClosed):
         sim.step()

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -169,7 +169,7 @@ def test_lti_lowpass(rng, plt):
 def test_synapseparam():
     """SynapseParam must be a Synapse, and converts numbers to LowPass."""
     class Test(object):
-        sp = SynapseParam(default=Lowpass(0.1))
+        sp = SynapseParam('sp', default=Lowpass(0.1))
 
     inst = Test()
     assert isinstance(inst.sp, Lowpass)

--- a/nengo/utils/builder.py
+++ b/nengo/utils/builder.py
@@ -8,7 +8,7 @@ import collections
 import numpy as np
 
 import nengo
-from nengo.exceptions import ValidationError
+from nengo.exceptions import Unconvertible, ValidationError
 
 
 def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
@@ -152,15 +152,14 @@ def _create_replacement_connection(c_in, c_out):
     elif c_out.synapse is None:
         synapse = c_in.synapse
     else:
-        raise NotImplementedError('Cannot merge two filters')
+        raise Unconvertible("Cannot merge two filters")
         # Note: the algorithm below is in the right ballpark,
         #  but isn't exactly the same as two low-pass filters
         # filter = c_out.filter + c_in.filter
 
     function = c_in.function
     if c_out.function is not None:
-        raise Exception('Cannot remove a Node with a '
-                        'function being computed on it')
+        raise Unconvertible("Cannot remove a connection with a function")
 
     # compute the combined transform
     transform = np.dot(full_transform(c_out), full_transform(c_in))
@@ -228,7 +227,8 @@ def remove_passthrough_nodes(objs, connections,  # noqa: C901
             # replace those connections with equivalent ones
             for c_in in inputs[obj]:
                 if c_in.pre_obj is obj:
-                    raise Exception('Cannot remove a Node with feedback')
+                    raise Unconvertible(
+                        "Cannot remove a Node with a feedback connection")
 
                 for c_out in outputs[obj]:
                     c = create_connection_fn(c_in, c_out)

--- a/nengo/utils/builder.py
+++ b/nengo/utils/builder.py
@@ -8,6 +8,7 @@ import collections
 import numpy as np
 
 import nengo
+from nengo.exceptions import ValidationError
 
 
 def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
@@ -57,9 +58,11 @@ def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
         repeated_inds = lambda x: (
             not isinstance(x, slice) and np.unique(x).size != len(x))
         if repeated_inds(pre_slice):
-            raise ValueError("Input object selection has repeated indices")
+            raise NotImplementedError(
+                "Input object selection has repeated indices")
         if repeated_inds(post_slice):
-            raise ValueError("Output object selection has repeated indices")
+            raise NotImplementedError(
+                "Output object selection has repeated indices")
 
         rows_transform = np.array(new_transform[post_slice])
         rows_transform[:, pre_slice] = transform
@@ -69,7 +72,8 @@ def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
         #  just individual items
         return new_transform
     else:
-        raise ValueError("Transforms with > 2 dims not supported")
+        raise ValidationError("Transforms with > 2 dims not supported",
+                              attr='transform', obj=conn)
 
 
 def default_n_eval_points(n_neurons, dimensions):

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import numpy as np
 
 from . import numpy as npext
+from ..exceptions import ValidationError
 
 
 def target_function(eval_points, targets):
@@ -42,9 +43,9 @@ def target_function(eval_points, targets):
     targets = npext.array(targets, dtype=np.float64, min_dims=2)
 
     if len(eval_points) != len(targets):
-        raise ValueError("Number of evaluation points %s "
-                         "is not equal to number of targets "
-                         "%s" % (len(eval_points), len(targets)))
+        raise ValidationError(
+            "Number of evaluation points (%d) is not equal to the number of "
+            "targets (%s)" % (len(eval_points), len(targets)), 'eval_points')
 
     func_dict = {}
     for eval_point, target in zip(eval_points, targets):

--- a/nengo/utils/functions.py
+++ b/nengo/utils/functions.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 import numpy as np
 
+from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_number, iteritems
 
 
@@ -77,8 +78,8 @@ def piecewise(data):
     output_length = None  # the dimensionality of the returned values
     for time in data:
         if not is_number(time):
-            raise TypeError('Keys must be times (floats or ints), not "%s"'
-                            % repr(time.__class__))
+            raise ValidationError("Keys must be times (floats or ints), not %r"
+                                  % time.__class__.__name__, attr='data')
 
         # figure out the length of this item
         if callable(data[time]):
@@ -89,9 +90,8 @@ def piecewise(data):
 
         # make sure this is the same length as previous items
         if length != output_length and output_length is not None:
-            raise ValueError('Invalid data for piecewise function: '
-                             'time %4g has %d items instead of %d' %
-                             (time, length, output_length))
+            raise ValidationError("time %g has %d items instead of %d" %
+                                  (time, length, output_length), attr='data')
         output_length = length
 
     # make a default output of 0 when t before what was passed

--- a/nengo/utils/graphs.py
+++ b/nengo/utils/graphs.py
@@ -38,6 +38,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from collections import defaultdict
 
 from .compat import iteritems
+from ..exceptions import BuildError
 
 
 def graph(edges=None):
@@ -90,9 +91,10 @@ def toposort(edges):
             if not incoming_edges[m]:
                 vertices.add(m)
     if any(incoming_edges.get(v, None) for v in edges):
-        raise ValueError("Input graph has cycles. This usually occurs because "
-                         "too many connections have no synapses. Try setting "
-                         "more synapses to '0' instead of 'None'.")
+        raise BuildError(
+            "Input graph has cycles. This usually occurs because "
+            "too many connections have no synapses. Try setting "
+            "more synapses to '0' instead of 'None'.")
     return ordered
 
 

--- a/nengo/utils/logging.py
+++ b/nengo/utils/logging.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import logging
 import sys
 
-from nengo.utils.compat import TextIO
+from .compat import TextIO
 
 console_formatter = logging.Formatter('[%(levelname)s] %(message)s')
 file_formatter = logging.Formatter(

--- a/nengo/utils/matplotlib.py
+++ b/nengo/utils/matplotlib.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import warnings
 
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 
 from nengo.utils.compat import range
@@ -102,10 +103,11 @@ def rasterplot(time, spikes, ax=None, use_eventplot=False, **kwargs):  # noqa: C
     if ax is None:
         ax = plt.gca()
 
-    # older Matplotlib doesn't have eventplot
-    has_eventplot = hasattr(ax, 'eventplot')
-    if use_eventplot and not has_eventplot:
-        raise ValueError("Your Matplotlib version does not have 'eventplot'")
+    if use_eventplot and not hasattr(ax, 'eventplot'):
+        warnings.warn("Matplotlib version %s does not have 'eventplot'. "
+                      "Falling back to non-eventplot version."
+                      % matplotlib.__version__)
+        use_eventplot = False
 
     colors = kwargs.pop('colors', None)
     if colors is None:

--- a/nengo/utils/nco.py
+++ b/nengo/utils/nco.py
@@ -36,6 +36,7 @@ import numpy as np
 
 from .compat import ensure_bytes, pickle
 from .cache import byte_align
+from ..exceptions import CacheIOError
 
 
 class Subfile(object):
@@ -140,10 +141,10 @@ def read(fileobj):
         struct.unpack(HEADER_FORMAT, header))
 
     if magic != MAGIC_STRING:
-        raise IOError("Not a Nengo cache object file.")
+        raise CacheIOError("Not a Nengo cache object file.")
     if version not in SUPPORTED_PROTOCOLS:
-        raise IOError("NCO protocol version {} is not supported.".format(
-            version))
+        raise CacheIOError(
+            "NCO protocol version {} is not supported.".format(version))
 
     metadata = pickle.load(Subfile(fileobj, pickle_start, pickle_end))
     array = np.load(Subfile(fileobj, array_start, array_end))

--- a/nengo/utils/neurons.py
+++ b/nengo/utils/neurons.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 
 from . import numpy as npext
+from ..exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -12,9 +13,11 @@ def spikes2events(t, spikes):
     """Return an event-based representation of spikes (i.e. spike times)"""
     spikes = npext.array(spikes, copy=False, min_dims=2)
     if spikes.ndim > 2:
-        raise ValueError("Cannot handle %d-dimensional arrays" % spikes.ndim)
+        raise ValidationError("Cannot handle %d-dimensional arrays"
+                              % spikes.ndim, attr='spikes')
     if spikes.shape[-1] != len(t):
-        raise ValueError("Last dimension of `spikes` must equal `len(t)`")
+        raise ValidationError("Last dimension of 'spikes' must equal 'len(t)'",
+                              attr='spikes')
 
     # find nonzero elements (spikes) in each row, and translate to times
     return [t[spike != 0] for spike in spikes]
@@ -86,7 +89,7 @@ def lowpass_filter(x, tau, kind='expon'):
         kern = alpha**2 * t * np.exp(-alpha * t)
         delay = tau
     else:
-        raise ValueError("Unrecognized filter kind '%s'" % kind)
+        raise ValidationError("Unrecognized filter kind '%s'" % kind, 'kind')
 
     delay = int(np.round(delay))
     return np.array(
@@ -115,9 +118,11 @@ def rates_kernel(t, spikes, kind='gauss', tau=0.04):
     spikes = spikes.T
     spikes = npext.array(spikes, copy=False, min_dims=2)
     if spikes.ndim > 2:
-        raise ValueError("Cannot handle %d-dimensional arrays" % spikes.ndim)
+        raise ValidationError("Cannot handle %d-dimensional arrays"
+                              % spikes.ndim, attr='spikes')
     if spikes.shape[-1] != len(t):
-        raise ValueError("Last dimension of `spikes` must equal `len(t)`")
+        raise ValidationError("Last dimension of 'spikes' must equal 'len(t)'",
+                              attr='spikes')
 
     n, nt = spikes.shape
     dt = t[1] - t[0]

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import numpy as np
 
 from .compat import PY2
+from ..exceptions import ValidationError
 
 maxint = np.iinfo(np.int32).max
 
@@ -32,8 +33,8 @@ def array(x, dims=None, min_dims=0, readonly=False, **kwargs):
         shape[:y.ndim] = y.shape
         y.shape = shape
     elif y.ndim > dims:
-        raise ValueError(
-            "Input cannot be cast to array with %d dimensions" % dims)
+        raise ValidationError("Input cannot be cast to array with "
+                              "%d dimensions" % dims, attr='dims')
 
     if readonly:
         y.flags.writeable = False
@@ -103,7 +104,7 @@ def expm(A, n_factors=None, normalize=False):
     the matrices should be small, both in dimensions and norm.
     """
     if A.ndim != 2 or A.shape[0] != A.shape[1]:
-        raise ValueError("Argument must be a square matrix")
+        raise ValidationError("'A' must be a square matrix", attr='A')
 
     a = np.linalg.norm(A)
     if normalize:

--- a/nengo/utils/probe.py
+++ b/nengo/utils/probe.py
@@ -4,8 +4,7 @@ from .compat import iteritems
 
 def probe_all(net, recursive=False, probe_options=None,  # noqa: C901
               **probe_args):
-
-    """A helper function to make probing easier.
+    """Probes all objects in a network.
 
     Parameters
     ----------
@@ -70,17 +69,10 @@ def probe_all(net, recursive=False, probe_options=None,  # noqa: C901
                 # probe specified objects only
                 elif obj_type in probe_options:
                     for obj in obj_list:
-                        if not (hasattr(obj, 'probeable')
-                                and len(obj.probeable) > 0):
-                            raise ValueError("'%s' is not probeable" % obj)
                         probes[obj] = {}
                         for attr in probe_options[obj_type]:
-                            if attr not in obj.probeable:
-                                raise ValueError(
-                                    "'%s' is not probeable for '%s'" %
-                                    (obj, attr))
-                            probes[obj][
-                                attr] = nengo.Probe(obj, attr, **probe_args)
+                            probes[obj][attr] = (
+                                nengo.Probe(obj, attr, **probe_args))
 
     probe_helper(net, recursive, probe_options)
     return probes

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -11,9 +11,10 @@ import warnings
 
 import numpy as np
 
-from ..rc import rc
 from .stdlib import get_terminal_size
 from .ipython import get_ipython
+from ..exceptions import ValidationError
+from ..rc import rc
 
 
 class MemoryLeakWarning(UserWarning):
@@ -492,6 +493,6 @@ def wrap_with_progressupdater(progress_bar=True):
         updater_class = get_default_progressupdater(progress_bar)
         return updater_class(progress_bar)
     else:
-        raise ValueError("'progress_bar' must be a boolean or instance of "
-                         "ProgressBar or ProgressUpdater (got %s)" %
-                         type(progress_bar).__name__)
+        raise ValidationError(
+            "must be a boolean or instance of ProgressBar or ProgressUpdater "
+            "(got %r)" % type(progress_bar).__name__,  attr='progress_bar')

--- a/nengo/utils/tests/test_builder_passthrough.py
+++ b/nengo/utils/tests/test_builder_passthrough.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import nengo
+from nengo.exceptions import Unconvertible
 from nengo.utils.builder import objs_and_connections, remove_passthrough_nodes
 
 
@@ -65,12 +66,12 @@ def test_passthrough_errors():
         node = nengo.Node(None, size_in=1)
         nengo.Connection(a, node, synapse=0.01)
         nengo.Connection(node, b, synapse=0.01)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(Unconvertible):
         remove_passthrough_nodes(*objs_and_connections(model))
 
     model = nengo.Network()
     with model:
         node = nengo.Node(None, size_in=1)
         nengo.Connection(node, node, synapse=0.01)
-    with pytest.raises(Exception):
+    with pytest.raises(Unconvertible):
         remove_passthrough_nodes(*objs_and_connections(model))

--- a/nengo/utils/tests/test_functions_piecewise.py
+++ b/nengo/utils/tests/test_functions_piecewise.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from nengo.exceptions import ValidationError
 from nengo.utils.functions import piecewise
 
 
@@ -29,19 +30,19 @@ def test_lists():
 
 
 def test_invalid_key():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         f = piecewise({0.5: 1, 1: 0, 'a': 0.2})
         assert f
 
 
 def test_invalid_length():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         f = piecewise({0.5: [1, 0], 1.0: [1, 0, 0]})
         assert f
 
 
 def test_invalid_function_length():
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         f = piecewise({0.5: 0, 1.0: lambda t: [t, t ** 2]})
         assert f
 


### PR DESCRIPTION
I was adding a helpful exception when trying to probe decoders or transform, which will be removed in #729, but in order to get that exception working nicely, it kind of ballooned into reworking the exceptions currently raised for validation errors. This should be less magical / more clear, but perhaps more verbose (that might be fixable though).

But yeah, this is also a work in progress, I'm just making this PR now because I'm going to refer to this in #729.