### PR TITLE
Compare network now returns a scalar

### DIFF
--- a/nengo/networks/product.py
+++ b/nengo/networks/product.py
@@ -27,7 +27,6 @@ def Product(n_neurons, dimensions, input_magnitude=1, config=None, net=None):
         nengo.Connection(net.A, net.product.input[::2], synapse=None)
         nengo.Connection(net.B, net.product.input[1::2], synapse=None)
         net.output = net.product.add_output('product', lambda x: x[0] * x[1])
-
     return net
 
 

--- a/nengo/spa/tests/test_compare.py
+++ b/nengo/spa/tests/test_compare.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 import nengo
 from nengo import spa
 
@@ -11,12 +9,15 @@ def test_basic():
     inputA = model.get_module_input('compare_A')
     inputB = model.get_module_input('compare_B')
     output = model.get_module_output('compare')
+    # all nodes should be acquired correctly
     assert inputA[0] is model.compare.inputA
     assert inputB[0] is model.compare.inputB
     assert output[0] is model.compare.output
+    # all inputs should share the same vocab
     assert inputA[1] is inputB[1]
-    assert inputA[1] is output[1]
     assert inputA[1].dimensions == 16
+    # output should have no vocab
+    assert output[1] is None
 
 
 def test_run(Simulator, seed):
@@ -39,7 +40,5 @@ def test_run(Simulator, seed):
     sim = Simulator(model)
     sim.run(0.2)
 
-    data = np.dot(sim.data[p], vocab.parse('YES').v)
-
-    assert data[100] > 0.8
-    assert data[199] < 0.2
+    assert sim.data[p][100] > 0.8
+    assert sim.data[p][199] < 0.2

--- a/nengo/spa/tests/test_thalamus.py
+++ b/nengo/spa/tests/test_thalamus.py
@@ -164,9 +164,7 @@ def test_nondefault_routing(Simulator, seed, plt):
     sim = Simulator(model)
     sim.run(0.6)
 
-    vocab = model.get_output_vocab('cmp')
-    data = sim.data[compare_probe]
-    similarity = np.dot(data, vocab.parse('YES').v)
+    similarity = sim.data[compare_probe]
 
     valueA = np.mean(similarity[150:200], axis=0)  # should be [1]
     valueB = np.mean(similarity[350:400], axis=0)  # should be [0]


### PR DESCRIPTION
To fix #775 :
- Make the `spa.Compare` network return a scalar. 
- Allow multiple scalars to be added together for BasalGanglia inputs