### PR TITLE
Promote processes as a core part of Nengo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,16 +24,20 @@ Release History
 
 **API changes**
 
+- A new class for representing stateful functions called ``Process``
+  has been added. ``Node`` objects are now process-aware, meaning that
+  a process can be used as a node's ``output``. Unlike non-process
+  callables, processes are properly reset when a simulator is reset.
+  See the ``processes.ipynb`` example notebook, or the API documentation
+  for more details.
+  (`#590 <https://github.com/nengo/nengo/pull/590>`_,
+  `#652 <https://github.com/nengo/nengo/pull/652>`_,
+  `#945 <https://github.com/nengo/nengo/pull/945>`_,
+  `#955 <https://github.com/nengo/nengo/pull/955>`_)
 - Spiking ``LIF`` neuron models now accept an additional argument,
   ``min_voltage``. Voltages are clipped such that they do not drop below
   this value (previously, this was fixed at 0).
   (`#666 <https://github.com/nengo/nengo/pull/666>`_)
-- ``Process`` objects can now be passed directly as node outputs,
-  making them easier to use. The ``Process`` interface is also improved
-  and is currently the same as the ``Synapse`` interface. However,
-  further improvements are pending, and the current implementation
-  SHOULD NOT BE RELEASED!
-  (`#652 <https://github.com/nengo/nengo/pull/652>`_)
 - The ``PES`` learning rule no longer accepts a connection as an argument.
   Instead, error information is transmitted by making a connection to the
   learning rule object (e.g.,
@@ -121,6 +125,9 @@ Release History
 
 **Improvements**
 
+- Added ``Ensemble.noise`` attribute, which injects noise directly into
+  neurons according to a stochastic ``Process``.
+  (`#590 <https://github.com/nengo/nengo/pull/590>`_)
 - Added a ``randomized_svd`` subsolver for the L2 solvers. This can be much
   quicker for large numbers of neurons or evaluation points.
   (`#803 <https://github.com/nengo/nengo/pull/803>`_)

--- a/docs/backend_api.rst
+++ b/docs/backend_api.rst
@@ -70,6 +70,8 @@ Operators
 
 .. autoclass:: nengo.builder.learning_rules.SimVoja
 
+.. autoclass:: nengo.builder.processes.SimProcess
+
 Build functions
 ---------------
 
@@ -110,3 +112,7 @@ Build functions
 .. autofunction:: nengo.builder.learning_rules.build_voja
 
 .. autofunction:: nengo.builder.learning_rules.build_pes
+
+.. autofunction:: nengo.builder.processes.build_process
+
+.. autofunction:: nengo.builder.processes.build_synapse

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -61,6 +61,13 @@ Nodes
 
    examples/delay_node
 
+Processes
+=========
+
+.. toctree::
+
+   examples/processes
+
 Ensembles
 =========
 

--- a/docs/examples/processes.rst
+++ b/docs/examples/processes.rst
@@ -1,0 +1,5 @@
+*****************************
+Processes and how to use them
+*****************************
+
+.. notebook:: ../../examples/advanced/processes.ipynb

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -55,6 +55,21 @@ Learning rule types
 
 .. autoclass:: nengo.Voja
 
+Processes
+=========
+
+.. autoclass:: nengo.Process
+
+.. autoclass:: nengo.processes.PresentInput
+
+.. autoclass:: nengo.processes.FilteredNoise
+
+.. autoclass:: nengo.processes.BrownNoise
+
+.. autoclass:: nengo.processes.WhiteNoise
+
+.. autoclass:: nengo.processes.WhiteSignal
+
 Synapse models
 ==============
 

--- a/examples/advanced/processes.ipynb
+++ b/examples/advanced/processes.ipynb
@@ -1,0 +1,571 @@
+{
+ "metadata": {
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 1,
+     "metadata": {},
+     "source": [
+      "Processes and how to use them"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Processes in Nengo can be used to describe general functions or dynamical systems,\n",
+      "including those with randomness.\n",
+      "They can be useful if you want a `Node` output\n",
+      "that has a state (like a dynamical system),\n",
+      "and they're also used for things like \n",
+      "injecting noise into Ensembles\n",
+      "so that you can not only have \"white\" noise that samples from a distribution,\n",
+      "but can also have \"colored\" noise\n",
+      "where subsequent samples are correlated with past samples.\n",
+      "\n",
+      "This notebook will first present the basic process interface,\n",
+      "then demonstrate some of the built-in Nengo processes\n",
+      "and how they can be used in your code.\n",
+      "It will also describe how to create your own custom process."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import numpy as np\n",
+      "\n",
+      "import matplotlib.pyplot as plt\n",
+      "%matplotlib inline\n",
+      "\n",
+      "import nengo\n",
+      "%load_ext nengo.ipynb"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Interface"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We will begin by looking at how to run an existing process instance.\n",
+      "\n",
+      "The key functions for running processes are `run`, `run_steps`, and ``apply``.\n",
+      "The first two are for running without an input,\n",
+      "and the third is for applying the process to an input.\n",
+      "\n",
+      "There are also two helper functions,\n",
+      "`trange` and `ntrange`,\n",
+      "which return the time points corresponding to a process output,\n",
+      "given either a length of time or a number of steps, respectively."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### `run`: running a process for a length of time\n",
+      "\n",
+      "The `run` function runs a process for a given length of time, without any input.\n",
+      "Many of the random processes in `nengo.processes` will be run this way,\n",
+      "since they do not require an input signal."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# Create a process (details on the FilteredNoise process below)\n",
+      "process = nengo.processes.FilteredNoise(\n",
+      "    synapse=nengo.synapses.Alpha(0.1), seed=0)\n",
+      "\n",
+      "# run the process for two seconds\n",
+      "y = process.run(2.0)\n",
+      "\n",
+      "# get a corresponding two-second time range\n",
+      "t = process.trange(2.0)\n",
+      "\n",
+      "plt.plot(t, y)\n",
+      "plt.xlabel('time [s]')\n",
+      "plt.ylabel('process output');"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### `run_steps`: running a process for a number of steps\n",
+      "\n",
+      "To run the process for a number of steps, use the `run_steps` function.\n",
+      "The length of the generated signal will depend on the process's `default_dt`."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "process = nengo.processes.FilteredNoise(\n",
+      "    synapse=nengo.synapses.Alpha(0.1), seed=0)\n",
+      "\n",
+      "# run the process for 1000 steps\n",
+      "y = process.run_steps(1000)\n",
+      "\n",
+      "# get a corresponding 1000-step time range\n",
+      "t = process.ntrange(1000)\n",
+      "\n",
+      "plt.plot(t, y)\n",
+      "plt.xlabel('time [s]')\n",
+      "plt.ylabel('process output');"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### `apply`: running a process with an input\n",
+      "\n",
+      "To run a process with an input, use the `apply` function."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "process = nengo.synapses.Lowpass(0.2)\n",
+      "\n",
+      "t = process.trange(5)\n",
+      "x = np.minimum(t % 2, 2 - (t % 2))  # sawtooth wave\n",
+      "y = process.apply(x)  # general to all Processes\n",
+      "z = process.filtfilt(x)  # specific to Synapses\n",
+      "\n",
+      "plt.plot(t, x, label='input')\n",
+      "plt.plot(t, y, label='output')\n",
+      "plt.plot(t, z, label='filtfilt')\n",
+      "plt.xlabel('time [s]')\n",
+      "plt.ylabel('signal')\n",
+      "plt.legend();"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Note that Synapses are a special kind of process,\n",
+      "and have the additional functions `filt` and `filtfilt`.\n",
+      "`filt` works mostly the same as `apply`,\n",
+      "but with some additional functionality\n",
+      "such as the ability to filter along any axis.\n",
+      "`filtfilt` provides zero-phase filtering."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### Changing the time-step (`dt` and `default_dt`)\n",
+      "\n",
+      "To run a process with a different time-step,\n",
+      "you can either pass the new time step (`dt`) when calling the functions,\n",
+      "or change the `default_dt` property of the process."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "process = nengo.processes.FilteredNoise(\n",
+      "    synapse=nengo.synapses.Alpha(0.1), seed=0)\n",
+      "y1 = process.run(2.0, dt=0.05)\n",
+      "t1 = process.trange(2.0, dt=0.05)\n",
+      "\n",
+      "process = nengo.processes.FilteredNoise(\n",
+      "    synapse=nengo.synapses.Alpha(0.1), default_dt=0.1, seed=0)\n",
+      "y2 = process.run(2.0)\n",
+      "t2 = process.trange(2.0)\n",
+      "\n",
+      "plt.plot(t1, y1, label='dt = %s' % 0.05)\n",
+      "plt.plot(t2, y2, label='dt = %s' % 0.1)\n",
+      "plt.xlabel('time [s]')\n",
+      "plt.ylabel('output');"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## `WhiteSignal`\n",
+      "\n",
+      "The `WhiteSignal` process is used to generate band-limited white noise,\n",
+      "with only frequencies below a given cutoff frequency."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with nengo.Network() as model:\n",
+      "    a = nengo.Node(nengo.processes.WhiteSignal(1.0, high=5, seed=0))\n",
+      "    b = nengo.Node(nengo.processes.WhiteSignal(1.0, high=10, seed=0))\n",
+      "    c = nengo.Node(nengo.processes.WhiteSignal(1.0, high=5, rms=0.3, seed=0))\n",
+      "    d = nengo.Node(nengo.processes.WhiteSignal(0.5, high=5, seed=0))\n",
+      "    ap = nengo.Probe(a)\n",
+      "    bp = nengo.Probe(b)\n",
+      "    cp = nengo.Probe(c)\n",
+      "    dp = nengo.Probe(d)\n",
+      "    \n",
+      "with nengo.Simulator(model) as sim:\n",
+      "    sim.run(1.0)\n",
+      "    \n",
+      "plt.plot(sim.trange(), sim.data[ap], label='5 Hz cutoff')\n",
+      "plt.plot(sim.trange(), sim.data[bp], label='10 Hz cutoff')\n",
+      "plt.plot(sim.trange(), sim.data[cp], label='5 Hz cutoff, 0.3 RMS amplitude')\n",
+      "plt.plot(sim.trange(), sim.data[dp], label='5 Hz cutoff, 0.5 s period')\n",
+      "plt.xlabel(\"time [s]\")\n",
+      "plt.legend(loc=2);"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Note that the 10 Hz signal (green)\n",
+      "has similar low frequency characteristics\n",
+      "as the 5 Hz signal (blue),\n",
+      "but with additional higher-frequency components.\n",
+      "The 0.3 RMS amplitude 5 Hz signal (red)\n",
+      "is the same as the original 5 Hz signal (blue),\n",
+      "but scaled down (the default RMS amplitude is 0.5).\n",
+      "Finally, the signal with a 0.5 s period\n",
+      "(instead of a 1 s period like the others)\n",
+      "is completely different,\n",
+      "because changing the period changes\n",
+      "the spacing of the random frequency components\n",
+      "and thus creates a completely different signal.\n",
+      "Note how the signal with the 0.5 s period repeats itself;\n",
+      "for example, the value at $t = 0$\n",
+      "is the same as the value at $t = 0.5$,\n",
+      "and the value at $t = 0.4$\n",
+      "is the same as the value at $t = 0.9$."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## `WhiteNoise`\n",
+      "\n",
+      "The `WhiteNoise` process generates white noise,\n",
+      "with equal power across all frequencies.\n",
+      "By default, it is scaled so that the integral process (Brownian noise)\n",
+      "will have the same standard deviation regardless of `dt`."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "process = nengo.processes.WhiteNoise(\n",
+      "    dist=nengo.dists.Gaussian(0, 1))\n",
+      "\n",
+      "t = process.trange(0.5)\n",
+      "y = process.run(0.5)\n",
+      "plt.plot(t, y);"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "One use of the `WhiteNoise` process\n",
+      "is to inject noise into neural populations.\n",
+      "Here, we create two identical ensembles,\n",
+      "but add a bit of noise to one and no noise to the other.\n",
+      "We plot the membrane voltages of both."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "process = nengo.processes.WhiteNoise(\n",
+      "    dist=nengo.dists.Gaussian(0, 0.01), seed=1)\n",
+      "\n",
+      "with nengo.Network() as model:\n",
+      "    ens_args = dict(encoders=[[1]], intercepts=[0.01], max_rates=[100])\n",
+      "    a = nengo.Ensemble(1, 1, **ens_args)\n",
+      "    b = nengo.Ensemble(1, 1, noise=process, **ens_args)\n",
+      "    a_voltage = nengo.Probe(a.neurons, 'voltage')\n",
+      "    b_voltage = nengo.Probe(b.neurons, 'voltage')\n",
+      "    \n",
+      "with nengo.Simulator(model) as sim:\n",
+      "    sim.run(0.15)\n",
+      "    \n",
+      "plt.plot(sim.trange(), sim.data[a_voltage], label=\"deterministic\")\n",
+      "plt.plot(sim.trange(), sim.data[b_voltage], label=\"noisy\")\n",
+      "plt.xlabel('time [s]')\n",
+      "plt.ylabel('voltage')\n",
+      "plt.legend(loc=4);"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We see that the neuron without noise (blue)\n",
+      "approaches its firing threshold,\n",
+      "but never quite gets there.\n",
+      "Adding a bit of noise (green)\n",
+      "causes the neuron to occasionally jitter above the threshold,\n",
+      "resulting in two spikes\n",
+      "(where the voltage suddenly drops to zero)."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## `FilteredNoise`\n",
+      "\n",
+      "The `FilteredNoise` process takes a white noise signal\n",
+      "and passes it through a filter.\n",
+      "Using any type of lowpass filter (e.g. `Lowpass`, `Alpha`)\n",
+      "will result in a signal similar to `WhiteSignal`,\n",
+      "but rather than being ideally filtered\n",
+      "(i.e. no frequency content above the cutoff),\n",
+      "the `FilteredNoise` signal\n",
+      "will have some frequency content above the cutoff,\n",
+      "with the amount depending on the filter used.\n",
+      "Here, we can see how an `Alpha` filter\n",
+      "(a second-order lowpass filter)\n",
+      "is much better than the `Lowpass` filter\n",
+      "(a first-order lowpass filter)\n",
+      "at removing the high-frequency content."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "process1 = nengo.processes.FilteredNoise(\n",
+      "    dist=nengo.dists.Gaussian(0, 0.01), \n",
+      "    synapse=nengo.Alpha(0.005),\n",
+      "    seed=0)\n",
+      "\n",
+      "process2 = nengo.processes.FilteredNoise(\n",
+      "    dist=nengo.dists.Gaussian(0, 0.01), \n",
+      "    synapse=nengo.Lowpass(0.005),\n",
+      "    seed=0)\n",
+      "\n",
+      "tlen = 0.5\n",
+      "plt.plot(process1.trange(tlen), process1.run(tlen))\n",
+      "plt.plot(process2.trange(tlen), process2.run(tlen));"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "The `FilteredNoise` process with an `Alpha` synapse (blue)\n",
+      "has significantly lower high-frequency components\n",
+      "than a similar process with a `Lowpass` synapse (green)."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## `PresentInput`\n",
+      "\n",
+      "The `PresentInput` process is useful for\n",
+      "presenting a series of static inputs to a network,\n",
+      "where each input is shown for the same length of time.\n",
+      "Once all the images have been shown,\n",
+      "they repeat from the beginning.\n",
+      "One application is presenting a series of images to a classification network."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "inputs = [[0, 0.5], [0.3, 0.2], [-0.1, -0.7], [-0.8, 0.6]]\n",
+      "process = nengo.processes.PresentInput(\n",
+      "    inputs, presentation_time=0.1)\n",
+      "\n",
+      "tlen = 0.8\n",
+      "plt.plot(process.trange(tlen), process.run(tlen))\n",
+      "plt.xlim([0, tlen])\n",
+      "plt.ylim([-1, 1]);"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Custom processes\n",
+      "\n",
+      "You can create custom processes\n",
+      "by inheriting from the `nengo.Process` class\n",
+      "and overloading the `make_step` function.\n",
+      "\n",
+      "First, we'll make a simple custom process\n",
+      "that implements a two-dimensional oscillator dynamical system.\n",
+      "The `make_step` function defines a `state` variable\n",
+      "to store the state,\n",
+      "and a fixed `A` matrix that determines\n",
+      "how the state changes over time.\n",
+      "\n",
+      "One advantage to using a process over a simple function\n",
+      "is that if we reset our simulator,\n",
+      "`make_step` will be called again\n",
+      "and the process state\n",
+      "will be restored to the initial state."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "class SimpleOscillator(nengo.Process):\n",
+      "    def make_step(self, shape_in, shape_out, dt, rng):\n",
+      "        A = np.array([[-0.1, -1.], [1., -0.1]])\n",
+      "        state = np.array([1., 0.])\n",
+      "        \n",
+      "        # define the step function, which will be called \n",
+      "        # by the node every time step\n",
+      "        def step(t):\n",
+      "            state[:] += dt * np.dot(A, state)\n",
+      "            return state\n",
+      "        \n",
+      "        return step  # return the step function\n",
+      "    \n",
+      "with nengo.Network() as model:\n",
+      "    a = nengo.Node(SimpleOscillator(), size_in=0, size_out=2)\n",
+      "    a_p = nengo.Probe(a)\n",
+      "    \n",
+      "with nengo.Simulator(model) as sim:\n",
+      "    sim.run(20.0)\n",
+      "    \n",
+      "plt.plot(sim.trange(), sim.data[a_p])\n",
+      "plt.xlabel('time [s]');"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We can generalize this process to one\n",
+      "that can implement arbitrary linear dynamical systems,\n",
+      "given `A` and `B` matrices.\n",
+      "We will overload the `__init__` method\n",
+      "to take and store these matrices,\n",
+      "as well as check the matrix shapes\n",
+      "and set the default size in and out.\n",
+      "The advantage of using the default sizes\n",
+      "is that when we then create a node using the process,\n",
+      "or run the process using `apply`,\n",
+      "we do not need to specify the sizes."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "class LTIProcess(nengo.Process):\n",
+      "    def __init__(self, A, B, **kwargs):\n",
+      "        A, B = np.asarray(A), np.asarray(B)\n",
+      "        \n",
+      "        # check that the matrix shapes are compatible\n",
+      "        assert A.ndim == 2 and A.shape[0] == A.shape[1]\n",
+      "        assert B.ndim == 2 and B.shape[0] == A.shape[0]\n",
+      "        \n",
+      "        # store the matrices for `make_step`\n",
+      "        self.A = A\n",
+      "        self.B = B\n",
+      "        \n",
+      "        # pass the default sizes to the Process constructor\n",
+      "        super(LTIProcess, self).__init__(\n",
+      "            default_size_in=B.shape[1], default_size_out=A.shape[0], **kwargs)\n",
+      "    \n",
+      "    def make_step(self, shape_in, shape_out, dt, rng):\n",
+      "        assert shape_in == (self.B.shape[1],)\n",
+      "        assert shape_out == (self.A.shape[0],)\n",
+      "        A, B = self.A, self.B\n",
+      "        state = np.zeros(self.A.shape[0])\n",
+      "        \n",
+      "        def step(t, x):\n",
+      "            state[:] += dt * (np.dot(A, state) + np.dot(B, x))\n",
+      "            return state\n",
+      "        \n",
+      "        return step\n",
+      "    \n",
+      "# demonstrate the LTIProcess in action\n",
+      "A = [[-0.1, -1], [1, -0.1]]\n",
+      "B = [[10], [-10]]\n",
+      "\n",
+      "with nengo.Network() as model:\n",
+      "    u = nengo.Node(lambda t: 1 if t < 0.1 else 0)\n",
+      "    a = nengo.Node(LTIProcess(A, B))  # we don't need to specify size_in and size_out!\n",
+      "    nengo.Connection(u, a)\n",
+      "    a_p = nengo.Probe(a)\n",
+      "    \n",
+      "with nengo.Simulator(model) as sim:\n",
+      "    sim.run(20.0)\n",
+      "    \n",
+      "plt.plot(sim.trange(), sim.data[a_p])\n",
+      "plt.xlabel('time [s]');"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -16,6 +16,7 @@ from .version import version as __version__
 import logging
 
 # Nengo namespace (API)
+from .base import Process
 from .config import Config
 from .connection import Connection
 from .ensemble import Ensemble
@@ -28,7 +29,7 @@ from .params import Default
 from .probe import Probe
 from .rc import rc, RC_DEFAULTS
 from .simulator import Simulator
-from .synapses import Alpha, LinearFilter, Lowpass
+from .synapses import Alpha, LinearFilter, Lowpass, Triangle
 from .utils.logging import log
 from . import dists, exceptions, networks, processes, spa, utils
 

--- a/nengo/builder/processes.py
+++ b/nengo/builder/processes.py
@@ -6,7 +6,46 @@ from nengo.synapses import Synapse
 
 
 class SimProcess(Operator):
-    """Simulate a Process object."""
+    """Simulate a process.
+
+    Parameters
+    ----------
+    process : Process
+        The `.Process` to simulate.
+    input : Signal or None
+        Input to the process, or None if no input.
+    output : Signal or None
+        Output from the process, or None if no output.
+    t : Signal
+        The signal associated with the time (a float, in seconds).
+    mode : str, optional (Default: ``'set'``)
+        Denotes what type of update this operator performs.
+        Must be one of ``'update'``, ``'inc'`` or ``'set'``.
+    tag : str, optional (Default: None)
+        A label associated with the operator, for debugging purposes.
+
+    Attributes
+    ----------
+    input : Signal or None
+        Input to the process, or None if no input.
+    mode : str
+        Denotes what type of update this operator performs.
+    output : Signal or None
+        Output from the process, or None if no output.
+    process : Process
+        The `.Process` to simulate.
+    t : Signal
+        The signal associated with the time (a float, in seconds).
+    tag : str or None
+        A label associated with the operator, for debugging purposes.
+
+    Notes
+    -----
+    1. sets ``[output] if output is not None and mode=='set' else []``
+    2. incs ``[output] if output is not None and mode=='inc' else []``
+    3. reads ``[t, input] if input is not None else [t]``
+    4. updates ``[output] if output is not None and mode=='update' else []``
+    """
     def __init__(self, process, input, output, t, mode='set', tag=None):
         self.process = process
         self.input = input
@@ -55,12 +94,53 @@ class SimProcess(Operator):
 
 @Builder.register(Process)
 def build_process(model, process, sig_in=None, sig_out=None, inc=False):
+    """Builds a `.Process` object into a model.
+
+    Parameters
+    ----------
+    model : Model
+        The model to build into.
+    process : Process
+        Process to build.
+    sig_in : Signal, optional (Default: None)
+        The input signal, or None if no input signal.
+    sig_out : Signal, optional (Default: None)
+        The output signal, or None if no output signal.
+    inc : bool, optional (Default: False)
+        Whether `.SimProcess` should be made with
+        ``mode='inc'` (True) or ``mode='set'`` (False).
+
+    Notes
+    -----
+    Does not modify ``model.params[]`` and can therefore be called
+    more than once with the same `.Process` instance.
+    """
+
     model.add_op(SimProcess(
         process, sig_in, sig_out, model.time, mode='inc' if inc else 'set'))
 
 
 @Builder.register(Synapse)
 def build_synapse(model, synapse, sig_in, sig_out=None):
+    """Builds a `.Synapse` object into a model.
+
+    Parameters
+    ----------
+    model : Model
+        The model to build into.
+    synapse : Synapse
+        Synapse to build.
+    sig_in : Signal
+        The input signal.
+    sig_out : Signal, optional (Default: None)
+        The output signal. If None, a new output signal will be
+        created and returned.
+
+    Notes
+    -----
+    Does not modify ``model.params[]`` and can therefore be called
+    more than once with the same `.Synapse` instance.
+    """
     if sig_out is None:
         sig_out = Signal(
             np.zeros(sig_in.shape), name="%s.%s" % (sig_in.name, synapse))

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -13,15 +13,14 @@ class WhiteNoise(Process):
 
     Parameters
     ----------
-    dist : Distribution, optional
-        The distribution to draw samples from.
-        Default: Gaussian(mean=0, std=1)
-    scale : bool, optional
+    dist : Distribution, optional (Default: ``Gaussian(mean=0, std=1)``)
+        The distribution from which to draw samples.
+    scale : bool, optional (Default: True)
         Whether to scale the white noise for integration. Integrating white
-        noise requires using a time constant of `sqrt(dt)` instead of `dt`
+        noise requires using a time constant of ``sqrt(dt)`` instead of ``dt``
         on the noise term [1]_, to ensure the magnitude of the integrated
-        noise does not change with `dt`. Defaults to True.
-    seed : int, optional
+        noise does not change with ``dt``.
+    seed : int, optional (Default: None)
         Random number seed. Ensures noise will be the same each run.
 
     References
@@ -66,17 +65,16 @@ class FilteredNoise(Process):
 
     Parameters
     ----------
-    synapse : Synapse, optional
-        The synapse to use to filter the noise. Default: Lowpass(tau=0.005)
-    dist : Distribution, optional
+    synapse : Synapse, optional (Default: ``Lowpass(tau=0.005)``)
+        The synapse to use to filter the noise.
+    dist : Distribution, optional (Default: ``Gaussian(mean=0, std=1)``)
         The distribution used to generate the white noise.
-        Default: Gaussian(mean=0, std=1)
-    scale : bool, optional
+    scale : bool, optional (Default: True)
         Whether to scale the white noise for integration, making the output
-        signal invariant to `dt`. Defaults to True.
-    synapse_kwargs : dict, optional
-        Arguments to pass to `synapse.make_step`.
-    seed : int, optional
+        signal invariant to ``dt``.
+    synapse_kwargs : dict, optional (Default: None)
+        Arguments to pass to ``synapse.make_step``.
+    seed : int, optional (Default: None)
         Random number seed. Ensures noise will be the same each run.
     """
 
@@ -87,10 +85,10 @@ class FilteredNoise(Process):
 
     def __init__(self,
                  synapse=Lowpass(tau=0.005), dist=Gaussian(mean=0, std=1),
-                 scale=True, synapse_kwargs={}, **kwargs):
+                 scale=True, synapse_kwargs=None, **kwargs):
         super(FilteredNoise, self).__init__(default_size_in=0, **kwargs)
         self.synapse = synapse
-        self.synapse_kwargs = synapse_kwargs
+        self.synapse_kwargs = {} if synapse_kwargs is None else synapse_kwargs
         self.dist = dist
         self.scale = scale
 
@@ -124,10 +122,9 @@ class BrownNoise(FilteredNoise):
 
     Parameters
     ----------
-    dist : Distribution
+    dist : Distribution, optional (Default: ``Gaussian(mean=0, std=1)``)
         The distribution used to generate the white noise.
-        Default: Gaussian(mean=0, std=1)
-    seed : int, optional
+    seed : int, optional (Default: None)
         Random number seed. Ensures noise will be the same each run.
     """
 
@@ -156,13 +153,13 @@ class WhiteSignal(Process):
     period : float
         A white noise signal with this period will be generated.
         Samples will repeat after this duration.
-    high : float, optional
+    high : float
         The cut-off frequency of the low-pass filter, in Hz.
         Must not exceed the Nyquist frequency for the simulation
-        timestep, that is `high <= 0.5/dt`.
-    rms : float, optional
-        The root mean square power of the filtered signal. Default: 0.5.
-    seed : int, optional
+        timestep, which is ``0.5 / dt``.
+    rms : float, optional (Default: 0.5)
+        The root mean square power of the filtered signal
+    seed : int, optional (Default: None)
         Random number seed. Ensures noise will be the same each run.
     """
 
@@ -226,7 +223,7 @@ class PresentInput(Process):
     inputs : array_like
         Inputs to present, where each row is an input. Rows will be flattened.
     presentation_time : float
-        Show each input for `presentation_time` seconds.
+        Show each input for this amount of time (in seconds).
     """
 
     inputs = NdarrayParam('inputs', shape=('...',))

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -5,7 +5,7 @@ from nengo.base import Process
 from nengo.dists import DistributionParam, Gaussian
 from nengo.exceptions import ValidationError
 from nengo.params import BoolParam, DictParam, NdarrayParam, NumberParam
-from nengo.synapses import LinearFilter, LinearFilterParam, Lowpass
+from nengo.synapses import LinearFilter, Lowpass, SynapseParam
 
 
 class WhiteNoise(Process):
@@ -80,7 +80,7 @@ class FilteredNoise(Process):
         Random number seed. Ensures noise will be the same each run.
     """
 
-    synapse = LinearFilterParam('synapse')
+    synapse = SynapseParam('synapse')
     dist = DistributionParam('dist')
     scale = BoolParam('scale')
     synapse_kwargs = DictParam('synapse_kwargs')

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -498,11 +498,3 @@ class SynapseParam(Parameter):
             raise ValidationError("'%s' is not a synapse type" % synapse,
                                   attr=self.name, obj=instance)
         super(SynapseParam, self).validate(instance, synapse)
-
-
-class LinearFilterParam(SynapseParam):
-    def validate(self, instance, synapse):
-        if synapse is not None and not isinstance(synapse, LinearFilter):
-            raise ValidationError("'%s' is not a LinearFilter" % synapse,
-                                  attr=self.name, obj=instance)
-        super(SynapseParam, self).validate(instance, synapse)


### PR DESCRIPTION
This is another WIP PR to register that these things should be part of 2.1

Still to do in this PR:

- [x] Make an example notebook using processes
- [x] Make an example notebook making a new custom process
- [x] Add documentation for processes
  - [x] Make sure `SimProcess` is documented / added to API docs
- [x] Update the changelog to introduce processes and point to docs
- [x] Ensure everything from #622 and #723 is done