### PR TITLE
Added signals for simulator time and step

### DIFF
--- a/examples/usage/strings.ipynb
+++ b/examples/usage/strings.ipynb
@@ -275,8 +275,8 @@
       "print(nengo.builder.learning_rules.SimOja(sig, sig, sig, sig, 0.1, 1.0, tag=\"tag\"))\n",
       "print(nengo.builder.neurons.SimNeurons(nengo.LIF(), sig, sig, [sig]))\n",
       "print(nengo.builder.neurons.SimNeurons(nengo.LIF(), sig, sig, [sig], tag=\"tag\"))\n",
-      "print(nengo.builder.processes.SimProcess(nengo.processes.Process(), sig, sig))\n",
-      "print(nengo.builder.processes.SimProcess(nengo.processes.Process(), sig, sig, tag=\"tag\"))\n",
+      "print(nengo.builder.processes.SimProcess(nengo.processes.Process(), sig, sig, sig))\n",
+      "print(nengo.builder.processes.SimProcess(nengo.processes.Process(), sig, sig, sig, tag=\"tag\"))\n",
       "print(nengo.builder.synapses.SimSynapse(sig, sig, nengo.Lowpass(0.005)))\n",
       "print(nengo.builder.synapses.SimSynapse(sig, sig, nengo.Lowpass(0.005), tag=\"tag\"))"
      ],

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -4,6 +4,7 @@ import warnings
 import numpy as np
 
 from nengo.builder.signal import Signal, SignalDict
+from nengo.builder.operator import TimeUpdate
 from nengo.cache import NoDecoderCache
 from nengo.exceptions import BuildError
 
@@ -31,6 +32,10 @@ class Model(object):
         self.sig['common'][0] = Signal(0., readonly=True, name='ZERO')
         self.sig['common'][1] = Signal(1., readonly=True, name='ONE')
 
+        self.step = Signal(np.array(0, dtype=np.int64), name='step')
+        self.time = Signal(np.array(0, dtype=np.float64), name='time')
+        self.add_op(TimeUpdate(self.step, self.time))
+
     def __str__(self):
         return "Model: %s" % self.label
 
@@ -40,7 +45,7 @@ class Model(object):
     def add_op(self, op):
         self.operators.append(op)
         # Fail fast by trying make_step with a temporary sigdict
-        signals = SignalDict(__time__=np.asarray(0.0, dtype=np.float64))
+        signals = SignalDict()
         op.init_signals(signals)
         op.make_step(signals, self.dt, np.random)
 

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -176,8 +176,7 @@ def build_connection(model, conn):
         if conn.function is not None:
             in_signal = Signal(np.zeros(conn.size_mid), name='%s.func' % conn)
             model.add_op(SimPyFunc(
-                output=in_signal, fn=conn.function,
-                t_in=False, x=sliced_in))
+                output=in_signal, fn=conn.function, t=None, x=sliced_in))
         else:
             in_signal = sliced_in
 

--- a/nengo/builder/node.py
+++ b/nengo/builder/node.py
@@ -28,7 +28,7 @@ def build_node(model, node):
         sig_out = (Signal(np.zeros(node.size_out), name="%s.out" % node)
                    if node.size_out > 0 else None)
         model.add_op(SimPyFunc(
-            output=sig_out, fn=node.output, t_in=True, x=sig_in))
+            output=sig_out, fn=node.output, t=model.time, x=sig_in))
     elif is_array_like(node.output):
         sig_out = Signal(node.output, name="%s.out" % node)
     else:

--- a/nengo/builder/processes.py
+++ b/nengo/builder/processes.py
@@ -5,10 +5,11 @@ from nengo.processes import Process
 
 class SimProcess(Operator):
     """Simulate a Process object."""
-    def __init__(self, process, input, output, inc=False, tag=None):
+    def __init__(self, process, input, output, t, inc=False, tag=None):
         self.process = process
         self.input = input
         self.output = output
+        self.t = t
         self.inc = inc
         self.tag = tag
 
@@ -18,7 +19,7 @@ class SimProcess(Operator):
         else:
             self.sets = [output] if output is not None else []
             self.incs = []
-        self.reads = [input] if input is not None else []
+        self.reads = [t, input] if input is not None else [t]
         self.updates = []
 
     def __str__(self):
@@ -26,7 +27,7 @@ class SimProcess(Operator):
             self.process, self.input, self.output, self._tagstr)
 
     def make_step(self, signals, dt, rng):
-        t = signals['__time__']
+        t = signals[self.t]
         input = signals[self.input] if self.input is not None else None
         output = signals[self.output] if self.output is not None else None
         size_in = input.size if input is not None else 0
@@ -49,4 +50,4 @@ class SimProcess(Operator):
 
 @Builder.register(Process)
 def build_process(model, process, sig_in=None, sig_out=None, inc=False):
-    model.add_op(SimProcess(process, sig_in, sig_out, inc=inc))
+    model.add_op(SimProcess(process, sig_in, sig_out, model.time, inc=inc))

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -7,23 +7,17 @@ from nengo.exceptions import SimulatorClosed
 
 
 def test_steps(RefSimulator):
+    dt = 0.001
     m = nengo.Network(label="test_steps")
-    with RefSimulator(m) as sim:
+    with RefSimulator(m, dt=dt) as sim:
         assert sim.n_steps == 0
+        assert np.allclose(sim.time, 0 * dt)
         sim.step()
         assert sim.n_steps == 1
+        assert np.allclose(sim.time, 1 * dt)
         sim.step()
         assert sim.n_steps == 2
-
-
-def test_time_steps(RefSimulator):
-    m = nengo.Network(label="test_time_steps")
-    with RefSimulator(m) as sim:
-        assert np.allclose(sim.signals["__time__"], 0.00)
-        sim.step()
-        assert np.allclose(sim.signals["__time__"], 0.001)
-        sim.step()
-        assert np.allclose(sim.signals["__time__"], 0.002)
+        assert np.allclose(sim.time, 2 * dt)
 
 
 def test_time_absolute(Simulator):


### PR DESCRIPTION
This makes things like resetting the simulator cleaner, since
time and step are no longer treated specially.

Sorry for the late addition to 2.1, but this will make some stuff in Nengo OCL easier. If it's contentious, it's not imperative.