### PR TITLE
Copy

### DIFF
--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -20,6 +20,7 @@ test_seed = 0  # changing this will change seeds for all tests
 def pytest_configure(config):
     rc.reload_rc([])
     rc.set('decoder_cache', 'enabled', 'False')
+    rc.set('exceptions', 'simplified', 'False')
 
 
 @pytest.fixture(scope="session")

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -303,6 +303,10 @@ class Connection(NengoObject):
         since="v2.1.0",
         url="https://github.com/nengo/nengo/issues/632#issuecomment-71663849")
 
+    _param_init_order = [
+        'pre', 'post', 'synapse', 'transform', 'eval_points', 'function_info',
+        'solver', 'learning_rule_type']
+
     def __init__(self, pre, post, synapse=Default, transform=Default,
                  solver=Default, learning_rule_type=Default, function=Default,
                  eval_points=Default, scale_eval_points=Default,

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -98,6 +98,15 @@ class Ensemble(NengoObject):
         self.noise = noise
         self._neurons = Neurons(self)
 
+    def __getstate__(self):
+        state = super(Ensemble, self).__getstate__()
+        del state['_neurons']
+        return state
+
+    def __setstate__(self, state):
+        state['_neurons'] = Neurons(self)
+        super(Ensemble, self).__setstate__(state)
+
     def __getitem__(self, key):
         return ObjView(self, key)
 

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -29,7 +29,8 @@ def is_param(obj):
 
 def params(obj):
     """Return list with the names of all parameters of an object."""
-    return [name for name, v in vars(obj.__class__).items() if is_param(v)]
+    return [name for name, v in vars(obj.__class__).items()
+            if is_param(v) and not isinstance(v, ObsoleteParam)]
 
 
 class Parameter(object):
@@ -367,9 +368,12 @@ FunctionInfo = collections.namedtuple('FunctionInfo', ['function', 'size'])
 
 class FunctionParam(Parameter):
     def __set__(self, instance, function):
-        size = (self.determine_size(instance, function)
-                if callable(function) else None)
-        function_info = FunctionInfo(function=function, size=size)
+        if isinstance(function, FunctionInfo):
+            function_info = function
+        else:
+            size = (self.determine_size(instance, function)
+                    if callable(function) else None)
+            function_info = FunctionInfo(function=function, size=size)
         super(FunctionParam, self).__set__(instance, function_info)
 
     def function_args(self, instance, function):

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -27,6 +27,11 @@ def is_param(obj):
     return isinstance(obj, Parameter)
 
 
+def params(obj):
+    """Return list with the names of all parameters of an object."""
+    return [name for name, v in vars(obj.__class__).items() if is_param(v)]
+
+
 class Parameter(object):
     """Simple descriptor for storing configuration parameters.
 

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -433,3 +433,44 @@ class FrozenObject(object):
         for k in self._paramdict:
             setattr(self, k, state.pop(k))
         self.__dict__.update(state)
+
+
+class CopyableObject(object):
+    """Mixin to allow to create copies of instances of classes with parameters.
+
+    You can add a list of strings as class attribute _param_init_order to
+    declare the order in which parameters have to be initialized. Missing
+    parameters will be initialized last in an undefined order.
+    """
+
+    def __getstate__(self):
+        sp = super(CopyableObject, self)
+        if hasattr(sp, '__getstate__'):
+            state = sp.__getstate__()
+        else:
+            state = dict(self.__dict__)
+
+        for attr in params(self):
+            param = getattr(self.__class__, attr)
+            if self in param:
+                state[attr] = getattr(self, attr)
+
+        return state
+
+    def __setstate__(self, state):
+        if hasattr(self.__class__, '_param_init_order'):
+            for attr in getattr(self.__class__, '_param_init_order'):
+                setattr(self, attr, state[attr])
+                del state[attr]
+
+        for attr in params(self):
+            if attr in state:
+                setattr(self, attr, state[attr])
+                del state[attr]
+
+        sp = super(CopyableObject, self)
+        if hasattr(sp, '__setstate__'):
+            sp.__setstate__(state)
+        else:
+            for k, v in state.items():
+                setattr(self, k, v)

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -93,6 +93,8 @@ class Probe(NengoObject):
     synapse = SynapseParam('synapse', default=None)
     solver = ProbeSolverParam('solver', default=ConnectionDefault)
 
+    _param_init_order = ['target']
+
     def __init__(self, target, attr=None, sample_every=Default,
                  synapse=Default, solver=Default, label=Default, seed=Default):
         super(Probe, self).__init__(label=label, seed=seed)

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import nengo
@@ -80,9 +81,12 @@ class TestCopyProbe(CopyTest, PickleTest):
         return p
 
 
-# Probe
-# Ensemble
-# Node
+class TestCopyNode(CopyTest, PickleTest):
+    def create_original(self):
+        with nengo.Network() as _:
+            n = nengo.Node(np.min, size_in=2, size_out=2)
+        return n
+
 # Connection
 
 # Network

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -62,7 +62,7 @@ class PickleTest(object):
 
 class TestCopyEnsemble(CopyTest, PickleTest):
     def create_original(self):
-        with nengo.Network() as _:
+        with nengo.Network():
             e = nengo.Ensemble(10, 1, radius=2.)
         return e
 
@@ -75,7 +75,7 @@ class TestCopyEnsemble(CopyTest, PickleTest):
 
 class TestCopyProbe(CopyTest, PickleTest):
     def create_original(self):
-        with nengo.Network() as _:
+        with nengo.Network():
             e = nengo.Ensemble(10, 1)
             p = nengo.Probe(e, synapse=0.01)
         return p
@@ -83,11 +83,17 @@ class TestCopyProbe(CopyTest, PickleTest):
 
 class TestCopyNode(CopyTest, PickleTest):
     def create_original(self):
-        with nengo.Network() as _:
+        with nengo.Network():
             n = nengo.Node(np.min, size_in=2, size_out=2)
         return n
 
-# Connection
+class TestCopyConnection(CopyTest, PickleTest):
+    def create_original(self):
+        with nengo.Network(self):
+            e1 = nengo.Ensemble(10, 1)
+            e2 = nengo.Ensemble(10, 1)
+            c = nengo.Connection(e1, e2, transform=2.)
+        return c
 
 # Network
 

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -1,0 +1,73 @@
+import pytest
+
+import nengo
+from nengo.exceptions import NetworkContextError
+from nengo.params import params
+
+
+
+class CopyTest(object):
+    def create_original(self):
+        raise NotImplementedError()
+
+    def test_copy_in_network(self):
+        original = self.create_original()
+
+        with nengo.Network() as model:
+            copy = original.copy()
+        assert copy in model.all_objects
+
+        self.assert_is_copy(copy, original)
+
+    def test_copy_in_network_without_adding(self):
+        original = self.create_original()
+
+        with nengo.Network() as model:
+            copy = original.copy(add_to_container=False)
+        assert copy not in model.all_objects
+
+        self.assert_is_copy(copy, original)
+
+    def test_copy_outside_network(self):
+        original = self.create_original()
+        with pytest.raises(NetworkContextError):
+            original.copy()
+
+    def test_copy_outside_network_without_adding(self):
+        original = self.create_original()
+        copy = original.copy(add_to_container=False)
+        self.assert_is_copy(copy, original)
+
+    @staticmethod
+    def assert_is_copy(copy, original):
+        assert copy is not original  # ensures separate parameters
+        for param in params(copy):
+            assert getattr(copy, param) == getattr(original, param)
+
+
+class TestCopyEnsemble(CopyTest):
+    def create_original(self):
+        with nengo.Network() as _:
+            e = nengo.Ensemble(10, 1, radius=2.)
+        return e
+
+    def test_neurons_reference_copy(self):
+        original = self.create_original()
+        copy = original.copy(add_to_container=False)
+        assert original.neurons.ensemble is original
+        assert copy.neurons.ensemble is copy
+
+
+# Probe
+# Ensemble
+# Node
+# Connection
+
+# Network
+
+# Process
+# Learning rule
+# Synapse
+
+
+# copy, copy with add to network, pickle and unpickle

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -283,6 +283,7 @@ def test_params():
     class Test(object):
         p1 = params.IntParam('p1')
         p2 = params.IntParam('p2')
+        obsolete = params.ObsoleteParam('obsolete', 'not included in params')
 
     assert set(params.params(Test())) == {'p1', 'p2'}
 

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -275,3 +275,11 @@ def test_functionparam():
     # Not OK: not a function
     with pytest.raises(ValidationError):
         inst.fp = 0
+
+
+def test_params():
+    class Test(object):
+        p1 = params.IntParam('p1')
+        p2 = params.IntParam('p2')
+
+    assert set(params.params(Test())) == {'p1', 'p2'}

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 import numpy as np
 import pytest
 
@@ -283,3 +285,16 @@ def test_params():
         p2 = params.IntParam('p2')
 
     assert set(params.params(Test())) == {'p1', 'p2'}
+
+
+def test_copyable_object():
+    class Test(params.CopyableObject):
+        p1 = params.IntParam('p1')
+
+    original = Test()
+    original.p1 = 2
+
+    copied = copy(original)
+
+    assert copied is not original  # ensures that parameters are separate
+    assert copied.p1 == 2


### PR DESCRIPTION
Addresses #977.

Nengo objects should be copyable and pickable now. There might be some weird effects for objects referencing other objects (e.g., connections). I might have to think about those and whether that works as expected (though, technically it works in some way).

Still todo:

* [ ] Networks
* [ ] FrozenObjects: Process, LearningRule, Synapse (also check for potential code duplication)