### PR TITLE
Made UniformHypersphere documentation clearer

### DIFF
--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -197,7 +197,10 @@ class Exponential(Distribution):
 
 
 class UniformHypersphere(Distribution):
-    """Distributions over an n-dimensional unit hypersphere.
+    """Uniform distribution on or in an n-dimensional unit hypersphere.
+
+    Sample points are uniformly distibuted across the volume (default) or
+    surface of an n-dimensional unit hypersphere.
 
     Parameters
     ----------


### PR DESCRIPTION
It is now clear that we sample from the volume of the sphere by default,
but can optionally sample from the surface. Fixes #923.