### PR TITLE
New processes for convnets

### DIFF
--- a/nengo/node.py
+++ b/nengo/node.py
@@ -17,6 +17,9 @@ class OutputParam(Parameter):
     def __set__(self, node, output):
         super(OutputParam, self).validate(node, output)
 
+        size_in_set = node.size_in is not None
+        node.size_in = node.size_in if size_in_set else 0
+
         # --- Validate and set the new size_out
         if output is None:
             if node.size_out is not None:
@@ -24,6 +27,8 @@ class OutputParam(Parameter):
                               "'Node.size_in' since 'Node.output=None'")
             node.size_out = node.size_in
         elif isinstance(output, Process):
+            if not size_in_set:
+                node.size_in = output.default_size_in
             if node.size_out is None:
                 node.size_out = output.default_size_out
         elif callable(output):
@@ -113,7 +118,7 @@ class Node(NengoObject):
     """
 
     output = OutputParam(default=None)
-    size_in = IntParam(default=0, low=0)
+    size_in = IntParam(default=None, low=0, optional=True)
     size_out = IntParam(default=None, low=0, optional=True)
     label = StringParam(default=None, optional=True)
 

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -209,6 +209,31 @@ class StringParam(Parameter):
         super(StringParam, self).validate(instance, string)
 
 
+class EnumParam(StringParam):
+    def __init__(self, default=Unconfigurable, values=(), lower=True,
+                 optional=False, readonly=None):
+        assert all(is_string(s) for s in values)
+        if lower:
+            values = tuple(s.lower() for s in values)
+        value_set = set(values)
+        assert len(values) == len(value_set)
+        self.values = values
+        self.value_set = value_set
+        self.lower = lower
+        super(EnumParam, self).__init__(default, optional, readonly)
+
+    def __set__(self, instance, value):
+        self.validate(instance, value)
+        self.data[instance] = value.lower() if self.lower else value
+
+    def validate(self, instance, string):
+        super(EnumParam, self).validate(instance, string)
+        string = string.lower() if self.lower else string
+        if string not in self.value_set:
+            raise ValueError("String %r must be one of %s"
+                             % (string, list(self.values)))
+
+
 class TupleParam(Parameter):
     def __init__(self, default=Unconfigurable, length=None,
                  optional=False, readonly=None):

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -209,6 +209,27 @@ class StringParam(Parameter):
         super(StringParam, self).validate(instance, string)
 
 
+class TupleParam(Parameter):
+    def __init__(self, default=Unconfigurable, length=None,
+                 optional=False, readonly=None):
+        self.length = length
+        super(TupleParam, self).__init__(default, optional, readonly)
+
+    def __set__(self, instance, value):
+        try:
+            value = tuple(value)
+        except TypeError:
+            raise ValueError("Value must be castable to a tuple")
+        super(TupleParam, self).__set__(instance, value)
+
+    def validate(self, instance, value):
+        if value is not None:
+            if self.length is not None and len(value) != self.length:
+                raise ValueError("Must be %d items (got %d)"
+                                 % (self.length, len(value)))
+        super(TupleParam, self).validate(instance, value)
+
+
 class DictParam(Parameter):
     def validate(self, instance, dct):
         if dct is not None and not isinstance(dct, dict):

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -330,18 +330,21 @@ class Conv2d(Process):
 
     shape_in = TupleParam(length=3)
     shape_out = TupleParam(length=3)
+    stride = TupleParam(length=2)
+    padding = TupleParam(length=2)
     filters = NdarrayParam(shape=('...',))
     biases = NdarrayParam(shape=('...',), optional=True)
 
-    def __init__(self, shape_in, filters, biases=None):
+    def __init__(self, shape_in, filters, biases=None, stride=1, padding=0):  # noqa: C901
+        from nengo.utils.compat import is_iterable, is_integer
+
         self.shape_in = tuple(shape_in)
         if len(self.shape_in) != 3:
             raise ValueError("`shape_in` must have three dimensions "
                              "(channels, height, width)")
 
         self.filters = filters
-        self.shape_out = (self.filters.shape[0],) + self.shape_in[1:]
-        if len(self.filters.shape) not in [4, 6]:
+        if self.filters.ndim not in [4, 6]:
             raise ValueError(
                 "`filters` must have four or six dimensions "
                 "(filters, [height, width,] channels, f_height, f_width)")
@@ -349,6 +352,31 @@ class Conv2d(Process):
             raise ValueError(
                 "Filter channels (%d) and input channels (%d) must match"
                 % (self.filters.shape[-3], self.shape_in[0]))
+        if not all(s % 2 == 1 for s in self.filters.shape[-2:]):
+            raise ValueError("Filter shapes must be odd (got %r)"
+                             % (self.filters.shape[-2:],))
+
+        self.stride = stride if is_iterable(stride) else [stride] * 2
+        if not all(is_integer(s) and s >= 1 for s in self.stride):
+            raise ValueError("All strides must be integers >= 1 (got %s)"
+                             % (self.stride,))
+
+        self.padding = padding if is_iterable(padding) else [padding] * 2
+        if not all(is_integer(p) and p >= 0 for p in self.padding):
+            raise ValueError("All padding must be integers >= 0 (got %s)"
+                             % (self.padding,))
+
+        nf = self.filters.shape[0]
+        nxi, nxj = self.shape_in[1:]
+        si, sj = self.filters.shape[-2:]
+        pi, pj = self.padding
+        sti, stj = self.stride
+        nyi = 1 + max(int(np.ceil((2*pi + nxi - si) / float(sti))), 0)
+        nyj = 1 + max(int(np.ceil((2*pj + nxj - sj) / float(stj))), 0)
+        self.shape_out = (nf, nyi, nyj)
+        if self.filters.ndim == 6 and self.filters.shape[1:3] != (nyi, nyj):
+            raise ValueError("Number of local filters %r must match out shape "
+                             "%r" % (self.filters.shape[1:3], (nyi, nyj)))
 
         self.biases = biases if biases is not None else None
         if self.biases is not None:
@@ -379,25 +407,29 @@ class Conv2d(Process):
         shape_in = self.shape_in
         shape_out = self.shape_out
 
+        nxi, nxj = shape_in[-2:]
+        nyi, nyj = shape_out[-2:]
+        nf = filters.shape[0]
+        si, sj = filters.shape[-2:]
+        pi, pj = self.padding
+        sti, stj = self.stride
+
         def step_conv2d(t, x):
             x = x.reshape(shape_in)
-            ni, nj = shape_in[-2:]
-            f = filters.shape[0]
-            si, sj = filters.shape[-2:]
-            si2 = (si - 1) / 2
-            sj2 = (sj - 1) / 2
-
             y = np.zeros(shape_out)
-            for i in range(ni):
-                for j in range(nj):
-                    i0, i1 = i - si2, i + si2 + 1
-                    j0, j1 = j - sj2, j + sj2 + 1
-                    sli = slice(max(-i0, 0), min(ni + si - i1, si))
-                    slj = slice(max(-j0, 0), min(nj + sj - j1, sj))
+
+            for i in range(nyi):
+                for j in range(nyj):
+                    i0 = i*sti - pi
+                    j0 = j*stj - pj
+                    i1, j1 = i0 + si, j0 + sj
+                    sli = slice(max(-i0, 0), min(nxi + si - i1, si))
+                    slj = slice(max(-j0, 0), min(nxj + sj - j1, sj))
                     w = (filters[:, i, j, :, sli, slj] if local_filters else
                          filters[:, :, sli, slj])
-                    xij = x[:, max(i0, 0):min(i1, ni), max(j0, 0):min(j1, nj)]
-                    y[:, i, j] = np.dot(xij.ravel(), w.reshape(f, -1).T)
+                    xij = x[:, max(i0, 0):min(i1, nxi),
+                            max(j0, 0):min(j1, nxj)]
+                    y[:, i, j] = np.dot(w.reshape(nf, -1), xij.ravel())
 
             if biases is not None:
                 y += biases
@@ -424,10 +456,10 @@ class Pool2d(Process):
             raise ValueError("Stride (%d) must be <= size (%d)" %
                              (self.stride, self.size))
 
-        c, nxi, nxj = self.shape_in
-        nyi = int(np.floor(float(nxi - 1) / self.stride)) + 1
-        nyj = int(np.floor(float(nxj - 1) / self.stride)) + 1
-        self.shape_out = (c, nyi, nyj)
+        nc, nxi, nxj = self.shape_in
+        nyi = 1 + int(np.ceil(float(nxi - size) / self.stride))
+        nyj = 1 + int(np.ceil(float(nxj - size) / self.stride))
+        self.shape_out = (nc, nyi, nyj)
 
         super(Pool2d, self).__init__(
             default_size_in=np.prod(self.shape_in),
@@ -436,21 +468,21 @@ class Pool2d(Process):
     def make_step(self, size_in, size_out, dt, rng):
         assert size_in == np.prod(self.shape_in)
         assert size_out == np.prod(self.shape_out)
-        c, nxi, nxj = self.shape_in
-        c, nyi, nyj = self.shape_out
+        nc, nxi, nxj = self.shape_in
+        nc, nyi, nyj = self.shape_out
         s = self.size
         st = self.stride
         kind = self.kind
+        nxi2, nxj2 = nyi * st, nyj * st
 
         def step_pool2d(t, x):
-            x = x.reshape(c, nxi, nxj)
-            y = np.zeros_like(x[:, ::st, ::st])
+            x = x.reshape(nc, nxi, nxj)
+            y = np.zeros((nc, nyi, nyj), dtype=x.dtype)
             n = np.zeros((nyi, nyj))
-            assert y.shape[-2:] == (nyi, nyj)
 
             for i in range(s):
                 for j in range(s):
-                    xij = x[:, i::st, j::st]
+                    xij = x[:, i:min(nxi2+i, nxi):st, j:min(nxj2+j, nxj):st]
                     ni, nj = xij.shape[-2:]
                     if kind == 'max':
                         y[:, :ni, :nj] = np.maximum(y[:, :ni, :nj], xij)

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -29,9 +29,9 @@ class Process(FrozenObject):
     default_dt = NumberParam(low=0, low_open=True)
     seed = IntParam(low=0, high=npext.maxint, optional=True)
 
-    def __init__(self, seed=None):
+    def __init__(self, default_size_out=1, seed=None):
         super(Process, self).__init__()
-        self.default_size_out = 1
+        self.default_size_out = default_size_out
         self.default_dt = 0.001
         self.seed = seed
 

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -48,7 +48,6 @@ class Process(FrozenObject):
         raise NotImplementedError("Process must implement `make_step` method.")
 
     def run_steps(self, n_steps, d=None, dt=None, rng=np.random):
-        # TODO: allow running with input
         d = self.default_size_out if d is None else d
         dt = self.default_dt if dt is None else dt
         rng = self.get_rng(rng)
@@ -59,10 +58,21 @@ class Process(FrozenObject):
         return output
 
     def run(self, t, d=None, dt=None, rng=np.random):
-        # TODO: allow running with input
         dt = self.default_dt if dt is None else dt
         n_steps = int(np.round(float(t) / dt))
         return self.run_steps(n_steps, d=d, dt=dt, rng=rng)
+
+    def run_input(self, x, d=None, dt=None, rng=np.random):
+        n_steps = len(x)
+        size_in = np.asarray(x[0]).size
+        size_out = self.default_size_out if d is None else d
+        dt = self.default_dt if dt is None else dt
+        rng = self.get_rng(rng)
+        step = self.make_step(size_in, size_out, dt, rng)
+        output = np.zeros((n_steps, size_out))
+        for i, xi in enumerate(x):
+            output[i] = step(i * dt, xi)
+        return output
 
     def ntrange(self, n_steps, dt=None):
         dt = self.default_dt if dt is None else dt

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -15,6 +15,8 @@ class Process(FrozenObject):
 
     Attributes
     ----------
+    default_size_in : int
+        Sets the default size in for nodes using this process. Default: 0.
     default_size_out : int
         Sets the default size out for nodes running this process. Also,
         if `d` isn't specified in `run` or `run_steps`, this will be used.
@@ -25,12 +27,14 @@ class Process(FrozenObject):
     seed : int, optional
         Random number seed. Ensures noise will be the same each run.
     """
