### PR TITLE
Simplified signal logic again

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -33,7 +33,7 @@ Nengo also includes code modified from other libraries.
 
 ------------
 
-The file ``nengo/builder.py`` contains code with the following
+The file ``nengo/builder/operator.py`` contains code with the following
 license:
 
 Copyright (c) 2014, James Bergstra

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -3,7 +3,6 @@ import warnings
 
 import numpy as np
 
-import nengo.utils.numpy as npext
 from nengo.builder.signal import Signal, SignalDict
 from nengo.cache import NoDecoderCache
 
@@ -28,10 +27,8 @@ class Model(object):
         self.probes = []
 
         self.sig = collections.defaultdict(dict)
-        self.sig['common'][0] = Signal(
-            npext.array(0., readonly=True), name='ZERO')
-        self.sig['common'][1] = Signal(
-            npext.array(1., readonly=True), name='ONE')
+        self.sig['common'][0] = Signal(0., readonly=True, name='ZERO')
+        self.sig['common'][1] = Signal(1., readonly=True, name='ONE')
 
     def __str__(self):
         return "Model: %s" % self.label

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -3,7 +3,8 @@ import warnings
 
 import numpy as np
 
-from nengo.builder.signal import SignalDict
+import nengo.utils.numpy as npext
+from nengo.builder.signal import Signal, SignalDict
 from nengo.cache import NoDecoderCache
 
 
@@ -25,7 +26,12 @@ class Model(object):
         self.params = {}
         self.seeds = {}
         self.probes = []
+
         self.sig = collections.defaultdict(dict)
+        self.sig['common'][0] = Signal(
+            npext.array(0., readonly=True), name='ZERO')
+        self.sig['common'][1] = Signal(
+            npext.array(1., readonly=True), name='ONE')
 
     def __str__(self):
         return "Model: %s" % self.label

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -36,6 +36,7 @@ def gen_eval_points(ens, eval_points, rng, scale_eval_points=True):
             warnings.warn("Number of eval_points doesn't match "
                           "n_eval_points. Ignoring n_eval_points.")
         eval_points = np.array(eval_points, dtype=np.float64)
+        assert eval_points.ndim == 2
 
     if scale_eval_points:
         eval_points *= ens.radius  # scale by ensemble radius
@@ -94,8 +95,8 @@ def build_ensemble(model, ens):
             np.zeros(ens.n_neurons), name="%s.neuron_in" % ens)
         model.sig[ens.neurons]['out'] = Signal(
             np.zeros(ens.n_neurons), name="%s.neuron_out" % ens)
-        model.add_op(Copy(src=Signal(bias, name="%s.bias" % ens),
-                          dst=model.sig[ens.neurons]['in']))
+        bias_sig = Signal(bias, name="%s.bias" % ens, readonly=True)
+        model.add_op(Copy(src=bias_sig, dst=model.sig[ens.neurons]['in']))
         # This adds the neuron's operator and sets other signals
         model.build(ens.neuron_type, ens.neurons)
 
@@ -106,7 +107,7 @@ def build_ensemble(model, ens):
         scaled_encoders = encoders * (gain / ens.radius)[:, np.newaxis]
 
     model.sig[ens]['encoders'] = Signal(
-        scaled_encoders, name="%s.scaled_encoders" % ens)
+        scaled_encoders, name="%s.scaled_encoders" % ens, readonly=True)
 
     # Inject noise if specified
     if ens.noise is not None:

--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -4,7 +4,6 @@ import numpy as np
 
 import nengo.utils.numpy as npext
 from nengo.builder.builder import Builder
-from nengo.builder.signal import Signal
 from nengo.network import Network
 
 logger = logging.getLogger(__name__)
@@ -34,10 +33,6 @@ def build_network(model, network):
 
     if model.toplevel is None:
         model.toplevel = network
