### PR TITLE
Provide SP expressions as keys to the SPA associative memory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ Release History
 - Added ``y0`` attribute to ``WhiteSignal``, which adjusts the phase of each
   dimension to begin with absolute value closest to ``y0``.
   (`#1064 <https://github.com/nengo/nengo/pull/1064>`_)
+- Allow the `AssociativeMemory` to accept Semantic Pointer expressions as
+  `input_keys` and `output_keys`.
+  (`#982 <https://github.com/nengo/nengo/pull/982>`_)
 
 **Bug fixes**
 

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -60,7 +60,9 @@ class AssociativeMemory(Module):
             input_keys = input_vocab.keys
             input_vectors = input_vocab.vectors
         else:
-            input_vectors = input_vocab.create_subset(input_keys).vectors
+            # parse keys (allows expressions as keys)
+            input_vectors = [input_vocab.parse(key).v for key in
+                             input_keys]
 
         # If output vocabulary is not specified, use input vocabulary
         # (i.e autoassociative memory)
@@ -70,7 +72,10 @@ class AssociativeMemory(Module):
         else:
             if output_keys is None:
                 output_keys = input_keys
-            output_vectors = output_vocab.create_subset(output_keys).vectors
+
+            # parse keys (allows expressions as keys)
+            output_vectors = [output_vocab.parse(key).v for key in
+                              output_keys]
 
         if default_output_key is None:
             default_output_vector = None

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -60,9 +60,7 @@ class AssociativeMemory(Module):
             input_keys = input_vocab.keys
             input_vectors = input_vocab.vectors
         else:
-            # parse keys (allows expressions as keys)
-            input_vectors = [input_vocab.parse(key).v for key in
-                             input_keys]
+            input_vectors = [input_vocab.parse(key).v for key in input_keys]
 
         # If output vocabulary is not specified, use input vocabulary
         # (i.e autoassociative memory)
@@ -73,9 +71,7 @@ class AssociativeMemory(Module):
             if output_keys is None:
                 output_keys = input_keys
 
-            # parse keys (allows expressions as keys)
-            output_vectors = [output_vocab.parse(key).v for key in
-                              output_keys]
+            output_vectors = [output_vocab.parse(key).v for key in output_keys]
 
         if default_output_key is None:
             default_output_vector = None

--- a/nengo/spa/tests/test_assoc_mem.py
+++ b/nengo/spa/tests/test_assoc_mem.py
@@ -1,5 +1,7 @@
 import nengo
-from nengo.spa import Vocabulary
+import numpy as np
+from nengo.spa import Vocabulary, Input
+from nengo.spa.utils import similarity
 from nengo.spa.assoc_mem import AssociativeMemory
 
 
@@ -35,3 +37,60 @@ def test_am_spa_interaction(Simulator, seed, rng):
     # Check to see if model builds properly. No functionality test needed
     with Simulator(m):
         pass
+
+
+def test_am_spa_keys_as_expressions(Simulator, plt, seed, rng):
+    """Provide semantic pointer expressions as input and output keys."""
+    D = 64
+
+    vocab_in = Vocabulary(D, rng=rng)
+    vocab_out = Vocabulary(D, rng=rng)
+
+    vocab_in.parse('A+B')
+    vocab_out.parse('C+D')
+
+    in_keys = ['A', 'A*B']
+    out_keys = ['C*D', 'C+D']
+
+    with nengo.spa.SPA(seed=seed) as model:
+        model.am = AssociativeMemory(input_vocab=vocab_in,
+                                     output_vocab=vocab_out,
+                                     input_keys=in_keys,
+                                     output_keys=out_keys)
+
+        model.inp = Input(am=lambda t: 'A' if t < 0.1 else 'A*B')
+
+        in_p = nengo.Probe(model.am.input)
+        out_p = nengo.Probe(model.am.output, synapse=0.03)
+
+    with nengo.Simulator(model) as sim:
+        sim.run(0.2)
+
+    # Specify t ranges
+    t = sim.trange()
+    t_item1 = (t > 0.075) & (t < 0.1)
+    t_item2 = (t > 0.175) & (t < 0.2)
+
+    # Modify vocabularies (for plotting purposes)
+    vocab_in.add(in_keys[1], vocab_in.parse(in_keys[1]).v)
+    vocab_out.add(out_keys[0], vocab_out.parse(out_keys[0]).v)
+
+    plt.subplot(2, 1, 1)
+    plt.plot(t, similarity(sim.data[in_p], vocab_in))
+    plt.ylabel("Input: " + ', '.join(in_keys))
+    plt.legend(vocab_in.keys, loc='best')
+    plt.ylim(top=1.1)
+    plt.subplot(2, 1, 2)
+    plt.plot(t, similarity(sim.data[out_p], vocab_out))
+    plt.plot(t[t_item1], np.ones(t.shape)[t_item1] * 0.9, c='r', lw=2)
+    plt.plot(t[t_item2], np.ones(t.shape)[t_item2] * 0.91, c='g', lw=2)
+    plt.plot(t[t_item2], np.ones(t.shape)[t_item2] * 0.89, c='b', lw=2)
+    plt.ylabel("Output: " + ', '.join(out_keys))
+    plt.legend(vocab_out.keys, loc='best')
+
+    assert np.mean(similarity(sim.data[out_p][t_item1],
+                              vocab_out.parse(out_keys[0]).v,
+                              normalize=True)) > 0.9
+    assert np.mean(similarity(sim.data[out_p][t_item2],
+                              vocab_out.parse(out_keys[1]).v,
+                              normalize=True)) > 0.9


### PR DESCRIPTION
I needed this scenario for my model, so I decided to submit a PR in case it might be of interest for others. Currently, only single keys can be passed as the input and output keys to the associative memory module. This PR slightly changes the existing code so that it also supports expressions in both input or output keys. Then something like this can be done:

```python
import nengo
from nengo import spa

with spa.SPA() as model:
    D = 16
    
    voc1 = spa.Vocabulary(D)
    voc2 = spa.Vocabulary(D)
    
    voc1.parse('A+B+C')
    voc2.parse('D+E+F')
    
    in_keys = ['A', 'B+C']
    out_keys = ['D-E', '0.4*F']
    
    model.am = spa.AssociativeMemory(input_vocab=voc1,
                                     output_vocab=voc2,
                                     input_keys=in_keys,
                                     output_keys=out_keys
                                    )
    model.inp = spa.State(D, vocab=voc1)
    nengo.Connection(model.inp.output, model.am.input)
```