### PR TITLE
Simultaneous ops

### DIFF
--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -215,6 +215,14 @@ class SlicedCopy(Operator):
     """Copy from `a` to `b` with slicing: `b[b_slice] = a[a_slice]`"""
     def __init__(self, a, b, a_slice=Ellipsis, b_slice=Ellipsis,
                  inc=False, tag=None):
+        if isinstance(a_slice, slice):
+            a = a[a_slice]
+            a_slice = Ellipsis
+        if isinstance(b_slice, slice):
+            b = b[b_slice]
+            b_slice = Ellipsis
+        # ^ a_slice and b_slice are now either lists of indices or `Ellipsis`
+
         self.a = a
         self.b = b
         self.a_slice = a_slice


### PR DESCRIPTION
This is some work I did a little while ago to allow ops that modify different parts of the same base array to not be dependent on one another in the op graph. This change allows these ops to all be scheduled simultaneously in Nengo OCL.

One good example of this is in EnsembleArray, where many connections modify different (non-overlapping) slices of the output node.