### PR TITLE
Compat fixes

### DIFF
--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -80,7 +80,10 @@ def is_integer(obj):
 
 
 def is_iterable(obj):
-    return isinstance(obj, collections.Iterable)
+    if isinstance(obj, np.ndarray):
+        return obj.ndim > 0  # 0-d arrays give error if iterated over
+    else:
+        return isinstance(obj, collections.Iterable)
 
 
 def is_number(obj, check_complex=False):


### PR DESCRIPTION
A couple minor improvements to `compat.py`. The `as_ascii` function is useful in Nengo OCL, so I thought it might be good to have it here in case we need it in Nengo or other backends down the road.