### PR TITLE
Move timer

### DIFF
--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import nengo
 from nengo.utils.compat import range
-from nengo.utils.testing import Timer
+from nengo.utils.stdlib import Timer
 
 
 def test_multirun(Simulator, rng):

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -12,7 +12,8 @@ import nengo
 from nengo.dists import UniformHypersphere
 from nengo.utils.compat import range
 from nengo.utils.numpy import rms, norm
-from nengo.utils.testing import allclose, Timer
+from nengo.utils.stdlib import Timer
+from nengo.utils.testing import allclose
 from nengo.solvers import (
     cholesky, conjgrad, block_conjgrad, conjgrad_scipy, lsmr_scipy,
     Lstsq, LstsqNoise, LstsqL2, LstsqL2nz,

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -11,6 +11,7 @@ import itertools
 import os
 import shutil
 import sys
+import time
 
 from .compat import iteritems, reraise
 
@@ -167,3 +168,40 @@ def nested(*managers):
                 exc = sys.exc_info()
         if exc != (None, None, None):
             reraise(exc[0], exc[1], exc[2])
+
+
+class Timer(object):
+    """A context manager for timing a block of code.
+
+    Attributes
+    ----------
+    duration : float
+        The difference between the start and end time (in seconds).
+        Usually this is what you care about.
+    start : float
+        The time at which the timer started (in seconds).
+    end : float
+        The time at which the timer ended (in seconds).
+
+    Example
+    -------
+    >>> import time
+    >>> with Timer() as t:
+    ...    time.sleep(1)
+    >>> assert t.duration >= 1
+    """
+
+    TIMER = time.clock if sys.platform == "win32" else time.time
+
+    def __init__(self):
+        self.start = None
+        self.end = None
+        self.duration = None
+
+    def __enter__(self):
+        self.start = Timer.TIMER()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.end = Timer.TIMER()
+        self.duration = self.end - self.start

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -9,7 +9,6 @@ import time
 import warnings
 
 import numpy as np
-import pytest
 
 from .compat import is_string
 from .logging import CaptureLogHandler, console_formatter
@@ -189,11 +188,13 @@ class WarningCatcher(object):
 
 class warns(WarningCatcher):
     def __init__(self, warning_type):
+        import pytest
+        self._pytest = pytest
         self.warning_type = warning_type
 
     def __exit__(self, type, value, traceback):
         if not any(r.category is self.warning_type for r in self.record):
-            pytest.fail("DID NOT RAISE")
+            self._pytest.fail("DID NOT WARN")
 
         super(warns, self).__exit__(type, value, traceback)
 

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -5,7 +5,6 @@ import itertools
 import logging
 import os
 import re
-import sys
 import time
 import warnings
 
@@ -176,43 +175,6 @@ class Logger(Recorder):
                 fp.write(self.handler.stream.getvalue())
             self.handler.close()
             del self.handler
-
-
-class Timer(object):
-    """A context manager for timing a block of code.
-
-    Attributes
-    ----------
-    duration : float
-        The difference between the start and end time (in seconds).
-        Usually this is what you care about.
-    start : float
-        The time at which the timer started (in seconds).
-    end : float
-        The time at which the timer ended (in seconds).
-
-    Example
-    -------
-    >>> import time
-    >>> with Timer() as t:
-    ...    time.sleep(1)
-    >>> assert t.duration >= 1
-    """
-
-    TIMER = time.clock if sys.platform == "win32" else time.time
-
-    def __init__(self):
-        self.start = None
-        self.end = None
-        self.duration = None
-
-    def __enter__(self):
-        self.start = Timer.TIMER()
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.end = Timer.TIMER()
-        self.duration = self.end - self.start
 
 
 class WarningCatcher(object):

--- a/nengo/utils/tests/test_stdlib.py
+++ b/nengo/utils/tests/test_stdlib.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from nengo.utils.stdlib import checked_call, groupby
+from nengo.utils.compat import range
+from nengo.utils.stdlib import checked_call, groupby, Timer
 
 
 def test_checked_call():
@@ -96,3 +97,11 @@ def test_groupby(hashable, force_list, rng):
         group = groups[keys.index(key2)]
         group2 = map(lambda x: x[1], keygroup2)
         assert sorted(group2) == sorted(group)
+
+
+def test_timer():
+    with Timer() as timer:
+        for i in range(1000):
+            2 + 2
+    assert timer.duration > 0.0
+    assert timer.duration < 1.0  # Pretty bad worst case

--- a/nengo/utils/tests/test_testing.py
+++ b/nengo/utils/tests/test_testing.py
@@ -3,16 +3,7 @@ import os
 
 import pytest
 
-from nengo.utils.compat import range
-from nengo.utils.testing import Analytics, Logger, Timer
-
-
-def test_timer():
-    with Timer() as timer:
-        for i in range(1000):
-            2 + 2
-    assert timer.duration > 0.0
-    assert timer.duration < 1.0  # Pretty bad worst case
+from nengo.utils.testing import Analytics, Logger
 
 
 def test_analytics_empty():


### PR DESCRIPTION
In Nengo OCL, I've been using `Timer` to time the build process. @xchoo was running this on a machine without `pytest` installed, and running into problems because `Timer` was in `utils/testing.py` which imports `pytest` globally. Both these commits help address that. Really, either one of them would fix the problem, but I think they're both good changes.