### PR TITLE
Improvements to operator strings

### DIFF
--- a/examples/usage/strings.ipynb
+++ b/examples/usage/strings.ipynb
@@ -255,6 +255,8 @@
      "collapsed": false,
      "input": [
       "sig = nengo.builder.signal.Signal(np.array([0.]), name=\"sig\")\n",
+      "print(nengo.builder.operator.TimeUpdate(sig, sig))\n",
+      "print(nengo.builder.operator.TimeUpdate(sig, sig, tag=\"tag\"))\n",
       "print(nengo.builder.operator.PreserveValue(sig))\n",
       "print(nengo.builder.operator.PreserveValue(sig, tag=\"tag\"))\n",
       "print(nengo.builder.operator.Reset(sig))\n",
@@ -275,8 +277,8 @@
       "print(nengo.builder.learning_rules.SimOja(sig, sig, sig, sig, 0.1, 1.0, tag=\"tag\"))\n",
       "print(nengo.builder.neurons.SimNeurons(nengo.LIF(), sig, sig, [sig]))\n",
       "print(nengo.builder.neurons.SimNeurons(nengo.LIF(), sig, sig, [sig], tag=\"tag\"))\n",
-      "print(nengo.builder.processes.SimProcess(nengo.processes.Process(), sig, sig, sig))\n",
-      "print(nengo.builder.processes.SimProcess(nengo.processes.Process(), sig, sig, sig, tag=\"tag\"))\n",
+      "print(nengo.builder.processes.SimProcess(nengo.processes.WhiteNoise(), sig, sig, sig))\n",
+      "print(nengo.builder.processes.SimProcess(nengo.processes.WhiteNoise(), sig, sig, sig, tag=\"tag\"))\n",
       "print(nengo.builder.synapses.SimSynapse(sig, sig, nengo.Lowpass(0.005)))\n",
       "print(nengo.builder.synapses.SimSynapse(sig, sig, nengo.Lowpass(0.005), tag=\"tag\"))"
      ],

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -15,8 +15,8 @@ class SimBCM(Operator):
     """Calculate delta omega according to the BCM rule."""
     def __init__(self, pre_filtered, post_filtered, theta, delta,
                  learning_rate, tag=None):
-        self.post_filtered = post_filtered
         self.pre_filtered = pre_filtered
+        self.post_filtered = post_filtered
         self.theta = theta
         self.delta = delta
         self.learning_rate = learning_rate
@@ -27,9 +27,9 @@ class SimBCM(Operator):
         self.reads = [pre_filtered, post_filtered, theta]
         self.updates = [delta]
 
-    def __str__(self):
-        return 'SimBCM(pre=%s, post=%s -> %s%s)' % (
-            self.pre_filtered, self.post_filtered, self.delta, self._tagstr)
+    def _descstr(self):
+        return 'pre=%s, post=%s -> %s' % (
+            self.pre_filtered, self.post_filtered, self.delta)
 
     def make_step(self, signals, dt, rng):
         pre_filtered = signals[self.pre_filtered]
@@ -48,8 +48,8 @@ class SimOja(Operator):
     """Calculate delta omega according to the Oja rule."""
     def __init__(self, pre_filtered, post_filtered, weights, delta,
                  learning_rate, beta, tag=None):
-        self.post_filtered = post_filtered
         self.pre_filtered = pre_filtered
+        self.post_filtered = post_filtered
         self.weights = weights
         self.delta = delta
         self.learning_rate = learning_rate
@@ -61,9 +61,9 @@ class SimOja(Operator):
         self.reads = [pre_filtered, post_filtered, weights]
         self.updates = [delta]
 
-    def __str__(self):
-        return 'SimOja(pre=%s, post=%s -> %s%s)' % (
-            self.pre_filtered, self.post_filtered, self.delta, self._tagstr)
+    def _descstr(self):
+        return 'pre=%s, post=%s -> %s' % (
+            self.pre_filtered, self.post_filtered, self.delta)
 
     def make_step(self, signals, dt, rng):
         weights = signals[self.weights]
@@ -123,6 +123,10 @@ class SimVoja(Operator):
         self.updates = [delta]
         self.sets = []
         self.incs = []
+
+    def _descstr(self):
+        return 'pre=%s, post=%s -> %s' % (
+            self.pre_decoded, self.post_filtered, self.delta)
 
     def make_step(self, signals, dt, rng):
         pre_decoded = signals[self.pre_decoded]

--- a/nengo/builder/neurons.py
+++ b/nengo/builder/neurons.py
@@ -22,9 +22,8 @@ class SimNeurons(Operator):
         self.reads = [J]
         self.updates = []
 
-    def __str__(self):
-        return "SimNeurons(%s, %s, %s, %s%s)" % (
-            self.neurons, self.J, self.output, self.states, self._tagstr)
+    def _descstr(self):
+        return '%s, %s, %s' % (self.neurons, self.J, self.output)
 
     def make_step(self, signals, dt, rng):
         J = signals[self.J]

--- a/nengo/builder/processes.py
+++ b/nengo/builder/processes.py
@@ -22,9 +22,8 @@ class SimProcess(Operator):
         self.reads = [t, input] if input is not None else [t]
         self.updates = []
 
-    def __str__(self):
-        return 'SimProcess(%s, %s -> %s%s)' % (
-            self.process, self.input, self.output, self._tagstr)
+    def _descstr(self):
+        return '%s, %s -> %s' % (self.process, self.input, self.output)
 
     def make_step(self, signals, dt, rng):
         t = signals[self.t]

--- a/nengo/builder/synapses.py
+++ b/nengo/builder/synapses.py
@@ -19,9 +19,8 @@ class SimSynapse(Operator):
         self.reads = [input_sig]
         self.updates = [output_sig]
 
-    def __str__(self):
-        return "SimSynapse(%s, %s -> %s%s)" % (
-            self.synapse, self.input, self.output, self._tagstr)
+    def _descstr(self):
+        return '%s, %s -> %s' % (self.synapse, self.input, self.output)
 
     def make_step(self, signals, dt, rng):
         input_sig = signals[self.input]


### PR DESCRIPTION
- TimeUpdate now has a `tag` so that the `__repr__` doesn't throw
  an exception.
- Operators now have a `_descstr` function that they should overload.
  This function returns a describing string, which the operator uses
  in creating its `__str__`. This means that Operator subclasses
  don't have to overload `__str__`, they can just overload `_descstr`.

Really the only bug here was TimeUpdate not having a tag. If people are unsure about the second part, I can rip that out and we can just put the TimeUpdate tag in 2.1.0.