### PR TITLE
Added digital synapses, fixed filter test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,10 @@ Release History
   to be computed by each ensemble.
   (`#562 <https://github.com/nengo/nengo/issues/562>`_,
   `#580 <https://github.com/nengo/nengo/pull/580>`_)
+- ``LinearFilter`` now has an ``analog`` argument which can be set
+  through its constructor. Linear filters with digital coefficients
+  can be specified by setting ``analog`` to ``False``.
+  (`#819 <https://github.com/nengo/nengo/pull/819>`_)
 - Added ``SqrtBeta`` distribution, which describes the distribution
   of semantic pointer elements.
   (`#414 <https://github.com/nengo/nengo/issues/414>`_,

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -34,9 +34,10 @@ class LinearFilter(Synapse):
     .. [1] http://en.wikipedia.org/wiki/Filter_%28signal_processing%29
     """
 
-    def __init__(self, num, den):
+    def __init__(self, num, den, analog=True):
         self.num = num
         self.den = den
+        self.analog = analog
 
     def __repr__(self):
         return "%s(%s, %s)" % (self.__class__.__name__, self.num, self.den)
@@ -72,8 +73,13 @@ class LinearFilter(Synapse):
         y.appendleft(np.array(output))
 
     def make_step(self, dt, output, method='zoh'):
-        num, den, _ = cont2discrete((self.num, self.den), dt, method=method)
-        num = num.flatten()
+        num, den = self.num, self.den
+        if self.analog:
+            num, den, _ = cont2discrete((num, den), dt, method=method)
+            num = num.flatten()
+
+        if den[0] != 1.:
+            raise ValueError("First element of the denominator must be 1")
         num = num[1:] if num[0] == 0 else num
         den = den[1:]  # drop first element (equal to 1)
 

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -83,13 +83,14 @@ def test_linearfilter(Simulator, plt, seed):
     dt = 1e-3
 
     # The following num, den are for a 4th order analog Butterworth filter,
-    # generated with `scipy.signal.butter(4, 1. / 0.03, analog=True)`
-    num = np.array([1234567.90123457])
-    den = np.array([1.0, 87.104197658425107, 3793.5706248589954,
-                    96782.441842694592, 1234567.9012345686])
+    # generated with `scipy.signal.butter(4, 0.2, analog=False)`
+    num = np.array(
+        [0.00482434, 0.01929737, 0.02894606, 0.01929737, 0.00482434])
+    den = np.array([1., -2.36951301,  2.31398841, -1.05466541,  0.18737949])
 
-    t, x, yhat = run_synapse(Simulator, seed, LinearFilter(num, den), dt=dt)
-    y = filt(x, LinearFilter(num, den), dt=dt)
+    synapse = LinearFilter(num, den, analog=False)
+    t, x, yhat = run_synapse(Simulator, seed, synapse, dt=dt)
+    y = filt(x, synapse, dt=dt)
 
     assert allclose(t, y, yhat, delay=dt, plt=plt)
 


### PR DESCRIPTION
Added ability to specify linear synapses with digital coefficients
directly, since it can often be easier to design filters directly
in the digital domain.

Fixed the test of general linear filters to use much more stable
(less extreme) coefficients, so that backends with more limited
precision can still pass the test.