-        model.sig['common'][0] = Signal(
-            npext.array(0.0, readonly=True), name='Common: Zero')
-        model.sig['common'][1] = Signal(
-            npext.array(1.0, readonly=True), name='Common: One')
         model.seeds[network] = get_seed(network, np.random)
 
     # Set config

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -132,8 +132,8 @@ class Operator(object):
         that use extra buffers should create them here.
         """
         for sig in self.all_signals:
-            if sig.base not in signals:
-                signals.init(sig.base)
+            if sig not in signals:
+                signals.init(sig)
 
 
 class PreserveValue(Operator):

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -11,6 +11,10 @@ from nengo.utils.compat import iteritems
 
 
 def conn_probe(model, probe):
+    # Connection probes create a connection from the target, and probe
+    # the resulting signal (used when you want to probe the default
+    # output of an object, which may not have a predefined signal)
+
     conn = Connection(probe.target, probe, synapse=probe.synapse,
                       solver=probe.solver, add_to_container=False)
 
@@ -25,11 +29,13 @@ def conn_probe(model, probe):
     model.build(conn)
 
 
-def synapse_probe(model, key, probe):
+def signal_probe(model, key, probe):
+    # Signal probes directly probe a target signal
+
     try:
         sig = model.sig[probe.obj][key]
     except IndexError:
-        raise ValueError("Attribute '%s' is not probable on %s."
+        raise ValueError("Attribute '%s' is not probeable on %s."
                          % (key, probe.obj))
 
     if probe.slice is not None:
@@ -51,7 +57,7 @@ probemap = {
     Node: {'output': None},
     Connection: {'output': 'out',
                  'input': 'in'},
-    LearningRule: {},  # make LR signals probable, but no mapping required
+    LearningRule: {},  # make LR signals probeable, but no mapping required
 }
 
 
@@ -68,7 +74,7 @@ def build_probe(model, probe):
     if key is None:
         conn_probe(model, probe)
     else:
-        synapse_probe(model, key, probe)
+        signal_probe(model, key, probe)
 
     model.probes.append(probe)
 

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -1,306 +1,14 @@
 """Signals represent values that will be used in the simulation.
