### PR TITLE
Use RefSimulator for tests using 'step'

### DIFF
--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -257,7 +257,7 @@ def test_fails_for_lambda_expression():
         Fingerprint(lambda x: x)
 
 
-def test_cache_works(tmpdir, Simulator, seed):
+def test_cache_works(tmpdir, RefSimulator, seed):
     cache_dir = str(tmpdir)
 
     model = nengo.Network(seed=seed)
@@ -265,7 +265,7 @@ def test_cache_works(tmpdir, Simulator, seed):
         nengo.Connection(nengo.Ensemble(10, 1), nengo.Ensemble(10, 1))
 
     assert len(os.listdir(cache_dir)) == 0
-    with Simulator(model, model=nengo.builder.Model(
+    with RefSimulator(model, model=nengo.builder.Model(
             dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
         assert len(os.listdir(cache_dir)) == 2  # legacy.txt and *.nco
 

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -205,6 +205,7 @@ def test_none(Simulator, seed):
 def test_unconnected_node(Simulator):
     """Make sure unconnected nodes still run."""
     hits = np.array(0)
+    dt = 0.001
 
     def f(t):
         hits[...] += 1
@@ -213,9 +214,9 @@ def test_unconnected_node(Simulator):
         nengo.Node(f, size_in=0, size_out=0)
     with Simulator(model) as sim:
         assert hits == 0
-        sim.step()
+        sim.run(dt)
         assert hits == 1
-        sim.step()
+        sim.run(dt)
         assert hits == 2
 
 

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -55,7 +55,7 @@ def test_probedict():
     assert np.all(probedict.get("list") == np.asarray(raw.get("list")))
 
 
-def test_close(Simulator):
+def test_close_function(Simulator):
     m = nengo.Network()
     with m:
         nengo.Ensemble(10, 1)
@@ -65,14 +65,10 @@ def test_close(Simulator):
     with pytest.raises(ValueError):
         sim.run(1.)
     with pytest.raises(ValueError):
-        sim.run_steps(1)
-    with pytest.raises(ValueError):
-        sim.step()
-    with pytest.raises(ValueError):
         sim.reset()
 
 
-def test_usage_in_with_statement(Simulator):
+def test_close_context(Simulator):
     m = nengo.Network()
     with m:
         nengo.Ensemble(10, 1)
@@ -83,8 +79,28 @@ def test_usage_in_with_statement(Simulator):
     with pytest.raises(ValueError):
         sim.run(1.)
     with pytest.raises(ValueError):
+        sim.reset()
+
+
+def test_close_steps(RefSimulator):
+    """For RefSimulator, closed simulators should fail for ``step``"""
+    m = nengo.Network()
+    with m:
+        nengo.Ensemble(10, 1)
+
+    # test close function
+    sim = RefSimulator(m)
+    sim.close()
+    with pytest.raises(ValueError):
         sim.run_steps(1)
     with pytest.raises(ValueError):
         sim.step()
+
+    # test close context
+    with RefSimulator(m) as sim:
+        sim.run(0.01)
+
     with pytest.raises(ValueError):
-        sim.reset()
+        sim.run_steps(1)
+    with pytest.raises(ValueError):
+        sim.step()


### PR DESCRIPTION
Simulator.step is used to run the reference backend, but we don't require a step method for all backends. Tests that use step, therefore, should use the RefSimulator fixture, or run for `dt` time.

Fixes #836 and #837.