### PR TITLE
Move label and seed to base NengoObject

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,9 @@ Release History
 - Most exceptions that Nengo can raise are now custom exception classes
   that can be found in the ``nengo.exceptions`` module.
   (`#781 <https://github.com/nengo/nengo/pull/781>`_)
+- All Nengo objects (``Connection``, ``Ensemble``, ``Node``, and ``Probe``)
+  now accept a ``label`` and ``seed`` argument if they didn't previously.
+  (`#958 <https://github.com/nengo/nengo/pull/859>`_)
 
 **Behavioural changes**
 

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import warnings
 
@@ -6,11 +5,10 @@ import numpy as np
 
 from nengo.config import Config
 from nengo.exceptions import ValidationError
-from nengo.params import Default, is_param, Parameter, Unconfigurable
+from nengo.params import (
+    Default, is_param, IntParam, Parameter, StringParam, Unconfigurable)
 from nengo.rc import rc
 from nengo.utils.compat import is_integer, reraise, with_metaclass
-
-logger = logging.getLogger(__name__)
 
 
 class NetworkMember(type):
@@ -41,6 +39,13 @@ class NengoObject(with_metaclass(NetworkMember)):
     for correct operation. In particular, list membership
     and object comparison require each object to have a unique ID.
     """
+
+    label = StringParam('label', default=None, optional=True)
+    seed = IntParam('seed', default=None, optional=True)
+
+    def __init__(self, label, seed):
+        self.label = label
+        self.seed = seed
 
     def _str(self, include_id):
         return "<%s%s%s>" % (

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -9,9 +9,8 @@ from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import ValidationError
 from nengo.learning_rules import LearningRuleType, LearningRuleTypeParam
 from nengo.node import Node
-from nengo.params import (
-    Default, Unconfigurable, ObsoleteParam, BoolParam, FunctionParam,
-    IntParam, NdarrayParam)
+from nengo.params import (Default, Unconfigurable, ObsoleteParam,
+                          BoolParam, FunctionParam, NdarrayParam)
 from nengo.solvers import LstsqL2, SolverParam
 from nengo.synapses import Lowpass, SynapseParam
 from nengo.utils.compat import is_iterable, iteritems
@@ -288,16 +287,15 @@ class Connection(NengoObject):
     synapse = SynapseParam('synapse', default=Lowpass(0.005))
     transform = TransformParam('transform', default=np.array(1.0))
     solver = ConnectionSolverParam('solver', default=LstsqL2())
-    function_info = ConnectionFunctionParam(
-        'function', default=None, optional=True)
     learning_rule_type = ConnectionLearningRuleTypeParam(
         'learning_rule_type', default=None, optional=True)
+    function_info = ConnectionFunctionParam(
+        'function', default=None, optional=True)
     eval_points = EvalPointsParam('eval_points',
                                   default=None,
                                   optional=True,
                                   sample_shape=('*', 'size_in'))
     scale_eval_points = BoolParam('scale_eval_points', default=True)
-    seed = IntParam('seed', default=None, optional=True)
     modulatory = ObsoleteParam(
         'modulatory',
         "Modulatory connections have been removed. "
@@ -307,8 +305,10 @@ class Connection(NengoObject):
 
     def __init__(self, pre, post, synapse=Default, transform=Default,
                  solver=Default, learning_rule_type=Default, function=Default,
-                 eval_points=Default, scale_eval_points=Default, seed=Default,
-                 modulatory=Unconfigurable):
+                 eval_points=Default, scale_eval_points=Default,
+                 label=Default, seed=Default, modulatory=Unconfigurable):
+        super(Connection, self).__init__(label=label, seed=seed)
+
         self.pre = pre
         self.post = post
 
@@ -319,7 +319,6 @@ class Connection(NengoObject):
         self.function_info = function  # Must be set after transform
         self.solver = solver  # Must be set before learning rule
         self.learning_rule_type = learning_rule_type  # set after transform
-        self.seed = seed
         self.modulatory = modulatory
 
     @property
@@ -371,17 +370,20 @@ class Connection(NengoObject):
         return self.post.size_in
 
     @property
-    def _label(self):
+    def _str(self):
+        if self.label is not None:
+            return self.label
+
         return "from %s to %s%s" % (
             self.pre, self.post,
             " computing '%s'" % self.function.__name__
             if self.function is not None else "")
 
     def __str__(self):
-        return "<Connection %s>" % self._label
+        return "<Connection %s>" % self._str
 
     def __repr__(self):
-        return "<Connection at 0x%x %s>" % (id(self), self._label)
+        return "<Connection at 0x%x %s>" % (id(self), self._str)
 
     @property
     def learning_rule(self):

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -4,8 +4,7 @@ from nengo.base import NengoObject, ObjView
 from nengo.dists import DistOrArrayParam, Uniform, UniformHypersphere
 from nengo.exceptions import ReadonlyError
 from nengo.neurons import LIF, NeuronTypeParam, Direct
-from nengo.params import (
-    Default, IntParam, NumberParam, StringParam)
+from nengo.params import Default, IntParam, NumberParam
 from nengo.processes import ProcessParam
 
 
@@ -79,28 +78,24 @@ class Ensemble(NengoObject):
                             optional=True,
                             sample_shape=('n_neurons',))
     noise = ProcessParam('noise', default=None, optional=True)
-    seed = IntParam('seed', default=None, optional=True)
-    label = StringParam('label', default=None, optional=True)
 
     def __init__(self, n_neurons, dimensions, radius=Default, encoders=Default,
                  intercepts=Default, max_rates=Default, eval_points=Default,
                  n_eval_points=Default, neuron_type=Default, gain=Default,
-                 bias=Default, noise=Default, seed=Default, label=Default):
-
+                 bias=Default, noise=Default, label=Default, seed=Default):
+        super(Ensemble, self).__init__(label=label, seed=seed)
         self.n_neurons = n_neurons
         self.dimensions = dimensions
         self.radius = radius
         self.encoders = encoders
         self.intercepts = intercepts
         self.max_rates = max_rates
-        self.label = label
         self.n_eval_points = n_eval_points
         self.eval_points = eval_points
         self.bias = bias
         self.gain = gain
         self.neuron_type = neuron_type
         self.noise = noise
-        self.seed = seed
         self._neurons = Neurons(self)
 
     def __getitem__(self, key):

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -5,7 +5,7 @@ import numpy as np
 import nengo.utils.numpy as npext
 from nengo.base import NengoObject, ObjView
 from nengo.exceptions import ValidationError
-from nengo.params import Default, IntParam, Parameter, StringParam
+from nengo.params import Default, IntParam, Parameter
 from nengo.processes import Process
 from nengo.utils.compat import is_array_like
 from nengo.utils.stdlib import checked_call
@@ -131,13 +131,16 @@ class Node(NengoObject):
     output = OutputParam('output', default=None)
     size_in = IntParam('size_in', default=None, low=0, optional=True)
     size_out = IntParam('silze_out', default=None, low=0, optional=True)
-    label = StringParam('label', default=None, optional=True)
 
-    def __init__(self, output=Default,
-                 size_in=Default, size_out=Default, label=Default):
+    def __init__(self, output=Default, size_in=Default, size_out=Default,
+                 label=Default, seed=Default):
+        if not (seed is Default or seed is None):
+            raise NotImplementedError(
+                "Changing the seed of a node has no effect")
+        super(Node, self).__init__(label=label, seed=seed)
+
         self.size_in = size_in
         self.size_out = size_out
-        self.label = label
         self.output = output  # Must be set after size_out; may modify size_out
 
     def __getitem__(self, key):

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -2,8 +2,7 @@ from nengo.base import NengoObject, NengoObjectParam, ObjView
 from nengo.config import Config
 from nengo.connection import Connection, LearningRule
 from nengo.exceptions import ObsoleteError, ValidationError
-from nengo.params import (
-    Default, ConnectionDefault, IntParam, NumberParam, StringParam)
+from nengo.params import Default, ConnectionDefault, NumberParam, StringParam
 from nengo.solvers import SolverParam
 from nengo.synapses import SynapseParam
 
@@ -93,18 +92,15 @@ class Probe(NengoObject):
         'sample_ever', default=None, optional=True, low=1e-10)
     synapse = SynapseParam('synapse', default=None)
     solver = ProbeSolverParam('solver', default=ConnectionDefault)
-    seed = IntParam('seed', default=None, optional=True)
-    label = StringParam('label', default=None, optional=True)
 
     def __init__(self, target, attr=None, sample_every=Default,
-                 synapse=Default, solver=Default, seed=Default, label=Default):
+                 synapse=Default, solver=Default, label=Default, seed=Default):
+        super(Probe, self).__init__(label=label, seed=seed)
         self.target = target
         self.attr = attr if attr is not None else self.obj.probeable[0]
         self.sample_every = sample_every
         self.synapse = synapse
         self.solver = solver
-        self.seed = seed
-        self.label = label
 
     @property
     def obj(self):

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -339,3 +339,10 @@ def test_wrong_output():
 
         with pytest.raises(ValueError):
             nengo.Node(node1)
+
+
+def test_seed_error():
+    """Setting a Node seed is currently not implemented."""
+    with nengo.Network():
+        with pytest.raises(NotImplementedError):
+            nengo.Node(seed=1)


### PR DESCRIPTION
While making the docstring changes in #851, this seemed like a natural thing to do, so I made it its own PR as it should be considered in more depth than documentation changes.

Moving the label and seed to the base NengoObject simplifies the subclass code a little bit, and makes their interfaces more obvious and consistent. This adds a label to `Connection` and a seed to `Node`; the node seed doesn't do anything right now (I think?) but we could later on hook it up to the process if the node has a process.

I made the ordering of label and seed consistent -- label first, then seed, but could switch it around if there are arguments for having label last.