### PR TITLE
Threadsafe context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,6 +205,8 @@ Release History
   Connection, rather than the input to the Connection's post Ensemble.
   (`#973 <https://github.com/nengo/nengo/issues/973>`_,
   `#974 <https://github.com/nengo/nengo/pull/974>`_)
+- Fixed thread-safety of using networks and config in ``with`` statements.
+  (`#989 <https://github.com/nengo/nengo/pull/989>`_)
 
 2.0.3 (December 7, 2015)
 ========================

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -225,7 +225,7 @@ class Config(object):
     1
     """
 
-    context = ThreadLocalStack()  # static stack of Config objects
+    context = ThreadLocalStack(maxsize=100)  # static stack of Config objects
 
     def __init__(self, *configures):
         self.params = {}

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -12,12 +12,12 @@ http://nbviewer.ipython.org/urls/gist.github.com/ChrisBeaumont/5758381/raw/descr
 
 """
 
-import collections
 import inspect
 
 from nengo.exceptions import ConfigError
 from nengo.params import is_param
 from nengo.utils.compat import itervalues
+from nengo.utils.threading import ThreadLocalStack
 
 
 class ClassParams(object):
@@ -225,7 +225,7 @@ class Config(object):
     1
     """
 
-    context = collections.deque(maxlen=100)  # static stack of Config objects
+    context = ThreadLocalStack()  # static stack of Config objects
 
     def __init__(self, *configures):
         self.params = {}

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -70,7 +70,7 @@ class Network(object):
         List of nengo.BaseNetwork objects in this Network.
     """
 
-    context = ThreadLocalStack()  # static stack of Network objects
+    context = ThreadLocalStack(maxsize=100)  # static stack of Network objects
 
     def __init__(self, label=None, seed=None, add_to_container=None):
         self.label = label

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -1,11 +1,10 @@
-import collections
-
 from nengo.config import Config
 from nengo.connection import Connection
 from nengo.ensemble import Ensemble
 from nengo.exceptions import ConfigError, NetworkContextError, ReadonlyError
 from nengo.node import Node
 from nengo.probe import Probe
+from nengo.utils.threading import ThreadLocalStack
 
 
 class Network(object):
@@ -71,7 +70,7 @@ class Network(object):
         List of nengo.BaseNetwork objects in this Network.
     """
 
-    context = collections.deque(maxlen=100)  # static stack of Network objects
+    context = ThreadLocalStack()  # static stack of Network objects
 
     def __init__(self, label=None, seed=None, add_to_container=None):
         self.label = label

--- a/nengo/utils/tests/test_threading.py
+++ b/nengo/utils/tests/test_threading.py
@@ -1,0 +1,46 @@
+import pytest
+
+from nengo.utils.testing import ThreadedAssertion
+from nengo.utils.threading import ThreadLocalStack
+
+
+class TestThreadLocalStack(object):
+    def test_threadsafety(self):
+        stack = ThreadLocalStack()
+        stack.append(1)
+
+        class CheckIndependence(ThreadedAssertion):
+            def init_thread(self, worker):
+                stack.append(2)
+
+            def assert_thread(self, worker):
+                assert list(stack) == [2]
+
+        CheckIndependence(n_threads=2)
+
+    def test_has_length(self):
+        stack = ThreadLocalStack()
+        assert len(stack) == 0
+        stack.append(1)
+        assert len(stack) == 1
+
+    def test_implements_stack(self):
+        stack = ThreadLocalStack()
+        assert list(stack) == []
+        stack.append(1)
+        assert list(stack) == [1]
+        stack.append(2)
+        assert list(stack) == [1, 2]
+        assert stack.pop() == 2
+        assert list(stack) == [1]
+        assert stack.pop() == 1
+        assert list(stack) == []
+
+        with pytest.raises(IndexError):
+            stack.pop()
+
+    def test_implements_clear(self):
+        stack = ThreadLocalStack()
+        stack.append(1)
+        stack.clear()
+        assert len(stack) == 0

--- a/nengo/utils/tests/test_threading.py
+++ b/nengo/utils/tests/test_threading.py
@@ -44,3 +44,12 @@ class TestThreadLocalStack(object):
         stack.append(1)
         stack.clear()
         assert len(stack) == 0
+
+    def test_has_size_limit(self):
+        maxsize = 5
+        stack = ThreadLocalStack(maxsize=maxsize)
+        for i in range(maxsize):
+            stack.append(i)
+
+        with pytest.raises(RuntimeError):
+            stack.append(5)

--- a/nengo/utils/threading.py
+++ b/nengo/utils/threading.py
@@ -5,8 +5,9 @@ import threading
 
 
 class ThreadLocalStack(threading.local, collections.Sequence):
-    def __init__(self):
+    def __init__(self, maxsize=None):
         super(ThreadLocalStack, self).__init__()
+        self.maxsize = maxsize
         self._context = []
 
     def __len__(self):
@@ -16,6 +17,8 @@ class ThreadLocalStack(threading.local, collections.Sequence):
         return self._context[i]
 
     def append(self, item):
+        if self.maxsize is not None and len(self) >= self.maxsize:
+            raise RuntimeError("Stack limit exceeded.")
         self._context.append(item)
 
     def pop(self):

--- a/nengo/utils/threading.py
+++ b/nengo/utils/threading.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+
+import collections
+import threading
+
+
+class ThreadLocalStack(threading.local, collections.Sequence):
+    def __init__(self):
+        super(ThreadLocalStack, self).__init__()
+        self._context = []
+
+    def __len__(self):
+        return len(self._context)
+
+    def __getitem__(self, i):
+        return self._context[i]
+
+    def append(self, item):
+        self._context.append(item)
+
+    def pop(self):
+        return self._context.pop()
+
+    def clear(self):
+        self._context[:] = []


### PR DESCRIPTION
Not sure if we want to include this in the 2.1.0 release, but technically it's a bug fix.

This PR makes the network and config state thread-local. Without this you might get weird interactions and unpredictable behaviour between threads.