-
-This code adapted from sigops/signal.py and sigops/signaldict.py
-(https://github.com/jaberg/sigops).
-This modified code is included under the terms of their license:
-
-Copyright (c) 2014, James Bergstra
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the
-   distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import numpy as np
 
 import nengo.utils.numpy as npext
-from nengo.utils.compat import StringIO
+from nengo.utils.compat import StringIO, is_integer
 
 
-class SignalView(object):
-
-    def __init__(self, base, shape, elemstrides, offset, name=None):
-        assert base is not None
-        self.base = base
-        self.shape = tuple(shape)
-        self.elemstrides = tuple(elemstrides)
-        self.offset = int(offset)
-        if name is not None:
-            self._name = name
-
-    def __len__(self):
-        return self.shape[0]
-
-    def __str__(self):
-        return '%s{%s, %s}' % (
-            self.__class__.__name__,
-            self.name, self.shape)
-
-    def __repr__(self):
-        return '%s{%s, %s}' % (
-            self.__class__.__name__,
-            self.name, self.shape)
-
-    def view_like_self_of(self, newbase, name=None):
-        if newbase.base != newbase:
-            raise NotImplementedError()
-        if newbase.structure != self.base.structure:
-            raise NotImplementedError('technically ok but should not happen',
-                                      (self.base, newbase))
-        return SignalView(newbase,
-                          self.shape,
-                          self.elemstrides,
-                          self.offset,
-                          name)
-
-    @property
-    def structure(self):
-        return (self.shape, self.elemstrides, self.offset)
-
-    def same_view_as(self, other):
-        return self.structure == other.structure and self.base == other.base
-
-    @property
-    def dtype(self):
-        return np.dtype(self.base.dtype)
-
-    @property
-    def ndim(self):
-        return len(self.shape)
-
-    @property
-    def readonly(self):
-        return not self.value.flags.writeable
-
-    @property
-    def size(self):
-        return int(np.prod(self.shape))
-
-    def reshape(self, *shape):
-        if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
-            shape = shape[0]
-
-        if -1 in shape:
-            shape = list(shape)
-            shape[shape.index(-1)] = self.size / int(-1 * np.prod(shape))
-            if -1 in shape:
-                raise ValueError("can only specify one unknown dimension")
-
-        if self.size == 1:
-            # -- scalars can be reshaped to any number of (1, 1, 1...)
-            elemstrides = [1] * len(shape)
-        else:
-            elemstrides = [1]
-            for si in reversed(shape[1:]):
-                elemstrides = [si * elemstrides[0]] + elemstrides
-
-        size = int(np.prod(shape))
-        if size != self.size:
-            raise ValueError(shape, self.shape)
-        return SignalView(base=self.base,
-                          shape=shape,
-                          elemstrides=elemstrides,
-                          offset=self.offset)
-
-    def column(self):
-        """Reshape into a column vector."""
-        return self.reshape((self.size, 1))
-
-    def row(self):
-        """Reshape into a row vector."""
-        return self.reshape((1, self.size))
-
-    def transpose(self, neworder=None):
-        if neworder:
-            raise NotImplementedError()
-        return SignalView(
-            self.base,
-            reversed(self.shape),
-            reversed(self.elemstrides),
-            self.offset,
-            self.name + '.T'
-        )
-
-    @property
-    def T(self):
-        if self.ndim < 2:
-            return self
-        else:
-            return self.transpose()
-
-    def __getitem__(self, item):  # noqa: C901
-        # -- copy the shape and strides
-        shape = list(self.shape)
-        elemstrides = list(self.elemstrides)
-        offset = self.offset
-        if isinstance(item, (list, tuple)):
-            dims_to_del = []
-            for ii, idx in enumerate(item):
-                if isinstance(idx, int):
-                    dims_to_del.append(ii)
-                    offset += idx * elemstrides[ii]
-                elif isinstance(idx, slice):
-                    start, stop, stride = idx.indices(shape[ii])
-                    offset += start * elemstrides[ii]
-                    if stride != 1:
-                        raise NotImplementedError()
-                    shape[ii] = stop - start
-            for dim in reversed(dims_to_del):
-                shape.pop(dim)
-                elemstrides.pop(dim)
-            return SignalView(
-                base=self.base,
-                shape=shape,
-                elemstrides=elemstrides,
-                offset=offset)
-        elif isinstance(item, (int, np.integer)):
-            if len(self.shape) == 0:
-                raise IndexError()
-            if not (0 <= item < self.shape[0]):
-                raise NotImplementedError()
-            shape = self.shape[1:]
-            elemstrides = self.elemstrides[1:]
-            offset = self.offset + item * self.elemstrides[0]
-            return SignalView(
-                base=self.base,
-                shape=shape,
-                elemstrides=elemstrides,
-                offset=offset)
-        elif isinstance(item, slice):
-            return self.__getitem__((item,))
-        else:
-            raise NotImplementedError(item)
-
-    @property
-    def name(self):
-        try:
-            return self._name
-        except AttributeError:
-            if self.base is self:
-                return '<anon%d>' % id(self)
-            else:
-                return 'View(%s[%d])' % (self.base.name, self.offset)
-
-    @name.setter
-    def name(self, value):
-        self._name = value
-
-    def is_contiguous(self):
-        shape, strides, offset = self.structure
-        if len(shape) == 0:
-            return True, offset, offset + 1
-        elif len(shape) == 1:
-            if strides[0] == 1:
-                return True, offset, offset + shape[0]
-            else:
-                return False, None, None
-        elif len(shape) == 2:
-            if strides == (1, shape[0]) or strides == (shape[1], 1):
-                return True, offset, offset + shape[0] * shape[1]
-            else:
-                return False, None, None
-        else:
-            raise NotImplementedError()
-        # if self.ndim == 1 and self.elemstrides[0] == 1:
-            # return self.offset, self.offset + self.size
-
-    def shares_memory_with(self, other):  # noqa: C901
-        # TODO: WRITE SOME UNIT TESTS FOR THIS FUNCTION !!!
-        # Terminology: two arrays *overlap* if the lowermost memory addressed
-        # touched by upper one is higher than the uppermost memory address
-        # touched by the lower one.
-        #
-        # np.may_share_memory returns True iff there is overlap.
-        # Overlap is a necessary but insufficient condition for *aliasing*.
-        #
-        # Aliasing is when two ndarrays refer a common memory location.
-        if self.base is not other.base or self.size == 0 or other.size == 0:
-            return False
-        elif self is other or self.same_view_as(other):
-            return True
-        elif self.ndim < other.ndim:
-            return other.shares_memory_with(self)
-
-        assert self.ndim > 0
-        if self.ndim == 1:
-            # -- self is a vector view
-            #    and other is either a scalar or vector view
-            ae0, = self.elemstrides
-            be0, = other.elemstrides
-            amin = self.offset
-            amax = amin + self.shape[0] * ae0
-            bmin = other.offset
-            bmax = bmin + other.shape[0] * be0
-            if amin <= amax <= bmin <= bmax or bmin <= bmax <= amin <= amax:
-                return False
-            elif ae0 == be0 == 1:
-                # -- strides are equal, and we've already checked for
-                #    non-overlap. They do overlap, so they are aliased.
-                return True
-            # TODO: look for common divisor of ae0 and be0
-            raise NotImplementedError('1d', (self.structure, other.structure))
-        elif self.ndim == 2:
-            # -- self is a matrix view
-            #    and other is either a scalar, vector or matrix view
-            a_contig, amin, amax = self.is_contiguous()
-            b_contig, bmin, bmax = other.is_contiguous()
-
-            if a_contig and b_contig:
-                # -- both have a contiguous memory layout,
-                #    from min up to but not including max
-                return (not (amin <= amax <= bmin <= bmax)
-                        and not (bmin <= bmax <= amin <= amax))
-            elif a_contig:
-                # -- only a contiguous
-                raise NotImplementedError('2d self:contig, other:discontig',
-                                          (self.structure, other.structure))
-            else:
-                raise NotImplementedError('2d',
-                                          (self.structure, other.structure))
-        raise NotImplementedError()
-
-    @property
-    def value(self):
-        """Returns a view on the base array's value."""
-        try:
-            # for some installations, this works
-            itemsize = int(self.dtype.itemsize)
-        except TypeError:
-            # other installations, this...
-            itemsize = int(self.dtype().itemsize)
-        byteoffset = itemsize * self.offset
-        bytestrides = [itemsize * s for s in self.elemstrides]
-        view = np.ndarray(shape=self.shape,
-                          dtype=self.dtype,
-                          buffer=self.base._value.data,
-                          offset=byteoffset,
-                          strides=bytestrides)
-        return view
-
-
-class Signal(SignalView):
-    """Interpretable, vector-valued quantity within Nengo"""
+class Signal(object):
+    """Represents data or views onto data within Nengo"""
 
     # Set assert_named_signals True to raise an Exception
     # if model.signal is used to create a signal with no name.
@@ -309,27 +17,65 @@ class Signal(SignalView):
     # up in a model.
     assert_named_signals = False
 
-    def __init__(self, value, name=None):
+    def __init__(self, value, name=None, base=None, readonly=False):
         # Make sure we use a C-contiguous array
-        self._value = np.array(value, copy=False, order='C', dtype=np.float64)
-        if name is not None:
-            self._name = name
-        if Signal.assert_named_signals:
-            assert name
+        self._value = np.array(value, copy=(base is None), order='C').view()
+        self._value.setflags(write=False)
 
-    def __str__(self):
-        try:
-            return "Signal(" + self._name + ", shape=" + str(self.shape) + ")"
-        except AttributeError:
-            return ("Signal(id " + str(id(self)) + ", shape="
-                    + str(self.shape) + ")")
+        if base is not None:
+            assert isinstance(base, Signal) and not base.is_view
+            # make sure value uses the same data as base.value
+            assert npext.array_base(value) is npext.array_base(base.value)
+        self._base = base
+
+        if self.assert_named_signals:
+            assert name
+        self._name = name
+
+        self._readonly = bool(readonly)
 
     def __repr__(self):
-        return str(self)
+        return "Signal(%s, shape=%s)" % (self._name, self.shape)
+
+    @property
+    def base(self):
+        return self if self._base is None else self._base
 
     @property
     def dtype(self):
         return self.value.dtype
+
+    @property
+    def elemstrides(self):
+        return tuple(s / self.itemsize for s in self.value.strides)
+
+    @property
+    def is_view(self):
+        return self._base is not None
+
+    @property
+    def itemsize(self):
+        return self._value.itemsize
+
+    @property
+    def name(self):
+        return self._name if self._name is not None else ("0x%x" % id(self))
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
+    def ndim(self):
+        return self.value.ndim
+
+    @property
+    def offset(self):
+        return npext.array_offset(self.value) / self.itemsize
+
+    @property
+    def readonly(self):
+        return self._readonly
 
     @property
     def shape(self):
@@ -340,21 +86,44 @@ class Signal(SignalView):
         return self.value.size
 
     @property
-    def elemstrides(self):
-        s = np.asarray(self.value.strides)
-        return tuple(int(si / self.dtype.itemsize) for si in s)
-
-    @property
-    def offset(self):
-        return 0
-
-    @property
-    def base(self):
-        return self
-
-    @property
     def value(self):
         return self._value
+
+    @value.setter
+    def value(self, val):
+        raise RuntimeError("Cannot change signal value after initialization")
+
+    def __getitem__(self, item):
+        """Index or slice into array"""
+        if not isinstance(item, tuple):
+            item = (item,)
+
+        if not all(is_integer(i) or isinstance(i, slice) for i in item):
+            raise ValueError("Can only index or slice into signals")
+
+        if all(map(is_integer, item)):
+            # turn one index into slice to get a view from numpy
+            item = item[:-1] + (slice(item[-1], item[-1]+1),)
+
+        return Signal(self._value[item],
+                      name="%s[%s]" % (self.name, item),
+                      base=self.base)
+
+    def reshape(self, *shape):
+        return Signal(self._value.reshape(*shape),
+                      name="%s.reshape(%s)" % (self.name, shape),
+                      base=self.base)
+
+    def column(self):
+        """Reshape into a column vector."""
+        return self.reshape((self.size, 1))
+
+    def row(self):
+        """Reshape into a row vector."""
+        return self.reshape((1, self.size))
+
+    def may_share_memory(self, other):
+        return np.may_share_memory(self.value, other.value)
 
 
 class SignalDict(dict):
@@ -367,36 +136,6 @@ class SignalDict(dict):
     Use ``init`` to set the ndarray initially.
     """
 
-    def __getitem__(self, obj):
-        """SignalDict overrides __getitem__ for two reasons.
-
-        1. so that scalars are returned as 0-d ndarrays
-        2. so that a SignalView lookup returns a views of its base
-        """
-        if obj in self:
-            return dict.__getitem__(self, obj)
-        elif obj.base in self:
-            # look up views as a fallback
-            # --work around numpy's special case behaviour for scalars
-            base_array = self[obj.base]
-            try:
-                # for some installations, this works
-                itemsize = int(obj.dtype.itemsize)
-            except TypeError:
-                # other installations, this...
-                itemsize = int(obj.dtype().itemsize)
-            byteoffset = itemsize * obj.offset
-            bytestrides = [itemsize * s for s in obj.elemstrides]
-            view = np.ndarray(shape=obj.shape,
-                              dtype=obj.dtype,
-                              buffer=base_array.data,
-                              offset=byteoffset,
-                              strides=bytestrides)
-            return view
-        else:
-            raise KeyError("%s has not been initialized. Please call "
-                           "SignalDict.init first." % (str(obj)))
-
     def __setitem__(self, key, val):
         """Ensures that ndarrays stay in the same place in memory.
 
@@ -405,7 +144,7 @@ class SignalDict(dict):
         silent typos when debugging Simulator. Every key must instead
         be explicitly initialized with SignalDict.init.
         """
-        self.__getitem__(key)[...] = val
+        self[key][...] = val
 
     def __str__(self):
         """Pretty-print the signals and current values."""
@@ -416,9 +155,23 @@ class SignalDict(dict):
 
     def init(self, signal):
         """Set up a permanent mapping from signal -> ndarray."""
-        # Make a copy of base.value to start
-        val = npext.array(signal.base.value, readonly=signal.readonly)
-        dict.__setitem__(self, signal.base, val)
+        if signal in self:
+            raise ValueError("Cannot add signal twice")
+
+        if signal.is_view:
+            if signal.base not in self:
+                self.init(signal.base)
+
+            # get a view onto the base data
+            v = signal.value
+            offset = npext.array_offset(v)
+            view = np.ndarray(shape=v.shape, strides=v.strides, offset=offset,
+                              dtype=v.dtype, buffer=self[signal.base].data)
+            view.setflags(write=not signal.readonly)
+            dict.__setitem__(self, signal, view)
+        else:
+            val = npext.array(signal.value, readonly=signal.readonly)
+            dict.__setitem__(self, signal, val)
 
     def reset(self, signal):
         """Reset ndarray to the base value of the signal that maps to it"""

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -18,8 +18,7 @@ class Signal(object):
     assert_named_signals = False
 
     def __init__(self, value, name=None, base=None, readonly=False):
-        # Make sure we use a C-contiguous array
-        self._value = np.array(value, copy=(base is None), order='C').view()
+        self._value = np.asarray(value).view()
         self._value.setflags(write=False)
 
         if base is not None:
@@ -62,8 +61,8 @@ class Signal(object):
         return self._name if self._name is not None else ("0x%x" % id(self))
 
     @name.setter
-    def name(self, value):
-        self._name = value
+    def name(self, name):
+        self._name = name
 
     @property
     def ndim(self):
@@ -76,6 +75,10 @@ class Signal(object):
     @property
     def readonly(self):
         return self._readonly
+
+    @readonly.setter
+    def readonly(self, readonly):
+        self._readonly = bool(readonly)
 
     @property
     def shape(self):
@@ -170,7 +173,8 @@ class SignalDict(dict):
             view.setflags(write=not signal.readonly)
             dict.__setitem__(self, signal, view)
         else:
-            val = npext.array(signal.value, readonly=signal.readonly)
+            val = signal.value
+            val = val.view() if signal.readonly else val.copy()
             dict.__setitem__(self, signal, val)
 
     def reset(self, signal):

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -39,7 +39,7 @@ class ProbeDict(Mapping):
         rval = self.raw[key]
         if isinstance(rval, list):
             rval = np.asarray(rval)
-            rval.flags.writeable = False
+            rval.setflags(write=False)
         return rval
 
     def __str__(self):

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -230,7 +230,7 @@ class Solver(with_metaclass(DocstringInheritor)):
         """
         raise NotImplementedError("Solvers must implement '__call__'")
 
-    def mul_encoders(self, Y, E):
+    def mul_encoders(self, Y, E, copy=False):
         if self.weights:
             if E is None:
                 raise ValueError("Encoders must be provided for weight solver")
@@ -238,7 +238,7 @@ class Solver(with_metaclass(DocstringInheritor)):
         else:
             if E is not None:
                 raise ValueError("Encoders must be 'None' for decoder solver")
-            return Y
+            return Y.copy() if copy else Y
 
     def __hash__(self):
         items = list(self.__dict__.items())
@@ -399,7 +399,7 @@ class LstsqL1(Solver):
 
     def __call__(self, A, Y, rng=None, E=None):
         import sklearn.linear_model
-        Y = self.mul_encoders(Y, E)
+        Y = self.mul_encoders(Y, E, copy=True)  # copy since 'fit' may modify Y
 
         # TODO: play around with regularization constants (I just guessed).
         #   Do we need to scale regularization by number of neurons, to get

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -102,17 +102,17 @@ def test_signal():
 
 
 def test_signal_values():
-    """Make sure Signal.value and SignalView.value work."""
+    """Make sure Signal.initial_value works."""
     two_d = Signal([[1.], [1.]])
-    assert np.allclose(two_d.value, np.array([[1], [1]]))
+    assert np.allclose(two_d.initial_value, np.array([[1], [1]]))
     two_d_view = two_d[0, :]
-    assert np.allclose(two_d_view.value, np.array([1]))
+    assert np.allclose(two_d_view.initial_value, np.array([1]))
 
     # cannot change signal value after creation
     with pytest.raises(RuntimeError):
-        two_d.value = np.array([[0.5], [-0.5]])
+        two_d.initial_value = np.array([[0.5], [-0.5]])
     with pytest.raises((ValueError, RuntimeError)):
-        two_d.value[...] = np.array([[0.5], [-0.5]])
+        two_d.initial_value[...] = np.array([[0.5], [-0.5]])
 
 
 def test_signal_init_values(RefSimulator):
@@ -243,8 +243,8 @@ def test_signal_slicing(rng):
     for i in range(100):
         si0, si1 = rng.randint(0, len(slices), size=2)
         s0, s1 = slices[si0], slices[si1]
-        assert np.array_equiv(a[s0].value, x[s0])
-        assert np.array_equiv(b[s0, s1].value, y[s0, s1])
+        assert np.array_equiv(a[s0].initial_value, x[s0])
+        assert np.array_equiv(b[s0, s1].initial_value, y[s0, s1])
 
     with pytest.raises(ValueError):
         a[[0, 2]]

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -65,6 +65,28 @@ def array_hash(a, n=100):
         return hash(v.data if PY2 else v.data.tobytes())
 
 
+def array_base(x):
+    """Get base array (that is *not* a view) for ``x``.
+
+    In Numpy >= 1.7, this is simply ``x.base``. However, in Numpy <= 1.6,
+    we need to loop back through the bases, since bases can be views.
+    """
+    while x.base is not None:
+        x = x.base
+    return x
+
+
+def array_offset(x):
+    """Get offset of array data from base data in bytes."""
+    if x.base is None:
+        return 0
+
+    base = array_base(x)
+    base_start = base.__array_interface__['data'][0]
+    start = x.__array_interface__['data'][0]
+    return start - base_start
+
+
 def expm(A, n_factors=None, normalize=False):
     """Simple matrix exponential to replace Scipy's matrix exponential
 

--- a/nengo/utils/simulator.py
+++ b/nengo/utils/simulator.py
@@ -93,12 +93,12 @@ def validate_ops(sets, ups, incs):
 
     # -- assert that no two views are both set and aliased
     for _, base_group in groupby(sets, lambda x: x.base, hashable=True):
-        for node, other in itertools.combinations(base_group, 2):
-            assert not node.shares_memory_with(other), (
-                "%s shares memory with %s" % (node, other))
+        for sig, sig2 in itertools.combinations(base_group, 2):
+            assert not sig.may_share_memory(sig2), (
+                "%s shares memory with %s" % (sig, sig2))
 
     # -- assert that no two views are both updated and aliased
     for _, base_group in groupby(ups, lambda x: x.base, hashable=True):
-        for node, other in itertools.combinations(base_group, 2):
-            assert not node.shares_memory_with(other), (
-                "%s shares memory with %s" % (node, other))
+        for sig, sig2 in itertools.combinations(base_group, 2):
+            assert not sig.may_share_memory(sig2), (
+                "%s shares memory with %s" % (sig, sig2))


### PR DESCRIPTION
This is a new version of #681. I took @drasmuss's commit to remove the SignalView stuff and just use Numpy for all our slicing needs, and modified it a bit. I also took out the controversial stuff about moving the simulation values from the simulator's SignalDict to the signals themselves. We can always do that later if we want, since it's not directly related to these changes.