### PR TITLE
Ensure learning rule test does not affect others

### DIFF
--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -183,6 +183,11 @@ def test_unsupervised(Simulator, learning_rule_type, seed, rng, plt):
 
 def learning_net(learning_rule, net, rng):
     with net:
+        if learning_rule is nengo.PES:
+            learning_rule_type = learning_rule(learning_rate=1e-5)
+        else:
+            learning_rule_type = learning_rule()
+
         u = nengo.Node(output=1.0)
         pre = nengo.Ensemble(10, dimensions=1)
         post = nengo.Ensemble(10, dimensions=1)
@@ -190,9 +195,8 @@ def learning_net(learning_rule, net, rng):
                                       size=(pre.n_neurons, post.n_neurons))
         conn = nengo.Connection(pre.neurons, post.neurons,
                                 transform=initial_weights,
-                                learning_rule_type=learning_rule())
+                                learning_rule_type=learning_rule_type)
         if learning_rule is nengo.PES:
-            learning_rule.learning_rate = 1e-5
             err = nengo.Ensemble(10, dimensions=1)
             nengo.Connection(u, err)
             nengo.Connection(err, conn.learning_rule)


### PR DESCRIPTION
The function `learning_net` in test_learning_rules.py used to set
the learning rate on the PES class itself, which led to changes
affecting other tests when run together.

Everyone should take a look at how this error occurred, since it's an easy way to create problems that are really hard to find. If you change an attribute on a class itself, this will change will remain for **all tests that follow**. So we should never do this.