### PR TITLE
Cache improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -214,6 +214,8 @@ Release History
   `#974 <https://github.com/nengo/nengo/pull/974>`_)
 - Fixed thread-safety of using networks and config in ``with`` statements.
   (`#989 <https://github.com/nengo/nengo/pull/989>`_)
+- The decoder cache will only be used when a seed is specified.
+  (`#946 <https://github.com/nengo/nengo/pull/946>`_)
 
 2.0.3 (December 7, 2015)
 ========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -186,6 +186,9 @@ Release History
   can be used to disallow adding new semantic pointers. Vocabulary subsets
   are read-only by default.
   (`#699 <https://github.com/nengo/nengo/pull/699>`_)
+- Improved performance of the decoder cache by writing all decoders
+  of a network into a single file.
+  (`#946 <https://github.com/nengo/nengo/pull/946>`_)
 
 **Bug fixes**
 

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -10,23 +10,65 @@ from nengo.exceptions import BuildError
 
 
 class Model(object):
-    """Output of the Builder, used by the Simulator."""
+    """Output of the Builder, used by the Simulator.
+
+    Attributes
+    ----------
+    config : Config instance or None
+        Build functions can set a config object here to affect sub-builders.
+    decoder_cache : DecoderCache instance
+        An object that will be used to cache decoders for faster builds.
+    dt : float
+        The length of each timestep, in seconds.
+    label : str or None
+        A name or description to differentiate different models.
+    operators : list of Operator instances
+        List of all operators created in the build process.
+        All operators must be added to this list, as it is used by Simulator.
+    params : dict (NengoObject -> namedtuple)
+        Mapping from objects to namedtuples containing parameters generated
+        in the build process.
+    probes : list of Probe
+        List of all probes. Probes must be added to this list in the build
+        process, as this list is used by Simulator.
+    seeded : dict (NengoObject -> bool)
+        All objects are assigned a seed, whether the user defined the seed
+        or it was automatically generated. 'seeded' keeps track of whether
+        the seed is user-defined. We consider the seed to be user-defined
+        if it was set directly on the object, or if a seed was set on the
+        network in which the object resides, or if a seed was set on any
+        ancestor network of the network in which the object resides.
+    seeds : dict (NengoObject -> int)
+        Mapping from objects to the integer seed assigned to that object.
+    sig : dict (str -> dict (object -> Signal))
+        A dictionary of dictionaries that organizes all of the signals
+        created in the build process, as build functions often need to
+        access signals created by other build functions.
+    step : Signal(dtype=int64)
+        The current step (i.e., how many timesteps have occurred thus far).
+    time : Signal(dtype=float64)
+        The current point in time.
+    toplevel : Network instance
+        The top-level network being built.
+        This is sometimes useful for accessing network elements after build,
+        or for the network builder to determine if it is the top-level network.
+    """
 
     def __init__(self, dt=0.001, label=None, decoder_cache=NoDecoderCache()):
         self.dt = dt
         self.label = label
         self.decoder_cache = decoder_cache
 
-        # We want to keep track of the toplevel network
+        # Will be filled in by the network builder
         self.toplevel = None
-        # Builders can set a config object to affect sub-builders
         self.config = None
 
-        # Resources used by the build process.
+        # Resources used by the build process
         self.operators = []
         self.params = {}
-        self.seeds = {}
         self.probes = []
+        self.seeds = {}
+        self.seeded = {}
 
         self.sig = collections.defaultdict(dict)
         self.sig['common'][0] = Signal(0., readonly=True, name='ZERO')

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -80,7 +80,8 @@ def build_decoders(model, conn, rng, transform):
         targets = multiply(targets, transform.T)
 
     try:
-        wrapped_solver = model.decoder_cache.wrap_solver(solve_for_decoders)
+        wrapped_solver = (model.decoder_cache.wrap_solver(solve_for_decoders)
+                          if model.seeded[conn] else solve_for_decoders)
         decoders, solver_info = wrapped_solver(
             conn.solver, conn.pre_obj.neuron_type, gain, bias, x, targets,
             rng=rng, E=E)

--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -34,6 +34,7 @@ def build_network(model, network):
     if model.toplevel is None:
         model.toplevel = network
         model.seeds[network] = get_seed(network, np.random)
+        model.seeded[network] = getattr(network, 'seed', None) is not None
 
     # Set config
     old_config = model.config
@@ -44,6 +45,8 @@ def build_network(model, network):
     sorted_types = sorted(network.objects, key=lambda t: t.__name__)
     for obj_type in sorted_types:
         for obj in network.objects[obj_type]:
+            model.seeded[obj] = (model.seeded[network] or
+                                 getattr(obj, 'seed', None) is not None)
             model.seeds[obj] = get_seed(obj, rng)
 
     logger.debug("Network step 1: Building ensembles and nodes")

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -20,6 +20,7 @@ def conn_probe(model, probe):
                       solver=probe.solver, add_to_container=False)
 
     # Set connection's seed to probe's (which isn't used elsewhere)
+    model.seeded[conn] = model.seeded[probe]
     model.seeds[conn] = model.seeds[probe]
 
     # Make a sink signal for the connection

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -46,6 +46,14 @@ def safe_remove(path):
         logger.warning("OSError during safe_remove: %s", err)
 
 
