### PR TITLE
Reset RC before every test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ install:
 
 # Run the tests
 script:
-  - "echo 'backend : Agg' > matplotlibrc"
   - if [[ -n $SETUP_CMD ]]; then
       python -c "import numpy; numpy.show_config()"
       python setup.py -q install;

--- a/examples/usage/exceptions.ipynb
+++ b/examples/usage/exceptions.ipynb
@@ -47,7 +47,6 @@
       "import traceback\n",
       "import nengo\n",
       "import nengo.spa\n",
-      "from nengo.rc import RC_DEFAULTS\n",
       "%load_ext nengo.ipynb\n",
       "\n",
       "def print_exc(func):\n",
@@ -77,8 +76,7 @@
       "    with nengo.Network():\n",
       "        ens = nengo.Ensemble(n_neurons=0, dimensions=1)\n",
       "nengo.rc.set('exceptions', 'simplified', str(True))\n",
-      "print_exc(nengo_obj)\n",
-      "nengo.rc.set('exceptions', 'simplified', str(RC_DEFAULTS['exceptions']['simplified']))"
+      "print_exc(nengo_obj)"
      ],
      "language": "python",
      "metadata": {},
@@ -101,8 +99,7 @@
       "    with nengo.Network():\n",
       "        ens = nengo.Ensemble(n_neurons=0, dimensions=1)\n",
       "nengo.rc.set('exceptions', 'simplified', str(False))\n",
-      "print_exc(nengo_obj)\n",
-      "nengo.rc.set('exceptions', 'simplified', str(RC_DEFAULTS['exceptions']['simplified']))"
+      "print_exc(nengo_obj)"
      ],
      "language": "python",
      "metadata": {},
@@ -148,8 +145,7 @@
       "        p = nengo.Probe(ens)\n",
       "        p.target = ens\n",
       "nengo.rc.set('exceptions', 'simplified', str(True))\n",
-      "print_exc(nengo_obj)\n",
-      "nengo.rc.set('exceptions', 'simplified', str(RC_DEFAULTS['exceptions']['simplified']))"
+      "print_exc(nengo_obj)"
      ],
      "language": "python",
      "metadata": {},
@@ -174,8 +170,7 @@
       "        p = nengo.Probe(ens)\n",
       "        p.target = ens\n",
       "nengo.rc.set('exceptions', 'simplified', str(False))\n",
-      "print_exc(nengo_obj)\n",
-      "nengo.rc.set('exceptions', 'simplified', str(RC_DEFAULTS['exceptions']['simplified']))"
+      "print_exc(nengo_obj)"
      ],
      "language": "python",
      "metadata": {},

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -20,8 +20,6 @@ test_seed = 0  # changing this will change seeds for all tests
 
 def pytest_configure(config):
     matplotlib.use('agg')
-    rc.reload_rc([])
-    rc.set('decoder_cache', 'enabled', 'False')
 
 
 @pytest.fixture(scope="session")
@@ -195,6 +193,9 @@ def pytest_generate_tests(metafunc):
 
 
 def pytest_runtest_setup(item):
+    rc.reload_rc([])
+    rc.set('decoder_cache', 'enabled', 'False')
+
     if not hasattr(item, 'obj'):
         return
     for mark, option, message in [

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -3,6 +3,7 @@ import inspect
 import os
 import re
 
+import matplotlib
 import numpy as np
 import pytest
 
@@ -18,6 +19,7 @@ test_seed = 0  # changing this will change seeds for all tests
 
 
 def pytest_configure(config):
+    matplotlib.use('agg')
     rc.reload_rc([])
     rc.set('decoder_cache', 'enabled', 'False')
 

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -195,6 +195,7 @@ def pytest_generate_tests(metafunc):
 def pytest_runtest_setup(item):
     rc.reload_rc([])
     rc.set('decoder_cache', 'enabled', 'False')
+    rc.set('exceptions', 'simplified', 'False')
 
     if not hasattr(item, 'obj'):
         return

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -11,7 +11,6 @@ import pytest
 import nengo
 from nengo.cache import DecoderCache, Fingerprint, get_fragment_size
 from nengo.exceptions import FingerprintError
-from nengo.rc import rc, RC_DEFAULTS
 from nengo.utils.compat import int_types
 
 
@@ -366,12 +365,6 @@ sim = nengo.Simulator(model)
 
         times = [self.time_all(self.get_args(varying_param, v))
                  for v in varying]
-
-        # Restore RC to original settings
-        default = RC_DEFAULTS['decoder_cache', 'enabled']
-        rc.set("decoder_cache", "enabled", str(default))
-        default = RC_DEFAULTS['decoder_cache', 'readonly']
-        rc.set("decoder_cache", "readonly", str(default))
 
         for i, data in enumerate(zip(*times)):
             plt.plot(varying, np.median(data, axis=1), label=self.labels[i])

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -3,7 +3,6 @@ import os
 import pytest
 import _pytest.capture
 
-from nengo.rc import rc
 from nengo.utils.paths import examples_dir
 from nengo.utils.stdlib import execfile
 
@@ -53,15 +52,6 @@ for subdir, _, files in os.walk(examples_dir):
 all_examples.sort()
 slow_examples.sort()
 fast_examples.sort()
-
-
-def teardown_function(function):
-    """Executed by py.test after each test in this module
-
-    Since examples might muck with the RC settings, we reset them here.
-    """
-    rc.reload_rc([])
-    rc.set('decoder_cache', 'enabled', 'False')
 
 
 def assert_noexceptions(nb_file, tmpdir, plt):

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -179,7 +179,7 @@ class WarningCatcher(object):
     def __enter__(self):
         self.catcher = warnings.catch_warnings(record=True)
         self.record = self.catcher.__enter__()
-        warnings.simplefilter('always', append=True)
+        warnings.simplefilter('always')
 
     def __exit__(self, type, value, traceback):
         self.catcher.__exit__(type, value, traceback)


### PR DESCRIPTION
[As mentioned in this discussion] (PR #946) the rc params should be reset before every test to prevent test interactions. This PR does that.

In addition it also sets the matplotlib backend to 'AGG' for the tests. Certain other backends are not straight-forward to install in virtualenvs and make problems when runnings tests with tox. This also makes the test backend independent from what the user has set in their config. 'AGG' should be a good default and work on pretty much any system