### PR TITLE
Fixes error empty vocabs for assoc_mem

### DIFF
--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -60,6 +60,19 @@ class AssociativeMemory(nengo.Network):
             input_vectors = np.array(input_vectors, ndmin=2)
         if is_iterable(output_vectors):
             output_vectors = np.array(output_vectors, ndmin=2)
+
+        if input_vectors.shape[0] == 0:
+            raise ValueError('Number of input vectors cannot be 0.')
+        elif input_vectors.shape[0] != output_vectors.shape[0]:
+            # Fail if number of input items and number of output items don't
+            # match
+            raise ValueError(
+                'Number of input vectors does not match number of output '
+                'vectors. %d != %d'
+                % (input_vectors.shape[0], output_vectors.shape[0]))
+
+        # Handle possible different threshold / input_scale values for each
+        # element in the associative memory
         if not is_iterable(threshold):
             threshold = threshold * np.ones(input_vectors.shape[0])
         else:

--- a/nengo/networks/tests/test_assoc_mem.py
+++ b/nengo/networks/tests/test_assoc_mem.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import nengo
 from nengo.networks.assoc_mem import AssociativeMemory
@@ -21,6 +22,12 @@ def test_am_basic(Simulator, plt, seed, rng):
     """Basic associative memory test."""
 
     D = 64
+    vocab = np.array([])
+
+    with pytest.raises(ValueError):
+        with nengo.Network():
+            am = AssociativeMemory(vocab)
+
     vocab = make_vocab(4, D, rng)
 
     with nengo.Network('model', seed=seed) as m:


### PR DESCRIPTION
- Creating an associative memory with an empty vocabulary now throws an error.
- Added empty vocabulary test.

Resolves #879 