### PR TITLE
Utility for setting PES learning_rate

### DIFF
--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -100,3 +100,51 @@ def eval_point_decoding(conn, sim, eval_points=None):
     decoded = np.dot(activities, weights.T)
     targets = get_targets(sim.model, conn, eval_points)
     return eval_points, targets, decoded
+
+
+def pes_learning_rate(epsilon, activities, t, dt=0.001):
+    """Determine the ideal learning rate for PES without noise or filtering.
+
+    This function returns a `learning_rate` for use in the PES rule, such that
+    after `t` seconds (with a simulator timestep of `dt`) a constant input
+    will have error equal to `epsilon` times the initial error. [1]_
+
+    Parameters
+    ----------
+    epsilon : float
+        The desired approximation factor. The resulting error will be `epsilon`
+        times the initial error. If you want the error to be at most some
+        constant, then divide `epsilon` by the largest possible initial error
+        (usually no more than 2, when the radius is 1).
+    activities : array_like (N,)
+        An array of N activity rates. Less activity (small ||a||) need a higher
+        learning rate. Pick the activities with the smallest ||a|| that you
+        want to learn within epsilon, or make it the average firing rate of
+        each neuron.
+    t : float
+        The amount of simulation time (in seconds) required to obtain the
+        desired error.
+    dt : float (optional)
+        The simulation timestep, defaults to 1 ms.
+
+    Returns
+    -------
+    learning_rate : float
+        The learning rate to provide to the PES rule.
+    gamma : float
+        The rate of convergence, such that the error is the initial error
+        multiplied by `gamma ** k` on the k'th timestep.
+
+    References
+    ----------
+    .. [1] http://compneuro.uwaterloo.ca/publications/voelker2015.html
+    """
+    activities = np.asarray(activities)
+    if activities.ndim != 1:
+        raise ValueError("activities must be a one-dimensional array")
+    n, = activities.shape  # number of neurons
+    a_sq = np.dot(activities.T, activities) * dt  # ||a||^2
+    k = (t - dt) / dt  # number of simulation timesteps
+    gamma = epsilon**(1.0 / k)  # rate of convergence
+    kappa = (1 - gamma) / a_sq  # rearrange equation from theorem
+    return kappa * n, gamma

--- a/nengo/utils/tests/test_connection.py
+++ b/nengo/utils/tests/test_connection.py
@@ -3,8 +3,10 @@ import pytest
 from matplotlib.mlab import griddata
 
 import nengo
+from nengo.builder.ensemble import get_activities
 from nengo.dists import UniformHypersphere
-from nengo.utils.connection import target_function, eval_point_decoding
+from nengo.utils.connection import (
+    target_function, eval_point_decoding, pes_learning_rate)
 from nengo.utils.numpy import rms
 
 
@@ -78,3 +80,63 @@ def test_eval_point_decoding(Simulator, nl_nodirect, plt, seed):
     # Also make sure error is above zero, i.e. y != z
     error = rms(decoded - targets, axis=1).mean()
     assert error < 0.1 and error > 1e-8
+
+
+def test_pes_learning_rate(Simulator, plt, seed):
+    n = 50
+    dt = 0.0005
+    T = 1.0
+    initial = 0.7
+    desired = -0.9
+    epsilon = 1e-3  # get to factor epsilon with T seconds
+
+    # Get activity vector and initial decoders
+    with nengo.Network(seed=seed) as model:
+        x = nengo.Ensemble(
+            n, 1, seed=seed, neuron_type=nengo.neurons.LIFRate())
+        y = nengo.Node(size_in=1)
+        conn = nengo.Connection(x, y, synapse=None)
+
+    sim = Simulator(model, dt=dt)
+    a = get_activities(sim.model, x, [initial])
+    d = sim.data[conn].weights
+    assert np.any(a > 0)
+
+    # Use util function to calculate learning_rate
+    init_error = float(desired - np.dot(d, a))
+    learning_rate, gamma = pes_learning_rate(
+        epsilon / abs(init_error), a, T, dt)
+
+    # Build model with no filtering on any connections
+    with model:
+        stim = nengo.Node(output=initial)
+        ystar = nengo.Node(output=desired)
+
+        conn.learning_rule_type = nengo.PES(
+            pre_tau=1e-15, learning_rate=learning_rate)
+
+        nengo.Connection(stim, x, synapse=None)
+        nengo.Connection(ystar, conn.learning_rule, synapse=0, transform=-1)
+        nengo.Connection(y, conn.learning_rule, synapse=0)
+
+        p = nengo.Probe(y, synapse=None)
+        decoders = nengo.Probe(conn, 'weights', synapse=None)
+
+    sim = Simulator(model, dt=dt)
+    sim.run(T)
+
+    # Check that the final error is exactly epsilon
+    assert np.allclose(abs(desired - sim.data[p][-1]), epsilon)
+
+    # Check that all of the errors are given exactly by gamma**k
+    k = np.arange(len(sim.trange()))
+    error = init_error * gamma ** k
+    assert np.allclose(sim.data[p].flatten(), desired - error)
+
+    # Check that all of the decoders are equal to their analytical solution
+    dk = d.T + init_error * a.T[:, None] * (1 - gamma ** k) / np.dot(a, a.T)
+    assert np.allclose(dk, np.squeeze(sim.data[decoders].T))
+
+    plt.figure()
+    plt.plot(sim.trange(), sim.data[p], lw=5, alpha=0.5)
+    plt.plot(sim.trange(), desired - error, linestyle='--', lw=5, alpha=0.5)


### PR DESCRIPTION
This makes the results from some recent research easy to use. Just specify the error that you want PES to be able to achieve within some specified time, and `pes_learning_rate` will tell you the exact `learning_rate` that accomplishes this (for constant input, no error filtering, and no noise). At the very least, this should make the task of choosing learning rates better motivated. :sweat_smile: 

Details: http://compneuro.uwaterloo.ca/publications/voelker2015.html