### PR TITLE
fixed exception handling in spa.Module.__exit__

### DIFF
--- a/nengo/spa/input.py
+++ b/nengo/spa/input.py
@@ -40,7 +40,10 @@ class Input(Module):
         Module.on_add(self, spa)
 
         for name, value in iteritems(self.kwargs):
-            target, vocab = spa.get_module_input(name)
+            try:
+                target, vocab = spa.get_module_input(name)
+            except TypeError:
+                raise ValueError('Could not find input called "%s"' % name)
             if callable(value):
                 val = make_parse_func(value, vocab)
             else:

--- a/nengo/spa/input.py
+++ b/nengo/spa/input.py
@@ -40,10 +40,7 @@ class Input(Module):
         Module.on_add(self, spa)
 
         for name, value in iteritems(self.kwargs):
-            try:
-                target, vocab = spa.get_module_input(name)
-            except TypeError:
-                raise ValueError('Could not find input called "%s"' % name)
+            target, vocab = spa.get_module_input(name)
             if callable(value):
                 val = make_parse_func(value, vocab)
             else:

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -104,8 +104,12 @@ class SPA(nengo.Network):
 
             value.on_add(self)
 
-    def __exit__(self, *args):
-        super(SPA, self).__exit__(*args)
+    def __exit__(self, ex_type, ex_value, traceback):
+        super(SPA, self).__exit__(ex_type, ex_value, traceback)
+        if ex_type is not None:
+            # re-raise the exception that triggered this __exit__
+            return False
+
         module_list = frozenset(self._modules.values())
         for net in self.networks:
             # Since there are no attributes to distinguish what's been added

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -125,7 +125,9 @@ class SPA(nengo.Network):
             return self._modules[name]
         elif '_' in name:
             module, name = name.rsplit('_', 1)
-            return self._modules[module]
+            if module in self._modules:
+                return self._modules[module]
+        raise KeyError('Could not find module "%s"' % name)
 
     def get_default_vocab(self, dimensions):
         """Return a Vocabulary with the desired dimensions.
@@ -151,7 +153,11 @@ class SPA(nengo.Network):
             return self._modules[name].inputs['default']
         elif '_' in name:
             module, name = name.rsplit('_', 1)
-            return self._modules[module].inputs[name]
+            if module in self._modules:
+                m = self._modules[module]
+                if name in m.inputs:
+                    return m.inputs[name]
+        raise KeyError('Could not find module input "%s"' % name)
 
     def get_module_inputs(self):
         for name, module in iteritems(self._modules):
@@ -174,7 +180,11 @@ class SPA(nengo.Network):
             return self._modules[name].outputs['default']
         elif '_' in name:
             module, name = name.rsplit('_', 1)
-            return self._modules[module].outputs[name]
+            if module in self._modules:
+                m = self._modules[module]
+                if name in m.outputs:
+                    return m.outputs[name]
+        raise KeyError('Could not find module output "%s"' % name)
 
     def get_module_outputs(self):
         for name, module in iteritems(self._modules):

--- a/nengo/spa/tests/test_spa.py
+++ b/nengo/spa/tests/test_spa.py
@@ -39,3 +39,17 @@ def test_spa_verification(Simulator, seed, plt):
             buf = spa.Buffer(d)
             model.input_node = spa.Input(buf='B')
             buf.label = "woop"
+
+
+def test_spa_module_exception():
+    class MyException(Exception):
+        pass
+
+    class TestModule(spa.module.Module):
+        def __init__(self):
+            super(TestModule, self).__init__()
+            raise MyException()
+
+    with pytest.raises(MyException):
+        with spa.SPA() as model:
+            model.test = TestModule()

--- a/nengo/spa/tests/test_spa.py
+++ b/nengo/spa/tests/test_spa.py
@@ -31,7 +31,7 @@ def test_spa_verification(Simulator, seed, plt):
             input_node = spa.Input(buf='B')
             input_node.label = "woop"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         model = spa.SPA(seed=seed)
         # build a model that should raise a warning because no attribute
         # for the buffer
@@ -53,3 +53,31 @@ def test_spa_module_exception():
     with pytest.raises(MyException):
         with spa.SPA() as model:
             model.test = TestModule()
+
+
+def test_spa_get():
+    D = 16
+    model = spa.SPA()
+    with model:
+        model.buf1 = spa.State(D)
+        model.buf2 = spa.State(D)
+        model.compare = spa.Compare(D)
+
+    assert model.get_module('buf1') is model.buf1
+    assert model.get_module('buf1_default') is model.buf1
+    assert model.get_module('buf2') is model.buf2
+    assert model.get_module_input('buf1')[0] is model.buf1.input
+    assert model.get_module_output('buf1')[0] is model.buf1.output
+    assert model.get_module_input('compare_A')[0] is model.compare.inputA
+    assert model.get_module_input('compare_B')[0] is model.compare.inputB
+
+    with pytest.raises(KeyError):
+        model.get_module('dummy')
+    with pytest.raises(KeyError):
+        model.get_module_input('dummy')
+    with pytest.raises(KeyError):
+        model.get_module_output('dummy')
+    with pytest.raises(KeyError):
+        model.get_module_input('buf1_A')
+    with pytest.raises(KeyError):
+        model.get_module_input('compare')


### PR DESCRIPTION
This fixes #827 

Note that the change to ```Input``` is because the last test case in ```test_spa.py::test_spa_verification``` was actually relying on the buggy ValueError throwing that is fixed by this PR.  If ```spa.Input``` couldn't find an object with the name it was looking for, then it would actually throw a TypeError which would then get converted into a ValueError, obscuring the original bug.  So I also fixed ```spa.Input``` to give a useful ValueError in this case.