+    default_size_in = IntParam(low=0)
     default_size_out = IntParam(low=0)
     default_dt = NumberParam(low=0, low_open=True)
     seed = IntParam(low=0, high=npext.maxint, optional=True)
 
-    def __init__(self, default_size_out=1, seed=None):
+    def __init__(self, default_size_in=0, default_size_out=1, seed=None):
         super(Process, self).__init__()
+        self.default_size_in = default_size_in
         self.default_size_out = default_size_out
         self.default_dt = 0.001
         self.seed = seed

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -5,7 +5,7 @@ import numpy as np
 import nengo.utils.numpy as npext
 from nengo.dists import DistributionParam, Gaussian
 from nengo.params import (
-    BoolParam, IntParam, NumberParam, Parameter, FrozenObject)
+    BoolParam, IntParam, NdarrayParam, NumberParam, Parameter, FrozenObject)
 from nengo.synapses import LinearFilter, LinearFilterParam, Lowpass
 from nengo.utils.compat import range
 
@@ -262,6 +262,40 @@ class WhiteSignal(Process):
             return signal[i % signal.shape[0]]
 
         return step
+
+
+class PresentInput(Process):
+    """Present a series of inputs, each for the same fixed length of time.
+
+    Parameters
+    ----------
+    inputs : array_like
+        Inputs to present, where each row is an input. Rows will be flattened.
+    presentation_time : float
+        Show each input for `presentation_time` seconds.
+    """
+    inputs = NdarrayParam(shape=('...',))
+    presentation_time = NumberParam(low=0, low_open=True)
+
+    def __init__(self, inputs, presentation_time):
+        self.inputs = inputs
+        self.presentation_time = presentation_time
+        super(PresentInput, self).__init__(
+            default_size_out=self.inputs[0].size)
+
+    def make_step(self, size_in, size_out, dt, rng):
+        assert size_in == 0
+        assert size_out == self.inputs[0].size
+
+        n = len(self.inputs)
+        inputs = self.inputs.reshape(n, -1)
+        presentation_time = float(self.presentation_time)
+
+        def step_image_input(t):
+            i = int(t / presentation_time + 1e-7)
+            return inputs[i % n]
+
+        return step_image_input
 
 
 class ProcessParam(Parameter):

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -176,6 +176,24 @@ def test_stringparam():
         inst.sp = 1
 
 
