### PR TITLE
Fixed minor bugs in `test_neurons.test_reset`

### DIFF
--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -3,6 +3,7 @@ import numpy as np
 import nengo.utils.numpy as npext
 from nengo.base import Process
 from nengo.dists import DistributionParam, Gaussian
+from nengo.exceptions import ValidationError
 from nengo.params import BoolParam, NdarrayParam, NumberParam
 from nengo.synapses import LinearFilter, LinearFilterParam, Lowpass
 
@@ -169,6 +170,11 @@ class WhiteSignal(Process):
         self.period = period
         self.high = high
         self.rms = rms
+
+        if self.high is not None and self.high < 1. / self.period:
+            raise ValidationError(
+                "Make ``high >= 1. / period`` to produce a non-zero signal",
+                attr='high', obj=self)
 
     def __repr__(self):
         return "%s(period=%r, high=%r, rms=%r)" % (

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -173,7 +173,7 @@ def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt):
 
     m = nengo.Network(seed=seed)
     with m:
-        u = nengo.Node(WhiteSignal(0.5, high=5), size_out=2)
+        u = nengo.Node(WhiteSignal(0.5, high=10), size_out=2)
         a = nengo.Ensemble(n, dimensions=2)
         b = nengo.Ensemble(n+1, dimensions=2)
         nengo.Connection(u, a)

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -11,7 +11,7 @@ from nengo.utils.testing import allclose
 def run_synapse(Simulator, seed, synapse, dt=1e-3, runtime=1., n_neurons=None):
     model = nengo.Network(seed=seed)
     with model:
-        u = nengo.Node(output=WhiteSignal(runtime, 5))
+        u = nengo.Node(output=WhiteSignal(runtime, high=10))
 
         if n_neurons is not None:
             a = nengo.Ensemble(n_neurons, 1)


### PR DESCRIPTION
The WhiteSignal being used had a low frequency and duration,
resulting in a signal that was acutally all zeros.