### PR TITLE
Corrected regularization and rmse in non-negative solvers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -133,7 +133,7 @@ Release History
 - Fix for SPA actions that route to a module with multiple inputs.
   (`#714 <https://github.com/nengo/nengo/pull/714>`_)
 - Corrected the ``rmses`` values in ``BuiltConnection.solver_info`` when using
-  ``NNls`` and ``Nnl2sL2`` solvers.
+  ``NNls`` and ``Nnl2sL2`` solvers, and the ``reg`` argument for ``Nnl2sL2``.
   (`#839 <https://github.com/nengo/nengo/pull/839>`_)
 
 2.0.1 (January 27, 2015)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,9 @@ Release History
   `#671 <https://github.com/nengo/nengo/pull/671>`_)
 - Fix for SPA actions that route to a module with multiple inputs.
   (`#714 <https://github.com/nengo/nengo/pull/714>`_)
+- Corrected the ``rmses`` values in ``BuiltConnection.solver_info`` when using
+  ``NNls`` and ``Nnl2sL2`` solvers.
+  (`#839 <https://github.com/nengo/nengo/pull/839>`_)
 
 2.0.1 (January 27, 2015)
 ========================

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -517,7 +517,7 @@ class NnlsL2(Nnls):
         # form Gram matrix so we can add regularization
         GA = np.dot(A.T, A)
         GY = np.dot(A.T, Y)
-        np.fill_diagonal(GA, GA.diagonal() + sigma)
+        np.fill_diagonal(GA, GA.diagonal() + A.shape[0] * sigma**2)
         X, info = super(NnlsL2, self).__call__(GA, GY, rng=rng, E=E)
         # recompute the RMSE in terms of the original matrices
         info = {'rmses': _rmses(A, X, Y), 'gram_info': info}


### PR DESCRIPTION
Previously, the `'rmses`' for the non-negative solvers were off by an order of magnitude, because they were with respect to the Gram system instead of the original system. This has been fixed to make these values now comparable to the other solvers.

This fix has been tested offline using `nengo.utils.connection.eval_point_decoding` on the same set of eval points (now gives an exact match). If desired, I could also add a unit test to check that each solver's rmse is correct with respect to the given system.

Also, the regularization wasn't scaled consistently with the other solvers. This was causing drastically different performance results when using one solver over another (I also wonder if this contributed in part to the performance improvement in #321). I verified the fix (again offline) by comparing the RMSE when decoding a positive constant function -- they were roughly the same across a variety of regularization coefficients. Again, this can be made into a unit test if desired.