+def test_enumparam():
+    class Test(object):
+        ep = params.EnumParam(default='a', values=('a', 'b', 'c'))
+
+    inst = Test()
+    assert inst.ep == 'a'
+    inst.ep = 'b'
+    assert inst.ep == 'b'
+    inst.ep = 'c'
+    assert inst.ep == 'c'
+    inst.ep = 'A'
+    assert inst.ep == 'a'
+    with pytest.raises(ValueError):
+        inst.ep = 'd'
+    with pytest.raises(ValueError):
+        inst.ep = 3
+
+
 def test_dictparam():
     """DictParams must be dictionaries."""
     class Test(object):

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -302,3 +302,43 @@ def test_present_input(Simulator, rng):
     y = sim.data[up].reshape(len(t), c, ni, nj)
     for k, [ii, image] in enumerate(zip(i, y)):
         assert np.allclose(image, images[ii], rtol=1e-4, atol=1e-7), (k, ii)
+
+
+@pytest.mark.parametrize('local', [False, True])
+def test_conv2d(local, Simulator, rng):
+    f = 4
+    c = 2
+    ni, nj = 30, 32
+    si, sj = 5, 3
+
+    fshape = (f, ni, nj, c, si, sj) if local else (f, c, si, sj)
+    filters = rng.normal(size=fshape)
+    biases = rng.normal(size=f)
+    image = rng.normal(size=(c, ni, nj))
+
+    result = np.zeros((f, ni, nj))
+    result += biases.reshape(-1, 1, 1)
+    si2 = (si - 1) / 2
+    sj2 = (sj - 1) / 2
+    for i in range(ni):
+        for j in range(nj):
+            i0, i1 = i - si2, i + si2 + 1
+            j0, j1 = j - sj2, j + sj2 + 1
+            sli = slice(max(-i0, 0), min(ni + si - i1, si))
+            slj = slice(max(-j0, 0), min(nj + sj - j1, sj))
+            w = (filters[:, i, j, :, sli, slj] if local else
+                 filters[:, :, sli, slj])
+            xij = image[:, max(i0, 0):min(i1, ni), max(j0, 0):min(j1, nj)]
+            result[:, i, j] += np.dot(xij.ravel(), w.reshape(f, -1).T)
+
+    model = nengo.Network()
+    with model:
+        u = nengo.Node(image.ravel())
+        v = nengo.Node(nengo.processes.Conv2d((c, ni, nj), filters, biases))
+        nengo.Connection(u, v, synapse=None)
+        vp = nengo.Probe(v)
+
+    sim = Simulator(model)
+    sim.step()
+    y = sim.data[vp][-1].reshape((f, ni, nj))
+    assert np.allclose(result, y, rtol=1e-4, atol=1e-7)

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -343,7 +343,7 @@ def test_conv2d(local, Simulator, rng):
     sim = Simulator(model)
     sim.step()
     y = sim.data[vp][-1].reshape((f, ni, nj))
-    assert np.allclose(result, y, rtol=1e-4, atol=1e-7)
+    assert np.allclose(result, y, rtol=1e-3, atol=1e-6)
 
 
 @pytest.mark.parametrize('s, st', [(2, 2), (3, 1), (3, 3)])
@@ -378,4 +378,4 @@ def test_pool2d(s, st, Simulator, rng):
     sim = Simulator(model)
     sim.step()
     y = sim.data[vp][-1].reshape(result.shape)
-    assert np.allclose(result, y, rtol=1e-4, atol=1e-7)
+    assert np.allclose(result, y, rtol=1e-3, atol=1e-6)


### PR DESCRIPTION
I've added a couple new Processes to facilitate running convnets in Nengo, namely one for 2D convolution with a filterbank and one for presenting a series of inputs each for a fixed length of time.

I've also added a seed for random processes, as requested in #787.

This PR is based off the `frozen` branch (see #758).