### PR TITLE
Remove signatures from notebooks

### DIFF
--- a/examples/advanced/inhibitory_gating.ipynb
+++ b/examples/advanced/inhibitory_gating.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:4286a5dfc627265c6b6286f86e28f67e66b047dcf4212ef33124c79f9e8892a3"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/advanced/izhikevich.ipynb
+++ b/examples/advanced/izhikevich.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:2d48c60d9971ad985fc33e122e73ae1f159476dce041d743c057e76025a8ca8b"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/advanced/matrix_multiplication.ipynb
+++ b/examples/advanced/matrix_multiplication.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:c162d9b783412230e95e4a2d1c50a612db018b2b6d56fee495303bafbd1f4e3c"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/advanced/nef_summary.ipynb
+++ b/examples/advanced/nef_summary.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:2128ecf1d3df2c50e28c71266d91f7de1b93cd542404235f87a7047c39b3f91b"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/2d_representation.ipynb
+++ b/examples/basic/2d_representation.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:0d2cf768593894f6851a1b938fc6eddef2f2a208f5f544efa89c8eaad7b868b8"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/addition.ipynb
+++ b/examples/basic/addition.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:ed991982a55324b1fce065d4db7d4aeae1084f89fec94a0c1a29b302d702cae4"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/combining.ipynb
+++ b/examples/basic/combining.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:b1ca4291bd898141204101b6b31fa0a8531f4339995f0e926d472b8f446f1e78"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/communication_channel.ipynb
+++ b/examples/basic/communication_channel.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:28d0a8e8998416079f60f839b7e6c5c0cb8de613d272af289087f194023fb066"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/many_neurons.ipynb
+++ b/examples/basic/many_neurons.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:07cff1d33415571eace221e6e528278d6ee36fe4fc9d51511c86f394ec58b9e9"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/multiplication.ipynb
+++ b/examples/basic/multiplication.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:36fc9d0047a1b5d13d7448ae818621d998f92a0aeb194530ab6efbda7ba2b43b"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/single_neuron.ipynb
+++ b/examples/basic/single_neuron.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:6dda49e49c0c91754f8916ac2e9e0bd3f9f8e95652971c0a0c04b17923e43a84"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/squaring.ipynb
+++ b/examples/basic/squaring.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:3d193a94d941aac9f4e546dba231f95aa545e6173aaf7fb0fcdd36fb3b5b9776"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/basic/two_neurons.ipynb
+++ b/examples/basic/two_neurons.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:8f72bd9bb0a9480806aceffdb8a0303341a57307de2e2b0e6457bf670ab69e92"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/dynamics/controlled_integrator.ipynb
+++ b/examples/dynamics/controlled_integrator.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:c0345a7d9609f073a0ae0dc2ed8663bcb9a7ba2f8e4f3408eda769549ffc38a8"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/dynamics/controlled_integrator2.ipynb
+++ b/examples/dynamics/controlled_integrator2.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:fdd38e9c384256d334e90fdc895cb8c96367c35331837e6a37c9cb7bf3a72a3a"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/dynamics/controlled_oscillator.ipynb
+++ b/examples/dynamics/controlled_oscillator.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:295dc5b97d764bf20a97bd8fedad10963972f758dc8c4a9669edfe70be11e288"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/dynamics/integrator.ipynb
+++ b/examples/dynamics/integrator.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:5117f6bdbe3325cb5c6a5887f26a7fead650fee6a8c4a6fc498e2d953270619b"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/dynamics/lorenz_attractor.ipynb
+++ b/examples/dynamics/lorenz_attractor.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:0533b7885b69597d3645c7152cff8a82630aaab763b29c758201e9e78bd8a790"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/dynamics/oscillator.ipynb
+++ b/examples/dynamics/oscillator.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:a4fc96b278943b8e2b2f76a246ebe4cc62283b89dd05f650fff5fb2a429dbc42"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/learning/learn_communication_channel.ipynb
+++ b/examples/learning/learn_communication_channel.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "learn_communication_channel",
-  "signature": "sha256:f8a20d622b813a84ad4e3c6a6580cf79a3779a2a1f78eb121482093f2266b32f"
+  "name": "learn_communication_channel"
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/learning/learn_product.ipynb
+++ b/examples/learning/learn_product.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:22f20cbb79ccfbf3ad1879c9280e40dbbc73c156df4705ee1dc17ae7ea563202"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/learning/learn_square.ipynb
+++ b/examples/learning/learn_square.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "learn_square",
-  "signature": "sha256:9b43de8a8e25628b30a324d31dd7546a808b0cda275f3b7c4e5747fe49eb9b66"
+  "name": "learn_square"
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/learning/learn_unsupervised.ipynb
+++ b/examples/learning/learn_unsupervised.ipynb
@@ -12,8 +12,7 @@
    "pygments_lexer": "ipython2",
    "version": "2.7.5"
   },
