### PR TITLE
Add EnsembleArray.add_neuron_input/output.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ Release History
   (`#702 <https://github.com/nengo/nengo/pull/702>`_)
 - The ``Product`` and ``InputGatedMemory`` networks no longer accept a
   ``config`` argument. (`#814 <https://github.com/nengo/nengo/pull/814>`_)
+- The ``EnsembleArray`` network's ``neuron_nodes`` argument is deprecated.
+  Instead, call the new ``add_neuron_input`` or ``add_neuron_output`` methods.
+  (`#868 <https://github.com/nengo/nengo/pull/868>`_)
 
 **Behavioural changes**
 

--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -29,8 +29,10 @@ class EnsembleArray(nengo.Network):
         Whether to create a node that provides each access to each individual
         neuron, typically for the purpose of inibiting the entire
         EnsembleArray. Default: False.
+        *Note: this parameter is deprecated. Please call add_neuron_input
+        or add_neuron_output instead.*
     label : str, optional
-        A name to assign this EnsmbleArray.
+        A name to assign this EnsembleArray.
         Used for visualization and debugging.
     seed : int, optional
         Random number seed that will be used in the build step.
@@ -60,43 +62,90 @@ class EnsembleArray(nengo.Network):
         self.n_ensembles = n_ensembles
         self.dimensions_per_ensemble = ens_dimensions
 
+        # These may be set in add_neuron_input and add_neuron_output
+        self.neuron_input, self.neuron_output = None, None
+
         self.ea_ensembles = []
 
         with self:
             self.input = nengo.Node(size_in=self.dimensions, label="input")
 
-            if neuron_nodes:
-                self.neuron_input = nengo.Node(
-                    size_in=n_neurons * n_ensembles, label="neuron_input")
-                self.neuron_output = nengo.Node(
-                    size_in=n_neurons * n_ensembles, label="neuron_output")
-
             for i in range(n_ensembles):
-                e = nengo.Ensemble(
-                    n_neurons, self.dimensions_per_ensemble,
-                    label=label_prefix + str(i))
-
+                e = nengo.Ensemble(n_neurons, self.dimensions_per_ensemble,
+                                   label="%s%d" % (label_prefix, i))
                 nengo.Connection(self.input[i * ens_dimensions:
                                             (i + 1) * ens_dimensions],
                                  e, synapse=None)
-
-                if (neuron_nodes
-                        and not isinstance(e.neuron_type, nengo.Direct)):
-                    nengo.Connection(self.neuron_input[i * n_neurons:
-                                                       (i + 1) * n_neurons],
-                                     e.neurons, synapse=None)
-                    nengo.Connection(e.neurons,
-                                     self.neuron_output[i * n_neurons:
-                                                        (i + 1) * n_neurons],
-                                     synapse=None)
-
                 self.ea_ensembles.append(e)
 
-            if neuron_nodes and isinstance(e.neuron_type, nengo.Direct):
-                warnings.warn("Creating neuron nodes in an EnsembleArray"
-                              " with Direct neurons")
+        if neuron_nodes:
+            self.add_neuron_input()
+            self.add_neuron_output()
+            warnings.warn(
+                "'neuron_nodes' argument will be removed in Nengo 2.2. Use "
+                "'add_neuron_input' and 'add_neuron_output' methods instead.",
+                DeprecationWarning)
 
         self.add_output('output', function=None)
