### PR TITLE
Change cache logging level to debug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,10 @@ Release History
 - The ``EnsembleArray`` network's ``neuron_nodes`` argument is deprecated.
   Instead, call the new ``add_neuron_input`` or ``add_neuron_output`` methods.
   (`#868 <https://github.com/nengo/nengo/pull/868>`_)
+- The ``nengo.log`` utility function now takes a string ``level`` parameter
+  to specify any logging level, instead of the old binary ``debug`` parameter.
+  Cache messages are logged at DEBUG instead of INFO level.
+  (`#883 <https://github.com/nengo/nengo/pull/883>`_)
 
 **Behavioural changes**
 

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -249,14 +249,14 @@ class DecoderCache(object):
                 with open(path, 'rb') as f:
                     solver_info, decoders = nco.read(f)
             except:
-                logger.info("Cache miss [{0}].".format(key))
+                logger.debug("Cache miss [{0}].".format(key))
                 decoders, solver_info = solver_fn(
                     solver, neuron_type, gain, bias, x, targets, rng=rng, E=E)
                 if not self.read_only:
                     with open(path, 'wb') as f:
                         nco.write(f, solver_info, decoders)
             else:
-                logger.info(
+                logger.debug(
                     "Cache hit [{0}]: Loaded stored decoders.".format(key))
             return decoders, solver_info
         return cached_solver

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -206,8 +206,8 @@ class Simulator(object):
             or :class:`nengo.utils.progress.ProgressUpdater` instance.
         """
         steps = int(np.round(float(time_in_seconds) / self.dt))
-        logger.debug("Running %s for %f seconds, or %d steps",
-                     self.model.label, time_in_seconds, steps)
+        logger.info("Running %s for %f seconds, or %d steps",
+                    self.model.label, time_in_seconds, steps)
         self.run_steps(steps, progress_bar=progress_bar)
 
     def run_steps(self, steps, progress_bar=True):

--- a/nengo/utils/logging.py
+++ b/nengo/utils/logging.py
@@ -13,7 +13,7 @@ console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setFormatter(console_formatter)
 
 
-def log(debug=False, path=None):
+def log(level='warning', path=None):
     """Log messages.
 
     If path is None, logging messages will be printed to the console (stdout).
@@ -23,8 +23,20 @@ def log(debug=False, path=None):
     logging things, and Nengo will just populate their log.
     However, if the user is using Nengo directly, they can use this
     function to get log output.
+
+    Parameters
+    ----------
+    level : string (optional)
+        Collect messages targeting this level and above. The levels from
+        highest to lowest are: 'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'.
+    path : string (optional)
+        Path of a file to append log messages to. If ``None`` (default),
+        messages are logged to the console.
     """
-    level = logging.DEBUG if debug else logging.WARNING
+    if level.upper() not in ('CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'):
+        raise ValueError("Invalid logging level")
+
+    level = getattr(logging, level.upper())
     logging.root.setLevel(level)
 
     if path is None:

--- a/nengo/utils/tests/test_logging.py
+++ b/nengo/utils/tests/test_logging.py
@@ -7,11 +7,11 @@ import nengo.utils.logging
 
 
 def test_log_to_console():
-    nengo.log(debug=False, path=None)
+    nengo.log(path=None)
     assert logging.root.getEffectiveLevel() == logging.WARNING
     assert nengo.utils.logging.console_handler in logging.root.handlers
     n_handlers = len(logging.root.handlers)
-    nengo.log(debug=True, path=None)
+    nengo.log('debug', path=None)
     assert logging.root.getEffectiveLevel() == logging.DEBUG
     assert len(logging.root.handlers) == n_handlers
     logging.root.handlers.remove(nengo.utils.logging.console_handler)
@@ -19,13 +19,13 @@ def test_log_to_console():
 
 def test_log_to_file(tmpdir):
     tmpfile = str(tmpdir.join("log.txt"))
-    nengo.log(debug=False, path=tmpfile)
+    nengo.log(path=tmpfile)
     n_handlers = len(logging.root.handlers)
     handler = logging.root.handlers[-1]
     assert logging.root.getEffectiveLevel() == logging.WARNING
     assert isinstance(handler, logging.FileHandler)
     assert handler.baseFilename == tmpfile
-    nengo.log(debug=True, path=tmpfile)
+    nengo.log('debug', path=tmpfile)
     assert logging.root.getEffectiveLevel() == logging.DEBUG
     assert len(logging.root.handlers) == n_handlers
     logging.root.handlers.remove(handler)


### PR DESCRIPTION
Large models can have lots of cache interaction, and logging at
'info' level can flood the log. Also made the `log` utility function
able to set arbitrary levels.