### PR TITLE
Close open simulators at exit

### DIFF
--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -2,8 +2,9 @@
 
 from __future__ import print_function
 
-from collections import Mapping
 import logging
+import warnings
+from collections import Mapping
 
 import numpy as np
 
@@ -12,7 +13,7 @@ from nengo.builder import Model
 from nengo.builder.signal import SignalDict
 from nengo.cache import get_default_decoder_cache
 from nengo.exceptions import ReadonlyError, SimulatorClosed
-from nengo.utils.compat import range
+from nengo.utils.compat import range, ResourceWarning
 from nengo.utils.graphs import toposort
 from nengo.utils.progress import ProgressTracker
 from nengo.utils.simulator import operator_depencency_graph
@@ -135,6 +136,14 @@ class Simulator(object):
 
         seed = np.random.randint(npext.maxint) if seed is None else seed
         self.reset(seed=seed)
+
+    def __del__(self):
+        """Raise a ResourceWarning if we are deallocated while open."""
+        if not self.closed:
+            warnings.warn(
+                "Simulator with model=%s was deallocated while open. Please "
+                "close simulators manually to ensure resources are properly "
+                "freed." % self.model, ResourceWarning)
 
     def __enter__(self):
         return self

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -1,9 +1,13 @@
+import gc
+
 import numpy as np
 import pytest
 
 import nengo
 import nengo.simulator
 from nengo.exceptions import SimulatorClosed
+from nengo.utils.compat import ResourceWarning
+from nengo.utils.testing import warns
 
 
 def test_steps(RefSimulator):
@@ -99,3 +103,15 @@ def test_close_steps(RefSimulator):
         sim.run_steps(1)
     with pytest.raises(SimulatorClosed):
         sim.step()
+
+
+def test_warn_on_opensim_gc(Simulator):
+    with nengo.Network() as net:
+        nengo.Ensemble(10, 1)
+
+    sim = Simulator(net)
+    assert sim
+
+    with warns(ResourceWarning):
+        sim = None
+        gc.collect()

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -38,6 +38,17 @@ if PY2:
                                'replace')
             StringIO.write(self, data)
 
+    class ResourceWarning(DeprecationWarning):
+        """A warning about resource usage.
+
+        Note that we subclass from DeprecationWarning here solely because
+        DeprecationWarnings are filtered out by default in Python 2.7,
+        while in Python 3.2+ both DeprecationWarnings and ResourceWarnings
+        are filtered out. Subclassing from DeprecationWarning gives
+        the same (or at least very similar) behavior in Python 2 and 3
+        without having to modify filters in the warnings module.
+        """
+
 else:
     import pickle
     import configparser
@@ -46,6 +57,7 @@ else:
     string_types = (str,)
     int_types = (int,)
     range = range
+    ResourceWarning = ResourceWarning
 
     # No iterkeys; use ``for key in dict:`` instead
     iteritems = lambda d: iter(d.items())


### PR DESCRIPTION
Right now, this raises a warning when a simulator is closed at exit so that users will learn to close open simulators manually.

This was broken out from #932 into a separate PR as it is somewhat controversial whether we should raise a warning. #932 should be merged before this PR.

In the meantime, I would appreciate if people could vote as to whether they support raising a warning or not. I think everything else is pretty much agreed upon.

I am +1 on raising a warning.