+def safe_makedirs(path):
+    if not os.path.exists(path):
+        try:
+            os.makedirs(path)
+        except OSError as err:
+            logger.warning("OSError during safe_makedirs: %s", err)
+
+
 class Fingerprint(object):
     """Fingerprint of an object instance.
 
@@ -166,8 +174,7 @@ class DecoderCache(object):
         if cache_dir is None:
             cache_dir = self.get_default_dir()
         self.cache_dir = cache_dir
-        if not os.path.exists(self.cache_dir):
-            os.makedirs(self.cache_dir)
+        safe_makedirs(self.cache_dir)
         self._fragment_size = get_fragment_size(self.cache_dir)
         try:
             self._remove_legacy_files()
@@ -405,8 +412,7 @@ class DecoderCache(object):
         prefix = key[:2]
         suffix = key[2:]
         directory = os.path.join(self.cache_dir, prefix)
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+        safe_makedirs(directory)
         return os.path.join(directory, suffix + self._CACHE_EXT)
 
 

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -94,3 +94,7 @@ class Unconvertible(NengoException, ValueError):
 
 class CacheIOError(NengoException, IOError):
     """An IO error in reading from or writing to the decoder cache."""
+
+
+class TimeoutError(NengoException):
+    """A timeout occurred while waiting for a resource."""

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -271,6 +271,19 @@ def test_cache_works(tmpdir, RefSimulator, seed):
         assert len(os.listdir(cache_dir)) == 2  # legacy.txt and *.nco
 
 
+def test_cache_not_used_without_seed(tmpdir, Simulator):
+    cache_dir = str(tmpdir)
+
+    model = nengo.Network()
+    with model:
+        nengo.Connection(nengo.Ensemble(10, 1), nengo.Ensemble(10, 1))
+
+    assert len(os.listdir(cache_dir)) == 0
+    Simulator(model, model=nengo.builder.Model(
+        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir)))
+    assert len(os.listdir(cache_dir)) == 1  # legacy.txt
+
+
 def calc_relative_timer_diff(t1, t2):
     return (t2.duration - t1.duration) / (t2.duration + t1.duration)
 

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -313,22 +313,22 @@ with model:
 
     with_cache_miss_ro = {
         'rc': '''
+nengo.cache.DecoderCache().invalidate()
 rc.set("decoder_cache", "enabled", "True")
 rc.set("decoder_cache", "readonly", "True")
 ''',
         'stmt': '''
-nengo.cache.DecoderCache().invalidate()
 sim = nengo.Simulator(model)
 '''
     }
 
     with_cache_miss = {
         'rc': '''
+nengo.cache.DecoderCache().invalidate()
 rc.set("decoder_cache", "enabled", "True")
 rc.set("decoder_cache", "readonly", "False")
 ''',
         'stmt': '''
-nengo.cache.DecoderCache().invalidate()
 sim = nengo.Simulator(model)
 '''
     }

--- a/nengo/utils/lock.py
+++ b/nengo/utils/lock.py
@@ -1,0 +1,51 @@
+import errno
+import os
+import os.path
+import time
+
+from nengo.exceptions import TimeoutError
+
+
+class FileLock(object):
+    def __init__(self, filename, timeout=10., poll=0.1):
+        self.filename = filename
+        self.timeout = timeout
+        self.poll = poll
+        self._fd = None
+
+    def acquire(self):
+        start = time.time()
+        while True:
+            try:
+                self._fd = os.open(
+                    self.filename, os.O_CREAT | os.O_RDWR | os.O_EXCL)
+                return
+            except OSError as err:
+                if err.errno not in (errno.EEXIST, errno.EACCES):
+                    raise
+                elif time.time() - start >= self.timeout:
+                    raise TimeoutError(
+                        "Could not acquire lock '{filename}'.".format(
+                            filename=self.filename))
+                else:
+                    time.sleep(self.poll)
+
+    def release(self):
+        if self._fd is not None:
+            os.close(self._fd)
+            os.unlink(self.filename)
+            self._fd = None
+
+    @property
+    def acquired(self):
+        return self._fd is not None
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.release()
+
+    def __del__(self):
+        self.release()

--- a/nengo/utils/tests/test_lock.py
+++ b/nengo/utils/tests/test_lock.py
@@ -1,0 +1,51 @@
+import os.path
+
+import pytest
+
+from nengo.utils.lock import FileLock, TimeoutError
+
+
+def test_can_acquire_filelock_at_most_once(tmpdir):
+    filename = os.path.join(str(tmpdir), 'lock')
+    lock = FileLock(filename, timeout=0.01, poll=0.01)
+    lock.acquire()
+    with pytest.raises(TimeoutError):
+        lock.acquire()
+    lock2 = FileLock(filename, timeout=0.01, poll=0.01)
+    with pytest.raises(TimeoutError):
+        lock2.acquire()
+    lock.release()
+
+
+def test_released_filelock_can_be_reacquired(tmpdir):
+    filename = os.path.join(str(tmpdir), 'lock')
+    lock = FileLock(filename, timeout=0.01, poll=0.01)
+    lock.acquire()
+    lock.release()
+    lock.acquire()
+    lock.release()
+
+
+def test_can_release_filelock_multiple_times(tmpdir):
+    filename = os.path.join(str(tmpdir), 'lock')
+    lock = FileLock(filename, timeout=0.01, poll=0.01)
+    lock.release()
+    lock.acquire()
+    lock.release()
+    lock.release()
+
+
+def test_filelock_supports_with_statement(tmpdir):
+    filename = os.path.join(str(tmpdir), 'lock')
+    with FileLock(filename):
+        pass
+
+
+def test_filelock_gets_released_on_lock_deletion(tmpdir):
+    filename = os.path.join(str(tmpdir), 'lock')
+    lock = FileLock(filename, timeout=0.01, poll=0.01)
+    lock.acquire()
+    del lock
+    lock = FileLock(filename, timeout=0.01, poll=0.01)
+    lock.acquire()
+    lock.release()


### PR DESCRIPTION
The cache was always enabled, even without a seed (as long as not explicitely disabled). This PR changes this to use it only if the seed is actually set.

Currently, I am looking a bit more into other ways to improve the performance. This will likely include not caching results for small ensembles.