### PR TITLE
Return self in `Config.__enter__`

### DIFF
--- a/nengo/config.py
+++ b/nengo/config.py
@@ -291,6 +291,7 @@ class Config(object):
 
     def __enter__(self):
         Config.context.append(self)
+        return self
 
     def __exit__(self, dummy_exc_type, dummy_exc_value, dummy_tb):
         if len(Config.context) == 0:

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -115,14 +115,13 @@ def test_defaults():
 
 def test_configstack():
     """Test that setting defaults with bare configs works."""
-    inhib = nengo.Config(nengo.Connection)
-    inhib[nengo.Connection].synapse = nengo.synapses.Lowpass(0.00848)
     with nengo.Network() as net:
         net.config[nengo.Connection].transform = -1
         e1 = nengo.Ensemble(5, dimensions=1)
         e2 = nengo.Ensemble(6, dimensions=1)
         excite = nengo.Connection(e1, e2)
-        with inhib:
+        with nengo.Config(nengo.Connection) as inhib:
+            inhib[nengo.Connection].synapse = nengo.synapses.Lowpass(0.00848)
             inhibit = nengo.Connection(e1, e2)
     assert excite.synapse == nengo.Connection.synapse.default
     assert excite.transform == -1


### PR DESCRIPTION
This is needed so that `with nengo.Config() as x:` works properly.