### PR TITLE
Handle DoctestItems in conftest.py.

### DIFF
--- a/nengo/tests/conftest.py
+++ b/nengo/tests/conftest.py
@@ -194,6 +194,8 @@ def pytest_generate_tests(metafunc):
 
 
 def pytest_runtest_setup(item):
+    if not hasattr(item, 'obj'):
+        return
     for mark, option, message in [
             ('example', 'noexamples', "examples not requested"),
             ('slow', 'slow', "slow tests not requested")]:
@@ -219,6 +221,8 @@ def pytest_runtest_setup(item):
 def pytest_collection_modifyitems(session, config, items):
     compare = config.getvalue('compare') is None
     for item in list(items):
+        if not hasattr(item, 'obj'):
+            continue
         if (getattr(item.obj, 'compare', None) is None) != compare:
             items.remove(item)
 


### PR DESCRIPTION
DoctestItems do not have an 'obj' attribute, so our attempts to read it make it impossible to test.

Note that Nengo doesn't use DoctestItems, but `nengo_spinnaker` does. Maybe in the future we'll want to too, so best to make it possible.