+
+    @property
+    def dimensions(self):
+        return self.n_ensembles * self.dimensions_per_ensemble
+
+    @with_self
+    def add_neuron_input(self):
+        """Adds a node that provides input to the neurons of all ensembles.
+
+        Direct neuron input is useful for inhibiting the activity of all
+        neurons in the ensemble array.
+
+        This node is accessible through the 'neuron_input' attribute
+        of this ensemble array.
+        """
+        if self.neuron_input is not None:
+            warnings.warn("neuron_input already exists. Returning.")
+            return self.neuron_input
+
+        if isinstance(self.ea_ensembles[0].neuron_type, nengo.Direct):
+            raise TypeError("Ensembles use Direct neuron type. "
+                            "Cannot give neuron input to Direct neurons.")
+
+        self.neuron_input = nengo.Node(
+            size_in=self.n_neurons * self.n_ensembles, label="neuron_input")
+
+        for i, ens in enumerate(self.ea_ensembles):
+            nengo.Connection(self.neuron_input[i * self.n_neurons:
+                                               (i + 1) * self.n_neurons],
+                             ens.neurons, synapse=None)
+        return self.neuron_input
+
+    @with_self
+    def add_neuron_output(self):
+        """Adds a node that collects the neural output of all ensembles.
+
+        Direct neuron output is useful for plotting the spike raster of
+        all neurons in the ensemble array.
+
+        This node is accessible through the 'neuron_output' attribute
+        of this ensemble array.
+        """
+        if self.neuron_output is not None:
+            warnings.warn("neuron_output already exists. Returning.")
+            return self.neuron_output
+
+        if isinstance(self.ea_ensembles[0].neuron_type, nengo.Direct):
+            raise TypeError("Ensembles use Direct neuron type. "
+                            "Cannot get neuron output from Direct neurons.")
+
+        self.neuron_output = nengo.Node(
+            size_in=self.n_neurons * self.n_ensembles, label="neuron_output")
+
+        for i, ens in enumerate(self.ea_ensembles):
+            nengo.Connection(ens.neurons,
+                             self.neuron_output[i * self.n_neurons:
+                                                (i + 1) * self.n_neurons],
+                             synapse=None)
+        return self.neuron_output
 
     @with_self
     def add_output(self, name, function, synapse=None, **conn_kwargs):
@@ -132,7 +181,3 @@ class EnsembleArray(nengo.Network):
                 synapse=synapse, **conn_kwargs)
 
         return output
-
-    @property
-    def dimensions(self):
-        return self.n_ensembles * self.dimensions_per_ensemble

--- a/nengo/networks/workingmemory.py
+++ b/nengo/networks/workingmemory.py
@@ -18,15 +18,13 @@ def InputGatedMemory(n_neurons, dimensions, feedback=1.0,
 
     with net:
         # integrator to store value
-        net.mem = EnsembleArray(n_neurons, dimensions,
-                                neuron_nodes=True, label="mem")
+        net.mem = EnsembleArray(n_neurons, dimensions, label="mem")
         nengo.Connection(net.mem.output, net.mem.input,
                          transform=feedback,
                          synapse=recurrent_synapse)
 
         # calculate difference between stored value and input
-        net.diff = EnsembleArray(n_neurons, dimensions,
-                                 neuron_nodes=True, label="diff")
+        net.diff = EnsembleArray(n_neurons, dimensions, label="diff")
         nengo.Connection(net.mem.output, net.diff.input, transform=-1)
 
         # feed difference into integrator
@@ -37,13 +35,14 @@ def InputGatedMemory(n_neurons, dimensions, feedback=1.0,
         # gate difference (if gate==0, update stored value,
         # otherwise retain stored value)
         net.gate = nengo.Node(size_in=1)
+        net.diff.add_neuron_input()
         nengo.Connection(net.gate, net.diff.neuron_input,
                          transform=np.ones((n_total_neurons, 1)) * -10,
                          synapse=None)
 
         # reset input (if reset=1, remove all values, and set to 0)
         net.reset = nengo.Node(size_in=1)
-        nengo.Connection(net.reset, net.mem.neuron_input,
+        nengo.Connection(net.reset, net.mem.add_neuron_input(),
                          transform=np.ones((n_total_neurons, 1)) * -3,
                          synapse=None)
 


### PR DESCRIPTION
Previously, these both happened whenever `neuron_nodes=True` was passed in. However, there are occasions when you only want a neuron input (as occurred in `InputGatedMemory`) or only want a neuron output (for plotting a raster, for example). Additionally, adding these functions makes the `__init__` function a bit more readable.

For the time being, I've kept `neuron_nodes` around as a shortcut to calling `add_neuron_input` and `add_neuron_output`. However, I've added a DeprecationWarning when it's set to True; we should  remember to remove `neuron_nodes` in Nengo 2.2.

I also redid the unit tests appropriately, and moved the EA.dimensions property up in the file, as I tend to expect all properties to be organized before all methods.