### PR TITLE
PerfectLIF model with improved performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,14 @@ Release History
 2.1.1 (unreleased)
 ==================
 
+**Improvements**
+
+- Improved the default ``LIF`` neuron model to spike at the same rate as the
+  ``LIFRate`` neuron model for constant inputs. The older model has been
+  moved to `nengo_extras <https://github.com/nengo/nengo_extras>`_
+  under the name ``FastLIF``.
+  (`#975 <https://github.com/nengo/nengo/pull/975>`_)
+
 **Bug fixes**
 
 - The DecoderCache is used as context manager instead of relying on the

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -36,9 +36,9 @@ def test_lif_builtin(rng):
     assert np.allclose(sim_rates, math_rates, atol=1, rtol=0.02)
 
 
-def test_lif(Simulator, plt, rng, logger):
-    """Test that the dynamic model approximately matches the rates"""
-    dt = 0.001
+@pytest.mark.parametrize('dt', (0.001, 0.002))
+def test_lif(Simulator, plt, rng, logger, dt):
+    """Test that the dynamic model approximately matches the rates."""
     n = 5000
     x = 0.5
     encoders = np.ones((n, 1))
@@ -51,7 +51,8 @@ def test_lif(Simulator, plt, rng, logger):
         ens = nengo.Ensemble(
             n, dimensions=1, neuron_type=nengo.LIF(),
             encoders=encoders, max_rates=max_rates, intercepts=intercepts)
-        nengo.Connection(ins, ens.neurons, transform=np.ones((n, 1)))
+        nengo.Connection(
+            ins, ens.neurons, transform=np.ones((n, 1)), synapse=None)
         spike_probe = nengo.Probe(ens.neurons)
         voltage_probe = nengo.Probe(ens.neurons, 'voltage')
         ref_probe = nengo.Probe(ens.neurons, 'refractory_time')
@@ -84,6 +85,11 @@ def test_lif(Simulator, plt, rng, logger):
     # if voltage and ref time are non-constant, the probe is doing something
     assert np.abs(np.diff(sim.data[voltage_probe])).sum() > 1
     assert np.abs(np.diff(sim.data[ref_probe])).sum() > 1
+
+    # compute spike counts after each timestep
+    actual_counts = (spikes > 0).cumsum(axis=0)
+    expected_counts = np.outer(sim.trange(), math_rates)
+    assert (abs(actual_counts - expected_counts) < 1).all()
 
 
 @pytest.mark.parametrize('min_voltage', [-np.inf, -1, 0])


### PR DESCRIPTION
This is in some ways a natural continuation of #511 (@hunse).

In the above PR, the given math works off the assumption that the input current `J` is piece-wise constant over each time-step. From this, we can use the discretized lowpass filter with time-constant `tau_rc` to compute the exact voltage update at `t = dt`:

`v(t) = v(0) + (J - v(0)) * (1 - exp(-t/tau))`

But why stop there? As suggested in #511, the way we currently compute overshoot uses a linear interpolation scheme, whereas the previous equation can be used to solve for the exact amount of overshoot (by substituting `v(0) = 1` and rearranging for `t`).

But to make this work well, we must also deal with another issue: we currently handle partially remaining refractory periods by multiplicatively scaling the voltage, which is yet again a linear approximation. Instead, we can apply the same trick and substitute the amount of leftover time as `t` into the first equation (basically using a different time-step per neuron).

**This makes the neuron model's spike rate invariant to `dt`**, under the assumptions that `dt <= tau_ref` and the input is constant across each time-step (aside: we can in fact relax the first assumption with `O(1)` additional processing, although the approach becomes more complicated). We can thus think of it as a _perfect_ discretization for digital hardware. By 'perfect', I mean the spike count differs from the expected count by `< 1` at all times.

[Some testing](https://github.com/arvoelke/nengolib/blob/244557f0d5a13c02f76422614c1465b7bc9f989a/nengolib/tests/test_neurons.py) reveals that this reduces the `rmse(true_rates * T, sum_spikes)` versus the current `LIF` by as much as **90%** after `T = 2` seconds of simulation! This is because the current model will consistently spike slightly faster or slightly slower to accumulate `O(t)` error (see _Efficient and Accurate Time-Stepping Schemes for Integrate-and-Fire Neuronal Networks_, JCNS 2001).

This improvement was discovered while identifying a somewhat serious problem with drift during integration (thanks to Wilten Nicola). Any small errors from maintaining the `refractory_period` will add up over time, causing systematic drift in one direction.

![integrator_drift](https://cloud.githubusercontent.com/assets/5420057/13482233/a5142c66-e0b9-11e5-926b-a547c5e076be.png)

The improved neuron model reduces drift almost to zero, and this same qualitative result occurs over a wide range of seeds. So the main idea here is that this gives us the ability to run simulations at a higher time-step without sacrificing performance (normally you need to drop `dt` to see the same reduction in drift).

But, one drawback that I am aware of is this model can slow down the network by a non-negligible amount. Some tests on my machine with an integrator of `1000` neurons gave a slowdown of ~20%. I think this is due to the `expm1` and `log1p` being applied to arrays. :frowning:

If you are eager to see if this improves any of your models, as an interim solution you can make this the default neuron model by installing [NengoLib](https://github.com/arvoelke/nengolib/) and replacing `nengo.Network()` with `nengolib.Network()`.