### PR TITLE
Compatibility for nengo_lasagne

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,10 @@ Release History
   synapse type now has ``filt`` and ``filtfilt`` methods that filter
   using the synapse.
   (`#945 <https://github.com/nengo/nengo/pull/945>`_)
+- ``Connection`` objects can now accept a ``Distribution`` for the transform
+  argument; the transform matrix will be sampled from that distribution
+  when the model is built.
+  (`#979 <https://github.com/nengo/nengo/pull/979>`_).
 
 **Behavioural changes**
 

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -18,7 +18,7 @@ from nengo.utils.compat import is_iterable, itervalues
 
 
 BuiltConnection_ = collections.namedtuple(
-    'BuiltConnection', ['eval_points', 'solver_info', 'weights'])
+    'BuiltConnection', ['eval_points', 'solver_info', 'weights', 'transform'])
 
 
 class BuiltConnection(BuiltConnection_):
@@ -26,12 +26,6 @@ class BuiltConnection(BuiltConnection_):
     @property
     def decoders(self):
         raise ObsoleteError("decoders are now part of 'weights'. "
-                            "Access BuiltConnection.weights instead.",
-                            since="v2.1.0")
-
-    @property
-    def transform(self):
-        raise ObsoleteError("transform is now part of 'weights'. "
                             "Access BuiltConnection.weights instead.",
                             since="v2.1.0")
 
@@ -248,4 +242,5 @@ def build_connection(model, conn):
 
     model.params[conn] = BuiltConnection(eval_points=eval_points,
                                          solver_info=solver_info,
+                                         transform=transform,
                                          weights=weights)

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -278,5 +278,3 @@ def test_obsolete_params(RefSimulator):
         pass
     with pytest.raises(ObsoleteError):
         sim.data[c].decoders
-    with pytest.raises(ObsoleteError):
-        sim.data[c].transform


### PR DESCRIPTION
Some changes I made for compatibility with the `nengo_lasagne` back end.

The first commit just separates out the code for computing gains and biases into its own function (so that I can reuse that code in `nengo_lasagne`).  Doesn't change anything in reference Nengo.

The second commit is more significant, it adds the option to pass a Distribution for the transform parameter.  This isn't a necessary feature (you could always just manually sample a correctly sized matrix from the desired distribution, and pass that instead), but it is useful (and has been desired in other cases as well #639/#942).

I would say that this is a post-2.1 change, unless someone feels strongly about having `nengo_lasagne` be compatible with 2.1.