### PR TITLE
Make human2bytes robust to no space before unit.

### DIFF
--- a/nengo/utils/cache.py
+++ b/nengo/utils/cache.py
@@ -39,8 +39,10 @@ def human2bytes(s):
     1073741824
     """
     symbols = ('B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB')
-    letter = s[-2:].strip().upper()
-    num = s[:-2].strip()
+
+    ix = -1 if s[-2].isdigit() else -2
+    letter = s[ix:].strip().upper()
+    num = s[:ix].strip()
     assert letter in symbols
     num = float(num)
     prefix = {symbols[0]: 1}

--- a/nengo/utils/tests/test_cache.py
+++ b/nengo/utils/tests/test_cache.py
@@ -11,6 +11,8 @@ def test_human2bytes():
     assert human2bytes('1 MB') == 1048576
     assert human2bytes('1.5 GB') == 1610612736
     assert human2bytes('14 B') == 14
+    assert human2bytes('1B') == 1
+    assert human2bytes('1   B') == 1
 
 
 def test_byte_align():


### PR DESCRIPTION
Previously, `human2bytes` assumed that there was a space between the digit string and the unit. It now allows there to be no space between the two. `bytes2human` remains unchanged, and will return a string with a single space between the digit string and the unit.

Fixes #950.