-  "name": "",
-  "signature": "sha256:a5e1df2986e3c7c1b1e924e3a0483fb80f143fa0d2da5d21ad6cd6b507781e35"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/networks/basal_ganglia.ipynb
+++ b/examples/networks/basal_ganglia.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:21c107ff1231191020a6913327018f65dce9df4c5fc925aaeab7fbafa288852b"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/networks/ensemble_array.ipynb
+++ b/examples/networks/ensemble_array.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:c6aae384881d330e1f9f2e0a89dab9fdf87537cd59a5a900f6988bef583dac6a"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/networks/integrator_network.ipynb
+++ b/examples/networks/integrator_network.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:7d9995c1fb63388fe99de5dfd596f9d2aeba02ec92cf02469ce606e1321c2336"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/spa/convolution.ipynb
+++ b/examples/spa/convolution.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:96a66e632ae03f66c9dead0415a850a66c6ce26877cea719a43ba4f789c1f003"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/spa/question.ipynb
+++ b/examples/spa/question.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:4d1ab5b15eacbeac3c66babb4e1002bdee62cc0bc5b5bd15cb36b96442e494e0"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/spa/question_control.ipynb
+++ b/examples/spa/question_control.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:f562acc310f39070670e8da518041b95ec9d138581e370527a12e9058f8130cf"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/spa/question_memory.ipynb
+++ b/examples/spa/question_memory.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:8a5ec101c22ea6602a7f7a50ed40046ca7fc36b21dadcab2ffd99396450fc9a6"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/spa/spa_parser.ipynb
+++ b/examples/spa/spa_parser.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:b9f5b2cbecf282acbc6527a2f6db9f91375072979a2172919931d8b201e6c92b"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/spa/spa_sequence.ipynb
+++ b/examples/spa/spa_sequence.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:ebaea4f1e78a061b26883a7b6ddb89da391f17842dde1850678149363be62a6b"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/spa/spa_sequence_routed.ipynb
+++ b/examples/spa/spa_sequence_routed.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:553043f54cc6c2200ec31e71b8f19771e107d45381cf92d3d3ef353f3f3c36e1"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/usage/config.ipynb
+++ b/examples/usage/config.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:cba10c1a7dccbe927b655c459b37bf28a90ef6622809103e22e05701e9147210"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/usage/delay_node.ipynb
+++ b/examples/usage/delay_node.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:b1f4459a86096ef2c0f677e69a0729b698e42cfa6ba6d287053ab03b1e6be9c9"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/usage/network_design.ipynb
+++ b/examples/usage/network_design.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:80a64c5b889568dc590a5e3c1a2e11f86f110456724d8dc52bfd29ff0a25effe"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/usage/network_design_advanced.ipynb
+++ b/examples/usage/network_design_advanced.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:4e5bd93abfb50773c85dc49f9799ac3cdb6d426a7900bf2cb5487344c54b6409"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/usage/rectified_linear.ipynb
+++ b/examples/usage/rectified_linear.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:09bde728cac23394e3038d1a2a7ee800ef229d04de5a069f9dfdf8c921def053"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/usage/strings.ipynb
+++ b/examples/usage/strings.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:e48bd39420bb2cfdc500d2988ccea707f4d61eb5b851374bfcafef6cfc451d45"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/usage/tuning_curves.ipynb
+++ b/examples/usage/tuning_curves.ipynb
@@ -1,7 +1,6 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:41e34a6255d5244299c4c5e3aee968de174807e68d1b83733ec29d8839a345a2"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -97,6 +97,8 @@ def test_nooutput(nb_file):
 
     nb_path = os.path.join(examples_dir, "%s.ipynb" % nb_file)
     nb = load_notebook(nb_path)
+
+    assert 'signature' not in nb.metadata, "Remove signature in %s" % nb_path
     if nb.nbformat <= 3:
         for ws in nb.worksheets:
             check_all(ws.cells)


### PR DESCRIPTION
As we realized in #833, notebook signatures are machine-dependent.
We might as well remove them all and keep them out (with a test)
so that they're not showing up in our diffs all the time.

`devscripts/clearoutputs.py` has been changed to remove signatures,
so it should be easy to meet this requirement when changing notebooks.