### PR TITLE
removed working memory and product config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,8 @@ Release History
   stand-alone network in ``nengo.networks``. The AssociativeMemory SPA module
   also has an updated argument list.
   (`#702 <https://github.com/nengo/nengo/pull/702>`_)
+- The ``Product`` and ``InputGatedMemory`` networks no longer accept a
+  ``config`` argument. (`#814 <https://github.com/nengo/nengo/pull/814>`_)
 
 **Behavioural changes**
 

--- a/nengo/networks/product.py
+++ b/nengo/networks/product.py
@@ -2,10 +2,9 @@ import numpy as np
 
 import nengo
 from nengo.networks.ensemblearray import EnsembleArray
-from nengo.utils.stdlib import nested
 
 
-def Product(n_neurons, dimensions, input_magnitude=1, config=None, net=None):
+def Product(n_neurons, dimensions, input_magnitude=1, net=None):
     """Computes the element-wise product of two equally sized vectors.
 
     The network used to calculate the product is described in
@@ -18,10 +17,7 @@ def Product(n_neurons, dimensions, input_magnitude=1, config=None, net=None):
     if net is None:
         net = nengo.Network(label="Product")
 
-    if config is None:
-        config = nengo.Config(nengo.Ensemble)
-
-    with nested(net, config):
+    with net:
         net.A = nengo.Node(size_in=dimensions, label="A")
         net.B = nengo.Node(size_in=dimensions, label="B")
         net.output = nengo.Node(size_in=dimensions, label="output")

--- a/nengo/networks/tests/test_product.py
+++ b/nengo/networks/tests/test_product.py
@@ -47,8 +47,9 @@ def test_direct_mode_with_single_neuron(Simulator, plt, seed):
 
     config = nengo.Config(nengo.Ensemble)
     config[nengo.Ensemble].neuron_type = nengo.Direct()
-    product = nengo.networks.Product(
-        1, dim, radius, net=nengo.Network(seed=seed), config=config)
+    with config:
+        product = nengo.networks.Product(
+            1, dim, radius, net=nengo.Network(seed=seed))
 
     func_A = lambda t: np.sqrt(radius)*np.sin(np.arange(1, dim+1)*2*np.pi*t)
     func_B = lambda t: np.sqrt(radius)*np.sin(np.arange(dim, 0, -1)*2*np.pi*t)

--- a/nengo/networks/workingmemory.py
+++ b/nengo/networks/workingmemory.py
@@ -4,26 +4,25 @@ import nengo
 from nengo.networks import EnsembleArray
 
 
-def InputGatedMemory(n_neurons, dimensions, fdbk_scale=1.0, gate_gain=10,
-                     difference_gain=1.0, reset_gain=3,
-                     mem_config=None, net=None):
+def InputGatedMemory(n_neurons, dimensions, feedback=1.0,
+                     difference_gain=1.0, recurrent_synapse=0.1,
+                     difference_synapse=None, net=None):
     """Stores a given vector in memory, with input controlled by a gate."""
     if net is None:
         net = nengo.Network(label="Input Gated Memory")
 
-    if mem_config is None:
-        mem_config = nengo.Config(nengo.Connection)
-        mem_config[nengo.Connection].synapse = nengo.Lowpass(0.1)
+    if difference_synapse is None:
+        difference_synapse = recurrent_synapse
 
     n_total_neurons = n_neurons * dimensions
 
     with net:
         # integrator to store value
-        with mem_config:
-            net.mem = EnsembleArray(n_neurons, dimensions,
-                                    neuron_nodes=True, label="mem")
-            nengo.Connection(net.mem.output, net.mem.input,
-                             transform=fdbk_scale)
+        net.mem = EnsembleArray(n_neurons, dimensions,
+                                neuron_nodes=True, label="mem")
+        nengo.Connection(net.mem.output, net.mem.input,
+                         transform=feedback,
+                         synapse=recurrent_synapse)
 
         # calculate difference between stored value and input
         net.diff = EnsembleArray(n_neurons, dimensions,
@@ -31,21 +30,21 @@ def InputGatedMemory(n_neurons, dimensions, fdbk_scale=1.0, gate_gain=10,
         nengo.Connection(net.mem.output, net.diff.input, transform=-1)
 
         # feed difference into integrator
-        with mem_config:
-            nengo.Connection(net.diff.output, net.mem.input,
-                             transform=difference_gain)
+        nengo.Connection(net.diff.output, net.mem.input,
+                         transform=difference_gain,
+                         synapse=difference_synapse)
 
         # gate difference (if gate==0, update stored value,
         # otherwise retain stored value)
         net.gate = nengo.Node(size_in=1)
         nengo.Connection(net.gate, net.diff.neuron_input,
-                         transform=np.ones((n_total_neurons, 1)) * -gate_gain,
+                         transform=np.ones((n_total_neurons, 1)) * -10,
                          synapse=None)
 
         # reset input (if reset=1, remove all values, and set to 0)
         net.reset = nengo.Node(size_in=1)
         nengo.Connection(net.reset, net.mem.neuron_input,
-                         transform=np.ones((n_total_neurons, 1)) * -reset_gain,
+                         transform=np.ones((n_total_neurons, 1)) * -3,
                          synapse=None)
 
     net.input = net.diff.input


### PR DESCRIPTION
As discussed in #790 configs should not be passed as parameters into networks anymore, so I removed them from the Product network and the Working Memory network. 

I would have changed the Action Selection network too, but that depends on #810 .

I'll squash the commits together once everyone agrees on how I proceeded.