### PR TITLE
Fix recent TravisCI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
     - env: PYTHON="2.7" NUMPY="1.7"
     - env: PYTHON="2.7" NUMPY="1.8"
     - env: PYTHON="3.4"
+    - env: PYTHON="3.5"
 
 # Setup Miniconda
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ env:
     - NUMPY="1.9"
     - SETUP_CMD="test -a 'nengo -n 2 -v'"
     - EXTRA_CMD=""
-    - CONDA_DEPS="matplotlib ipython-notebook pygments"
+    - CONDA_DEPS="matplotlib jupyter pygments"
     - PIP_DEPS="mistune pytest==2.7.3 pytest-xdist"
 
 matrix:
   include:
     - env: >
         PYTHON="2.6"
-        CONDA_DEPS="$CONDA_DEPS ordereddict pygments"
+        CONDA_DEPS="matplotlib ipython-notebook ordereddict pygments"
         PIP_DEPS="$PIP_DEPS counter importlib IPython==1.2.1"
     - env: >
         PYTHON="2.7"
@@ -33,7 +33,6 @@ matrix:
     - env: PYTHON="2.7" NUMPY="1.6"
     - env: PYTHON="2.7" NUMPY="1.7"
     - env: PYTHON="2.7" NUMPY="1.8"
-    - env: PYTHON="3.3"
     - env: PYTHON="3.4"
 
 # Setup Miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 env:
   global:
     - NUMPY="1.9"
-    - SETUP_CMD="test -a 'nengo -n 2 -v'"
+    - SETUP_CMD="test -a 'nengo -n 2 -v --durations 20'"
     - EXTRA_CMD=""
     - CONDA_DEPS="matplotlib jupyter pygments"
     - PIP_DEPS="mistune pytest==2.7.3 pytest-xdist"
@@ -20,7 +20,7 @@ matrix:
         PIP_DEPS="$PIP_DEPS counter importlib IPython==1.2.1"
     - env: >
         PYTHON="2.7"
-        SETUP_CMD="test -a '--cov-config .coveragerc --cov nengo nengo -n 2 -v'"
+        SETUP_CMD="test -a '--cov-config .coveragerc --cov nengo nengo -n 2 -v --durations 20'"
         EXTRA_CMD="coveralls"
         CONDA_DEPS="$CONDA_DEPS coverage"
         PIP_DEPS="$PIP_DEPS pytest-cov coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
     - NUMPY="1.9"
     - SETUP_CMD="test -a 'nengo -n 2 -v'"
     - EXTRA_CMD=""
-    - CONDA_DEPS="matplotlib ipython-notebook pygments pytest"
-    - PIP_DEPS="mistune pytest-xdist"
+    - CONDA_DEPS="matplotlib ipython-notebook pygments"
+    - PIP_DEPS="mistune pytest==2.7.3 pytest-xdist"
 
 matrix:
   include:

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -253,7 +253,7 @@ def test_fingerprinting(reference, equal, different):
 
 
 def test_fails_for_lambda_expression():
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, AttributeError)):
         Fingerprint(lambda x: x)
 
 

--- a/requirements-test-py26.txt
+++ b/requirements-test-py26.txt
@@ -5,5 +5,5 @@ counter
 importlib
 ordereddict
 pygments
-pytest
+pytest==2.7.3
 pytest-xdist

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 matplotlib>=1.4
 jupyter
-pytest
+pytest==2.7.3
 pytest-xdist


### PR DESCRIPTION
We were still doing `conda install ipython-notebook` when we should have been installing `jupyter`.

Unfortunately we still have two annoying errors; this is due to a [pytest regression](https://github.com/pytest-dev/pytest/issues/979) which has been [fixed in master](https://github.com/pytest-dev/pytest/pull/983). So, our options are to depends on `pytest==2.7.3` or wait for 2.8.1 to be released with the bugfix. Any preferences?

Also, this PR also removes testing in Python 3.3 (Conda thinks that Jupyter doesn't work in it) and adds testing for Python 3.5.