### PR TITLE
Only add PreserveValue for encoders once

### DIFF
--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -233,8 +233,11 @@ def build_connection(model, conn):
             targets.append(r.modifies)
 
         if 'encoders' in targets:
-            model.sig[conn.post_obj]['encoders'].readonly = False
-            model.add_op(PreserveValue(model.sig[conn.post_obj]['encoders']))
+            encoder_sig = model.sig[conn.post_obj]['encoders']
+            if not any(isinstance(op, PreserveValue) and op.dst is encoder_sig
+                       for op in model.operators):
+                encoder_sig.readonly = False
+                model.add_op(PreserveValue(encoder_sig))
         if 'decoders' in targets or 'weights' in targets:
             if weights.ndim < 2:
                 raise BuildError(

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -69,6 +69,10 @@ class Operator(object):
     def __init__(self, tag=None):
         self.tag = tag
 
+    def __repr__(self):
+        return "<%s%s at 0x%x>" % (
+            self.__class__.__name__, self._tagstr, id(self))
+
     @property
     def _tagstr(self):
         return ' "%s"' % self.tag if self.tag is not None else ''


### PR DESCRIPTION
If multiple VOja (or other encoder learning) rules affect the same
ensemble, the PreserveValue op for the encoders should only be added
once. Fixes #911.