### PR TITLE
Assoc mem v3

### DIFF
--- a/examples/spa/associative_memory.ipynb
+++ b/examples/spa/associative_memory.ipynb
@@ -260,7 +260,7 @@
      "metadata": {},
      "source": [
       "We see that the vector at the input is mostly similar to the semantic pointer `APPLE` and somewhat similar to the semantic pointer `CHERRY`.\n",
-      "The vector at the output is very similar to the `APPLE`, indicating that the memory successfully cleaned up the noisy pattern. We can indicate that we want to completely recover the pattern at the output by setting the parameter `threshold_output` to `True`. This will produce a vector at the output which has similarity one with the semantic pointer `APPLE`. "
+      "The vector at the output is very similar to the `APPLE`, indicating that the memory successfully cleaned up the noisy pattern. We can indicate that we want to completely recover the pattern at the output by setting the parameter `cleanup_output` to `True`. This will produce a vector at the output which has similarity one with the semantic pointer `APPLE`. "
      ]
     },
     {
@@ -313,7 +313,7 @@
      "metadata": {},
      "source": [
       "We see that the input is very similar to semantic pointers `APPLE`, `CHERRY` and somewhat similar to `APRICOT`.\n",
-      "In this situation, it might be difficult to determine a fixed threshold which will clean up the input and differentiate between the vectors `APPLE` and `CHERRY`. To ensure that only one vector at the output is similar to the strongest input, we can set the parameter `wta_output` to `True`. `WTA` is a computational principle called winner-take-all, stating that one, mostly active element should be regarded as the winner among possible, less similar alternatives. Again, we set `threshold_output` to `True` to fully recover the pattern:"
+      "In this situation, it might be difficult to determine a fixed threshold which will clean up the input and differentiate between the vectors `APPLE` and `CHERRY`. To ensure that only one vector at the output is similar to the strongest input, we can set the parameter `wta_output` to `True`. `WTA` is a computational principle called winner-take-all, stating that one, mostly active element should be regarded as the winner among possible, less similar alternatives. Again, we set `cleanup_output` to `True` to fully recover the pattern:"
      ]
     },
     {
@@ -321,7 +321,7 @@
      "collapsed": false,
      "input": [
       "with spa.Module('CleanupThreshold', seed=1) as model_3:\n",
-      "    model_3.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, wta_output=True, threshold_output=True)\n",
+      "    model_3.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, wta_output=True, cleanup_output=True)\n",
       "    \n",
       "    input_expr = '0.9*APPLE + 0.85*CHERRY + 0.7*APRICOT'\n",
       "    model_3.am_input = spa.Input()\n",

--- a/examples/spa/associative_memory.ipynb
+++ b/examples/spa/associative_memory.ipynb
@@ -76,7 +76,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "dim = 32\n",
+      "dim = 64\n",
       "vocab = spa.Vocabulary(dimensions=dim)\n",
       "\n",
       "words = ['ORANGE', 'APRICOT', 'CHERRY', 'STRAWBERRY', 'APPLE']\n",
@@ -232,8 +232,43 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "with spa.Module('CleanupThreshold', seed=1) as model_2:\n",
+      "    model_2.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, threshold=0.7)\n",
+      "    \n",
+      "    input_expr = '0.9*APPLE + 0.5*CHERRY + 0.4*APRICOT'\n",
+      "    model_2.am_input = spa.Input()\n",
+      "    model_2.am_input.assoc_mem = input_expr\n",
+      "\n",
+      "    input_probe = nengo.Probe(model_2.assoc_mem.input)\n",
+      "    output_probe = nengo.Probe(model_2.assoc_mem.output, synapse=0.03)\n",
+      "\n",
+      "with nengo.Simulator(model_2) as sim:\n",
+      "    sim.run(0.2)\n",
+      "t = sim.trange()\n",
+      "\n",
+      "input_data = sim.data[input_probe]\n",
+      "output_data = sim.data[output_probe]\n",
+      "\n",
+      "plot_similarities(input_data, output_data, vocab)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We see that the vector at the input is mostly similar to the semantic pointer `APPLE` and somewhat similar to the semantic pointer `CHERRY`.\n",
+      "The vector at the output is very similar to the `APPLE`, indicating that the memory successfully cleaned up the noisy pattern. We can indicate that we want to completely recover the pattern at the output by setting the parameter `cleanup_output` to `True`. This will produce a vector at the output which has similarity one with the semantic pointer `APPLE`. "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
       "with spa.Module('CleanupThreshold', seed=1) as model_3:\n",
-      "    model_3.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, threshold=0.7)\n",
+      "    model_3.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, threshold=0.75, cleanup_output=True)\n",
       "    \n",
       "    input_expr = '0.9*APPLE + 0.5*CHERRY + 0.4*APRICOT'\n",
       "    model_3.am_input = spa.Input()\n",
@@ -259,14 +294,6 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "We see that the vector at the input is mostly similar to the semantic pointer `APPLE` and somewhat similar to the semantic pointer `CHERRY`.\n",
-      "The vector at the output is very similar to the `APPLE`, indicating that the memory successfully cleaned up the noisy pattern. We can indicate that we want to completely recover the pattern at the output by setting the parameter `cleanup_output` to `True`. This will produce a vector at the output which has similarity one with the semantic pointer `APPLE`. "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
       "In some modelling scenarios we might have an input vector which is very similar to several other vectors in the vocabulary:"
      ]
     },
@@ -274,16 +301,11 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "with spa.Module('Cleanup', seed=1) as model_2:\n",
-      "    model_2.assoc_mem = spa.AssociativeMemory(input_vocab=vocab)\n",
+      "with spa.Module('Cleanup', seed=1) as model_4:\n",
+      "    model_4.assoc_mem = spa.AssociativeMemory(input_vocab=vocab)\n",
       "    \n",
-      "    # noisy input\n",
-      "    input_expr = '0.9*APPLE + 0.85*CHERRY + 0.7*APRICOT'\n",
-      "    model_2.am_input = spa.Input()\n",
-      "    model_2.am_input.assoc_mem = input_expr\n",
-      "    \n",
-      "    input_probe = nengo.Probe(model_2.assoc_mem.input)\n",
-      "    output_probe = nengo.Probe(model_2.assoc_mem.output, synapse=0.03)"
+      "    input_probe = nengo.Probe(model_4.assoc_mem.input)\n",
+      "    output_probe = nengo.Probe(model_4.assoc_mem.output, synapse=0.03)"
      ],
      "language": "python",
      "metadata": {},
@@ -293,7 +315,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "with nengo.Simulator(model_2) as sim:\n",
+      "with nengo.Simulator(model_4) as sim:\n",
       "    sim.run(0.2)\n",
       "t = sim.trange()\n",
       "\n",
@@ -320,17 +342,17 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "with spa.Module('CleanupThreshold', seed=1) as model_3:\n",
-      "    model_3.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, wta_output=True, cleanup_output=True)\n",
+      "with spa.Module('CleanupThreshold', seed=1) as model_5:\n",
+      "    model_5.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, wta_output=True, cleanup_output=True)\n",
       "    \n",
       "    input_expr = '0.9*APPLE + 0.85*CHERRY + 0.7*APRICOT'\n",
-      "    model_3.am_input = spa.Input()\n",
-      "    model_3.am_input.assoc_mem = input_expr\n",
+      "    model_5.am_input = spa.Input()\n",
+      "    model_5.am_input.assoc_mem = input_expr\n",
       "\n",
-      "    input_probe = nengo.Probe(model_3.assoc_mem.input)\n",
-      "    output_probe = nengo.Probe(model_3.assoc_mem.output, synapse=0.03)\n",
+      "    input_probe = nengo.Probe(model_5.assoc_mem.input)\n",
+      "    output_probe = nengo.Probe(model_5.assoc_mem.output, synapse=0.03)\n",
       "\n",
-      "with nengo.Simulator(model_3) as sim:\n",
+      "with nengo.Simulator(model_5) as sim:\n",
       "    sim.run(0.2)\n",
       "t = sim.trange()\n",
       "\n",
@@ -413,16 +435,16 @@
       "# to patterns\n",
       "output_keys = ['TWO', 'THREE', 'FOUR', 'FIVE']\n",
       "    \n",
-      "with spa.Module('Counting', seed=1) as model_4:\n",
-      "    model_4.assoc_mem = spa.AssociativeMemory(input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
+      "with spa.Module('Counting', seed=1) as model_6:\n",
+      "    model_6.assoc_mem = spa.AssociativeMemory(input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
       "                                              input_keys=input_keys, output_keys=output_keys,\n",
       "                                              wta_output=True)\n",
       "\n",
-      "    model_4.am_input = spa.Input()\n",
-      "    model_4.am_input.assoc_mem = input_fun\n",
+      "    model_6.am_input = spa.Input()\n",
+      "    model_6.am_input.assoc_mem = input_fun\n",
       "\n",
-      "    input_probe = nengo.Probe(model_4.assoc_mem.input)\n",
-      "    output_probe = nengo.Probe(model_4.assoc_mem.output, synapse=0.03)"
+      "    input_probe = nengo.Probe(model_6.assoc_mem.input)\n",
+      "    output_probe = nengo.Probe(model_6.assoc_mem.output, synapse=0.03)"
      ],
      "language": "python",
      "metadata": {},
@@ -432,7 +454,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "with nengo.Simulator(model_4) as sim:\n",
+      "with nengo.Simulator(model_6) as sim:\n",
       "    sim.run(1.)\n",
       "t = sim.trange()\n",
       "\n",
@@ -463,19 +485,19 @@
       "    else:\n",
       "        return '0'\n",
       "\n",
-      "with spa.Module('Counting', seed=1) as model_5:\n",
-      "    model_5.assoc_mem = spa.AssociativeMemory(input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
+      "with spa.Module('Counting', seed=1) as model_7:\n",
+      "    model_7.assoc_mem = spa.AssociativeMemory(input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
       "                                              input_keys=input_keys, output_keys=output_keys,\n",
       "                                              wta_output=True)\n",
       "\n",
-      "    model_5.am_input = spa.Input()\n",
-      "    model_5.am_input.assoc_mem = input_fun\n",
+      "    model_7.am_input = spa.Input()\n",
+      "    model_7.am_input.assoc_mem = input_fun\n",
       "\n",
       "    # added feedback connection\n",
-      "    nengo.Connection(model_5.assoc_mem.output, model_5.assoc_mem.input, synapse=.18, transform=3.3)\n",
+      "    nengo.Connection(model_7.assoc_mem.output, model_7.assoc_mem.input, synapse=.18, transform=3.3)\n",
       "    \n",
-      "    input_probe = nengo.Probe(model_5.assoc_mem.input)\n",
-      "    output_probe = nengo.Probe(model_5.assoc_mem.output, synapse=0.03)"
+      "    input_probe = nengo.Probe(model_7.assoc_mem.input)\n",
+      "    output_probe = nengo.Probe(model_7.assoc_mem.output, synapse=0.03)"
      ],
      "language": "python",
      "metadata": {},
@@ -485,7 +507,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "with nengo.Simulator(model_5) as sim:\n",
+      "with nengo.Simulator(model_7) as sim:\n",
       "    sim.run(1.)\n",
       "t = sim.trange()\n",
       "\n",

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -154,7 +154,7 @@ class AssociativeMemory(nengo.Network):
             of the linear mapping function.
         """
         return lambda x, x_shift=x_shift, x_scale=x_scale: \
-            (x_scale * (x - x_scale))
+            (x_scale * (x - x_shift))
 
     def threshold_shifted_linear_funcs(self, x_shift=0.0, x_scale=1.0):
         """Returns a list of threshold-shifted linear mapping function.
@@ -168,9 +168,10 @@ class AssociativeMemory(nengo.Network):
         Parameters
         ----------
         x_shift: float, optional
-            Amount to shift the linear map on the 'x'-axis.
+            Amount to shift the linear map on the 'x'-axis, pre-shifted by the
+            threshold values for each ensemble.
             E.g. If the value of x_shift = 0.3, then the output of the linear
-                 mapping function would be 0 at x == 0.3.
+                 mapping function would be 0 at x == (0.3 - threshold).
         x_scale: float, optional
             Scaling factor to be applied to the 'x' input. Affects the slope
             of the linear mapping function.

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -44,6 +44,10 @@ class AssociativeMemory(nengo.Network):
     exp_scale = 0.15  # Scaling factor for exponential distribution
     n_eval_points = 5000
 
+    # Prefix and suffix tags to be used when creating the corresponding output
+    # nodes. E.g. Adding a 'utitilies' node to the 'output' output will use
+    # the 'utility_output_suffix' in the name, creating a node called
+    # 'output_utilities'
     cleanup_output_prefix = 'cleaned'
     default_ens_suffix = 'default_ens'
     utility_output_suffix = 'utilities'

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -109,10 +109,10 @@ class AssociativeMemory(nengo.Network):
         # -- Create the core network
         with self, self.am_ens_config:
             self.bias_node = nengo.Node(output=1)
-            self.elem_input = nengo.Node(
-                size_in=self.n_items, label="element input")
-            self.elem_utilities = nengo.Node(
-                size_in=self.n_items, label="element utilities")
+            self.ens_input = nengo.Node(
+                size_in=self.n_items, label="ensembles input")
+            self.ens_utilities = nengo.Node(
+                size_in=self.n_items, label="ensembles utilities")
 
             self.am_ensembles = []
             label_prefix = "" if label is None else label + "_"
@@ -123,13 +123,13 @@ class AssociativeMemory(nengo.Network):
 
                 # Connect input and output nodes
                 nengo.Connection(self.bias_node, e, transform=-threshold[i])
-                nengo.Connection(self.elem_input[i], e, synapse=None)
-                nengo.Connection(e, self.elem_utilities[i], synapse=None)
+                nengo.Connection(self.ens_input[i], e, synapse=None)
+                nengo.Connection(e, self.ens_utilities[i], synapse=None)
 
             if inhibitable:
                 # Input node for inhibitory gating signal (if enabled)
                 self.inhibit = nengo.Node(size_in=1, label="inhibit")
-                nengo.Connection(self.inhibit, self.elem_input,
+                nengo.Connection(self.inhibit, self.ens_input,
                                  transform=-np.ones((self.n_items, 1))
                                  * self._inhib_scale, synapse=None)
                 # Note: We can use a decoded connection here because all the
@@ -316,7 +316,7 @@ class AssociativeMemory(nengo.Network):
         # --- Finally, make the input node and connect it
         in_node = nengo.Node(size_in=d_vectors, label=name)
         setattr(self, name, in_node)
-        nengo.Connection(in_node, self.elem_input,
+        nengo.Connection(in_node, self.ens_input,
                          synapse=None,
                          transform=input_vectors * input_scales.T)
 
@@ -479,7 +479,7 @@ class AssociativeMemory(nengo.Network):
             Mutual inhibition synapse time constant.
         """
         if not self.is_wta:
-            nengo.Connection(self.elem_utilities, self.elem_input,
+            nengo.Connection(self.ens_utilities, self.ens_input,
                              synapse=inhibit_synapse,
                              transform=((np.eye(self.n_items) - 1) *
                                         inhibit_scale))

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -263,7 +263,7 @@ class AssociativeMemory(nengo.Network):
         cfg = nengo.Config(nengo.Ensemble)
         cfg[nengo.Ensemble].update({
             'radius': 1,
-            'intercepts': Uniform(0.5, 1.0),
+            'intercepts': Uniform(0.25, 1.0),
             'encoders': Choice([[1]]),
             'eval_points': Uniform(0.75, 1.1),
             'n_eval_points': self.n_eval_points,
@@ -488,7 +488,7 @@ class AssociativeMemory(nengo.Network):
 
     @with_self
     def add_cleanup_output(self, output_name='output', n_neurons=50,
-                           inhibit_scale=10, replace_output=False):
+                           inhibit_scale=3.5, replace_output=False):
         """Adds cleaned outputs to the associative memory network.
 
         Creates a doubled-inhibited ensemble structure to the desired assoc
@@ -517,7 +517,9 @@ class AssociativeMemory(nengo.Network):
             inhibited cleanup network.
         inhibit_scale: float
             Scaling factor applied to the inhibitory connections between
-            the ensembles.
+            the ensembles. It is recommended that this value be at
+            least 1.0 / minimum(assoc memory activation thresholds), and that
+            the minimum assoc memory activation threshold be at most 0.1.
 
         replace_output: boolean
             Flag to indicate whether or not to replace the output object
@@ -557,7 +559,7 @@ class AssociativeMemory(nengo.Network):
             nengo.Connection(utility, self.bias_ens1.input,
                              transform=-inhibit_scale)
             nengo.Connection(self.bias_ens1.output, self.bias_ens2.input,
-                             transform=-inhibit_scale)
+                             transform=-1.0)
 
             # --- Make the output node and connect it
             output_vectors = self._output_vectors[output_name]

--- a/nengo/networks/tests/test_assoc_mem.py
+++ b/nengo/networks/tests/test_assoc_mem.py
@@ -37,7 +37,7 @@ def test_am_basic(Simulator, plt, seed, rng):
 
         in_p = nengo.Probe(in_node)
         out_p = nengo.Probe(am.output, synapse=0.03)
-        utils_p = nengo.Probe(am.utilities, synapse=0.03)
+        utils_p = nengo.Probe(am.output_utilities, synapse=0.03)
 
     with Simulator(m) as sim:
         sim.run(0.2)
@@ -82,7 +82,7 @@ def test_am_threshold(Simulator, plt, seed, rng):
 
         in_p = nengo.Probe(in_node)
         out_p = nengo.Probe(am.output, synapse=0.03)
-        utils_p = nengo.Probe(am.utilities, synapse=0.03)
+        utils_p = nengo.Probe(am.output_utilities, synapse=0.03)
 
     with Simulator(m) as sim:
         sim.run(0.3)
@@ -131,7 +131,7 @@ def test_am_wta(Simulator, plt, seed, rng):
 
         in_p = nengo.Probe(in_node)
         out_p = nengo.Probe(am.output, synapse=0.03)
-        utils_p = nengo.Probe(am.utilities, synapse=0.03)
+        utils_p = nengo.Probe(am.output_utilities, synapse=0.03)
 
     with Simulator(m) as sim:
         sim.run(0.5)
@@ -186,7 +186,7 @@ def test_am_complex(Simulator, plt, seed, rng):
     with nengo.Network('model', seed=seed) as m:
         am = AssociativeMemory(vocab2, inhibitable=True)
         am.add_default_output_vector(vocab[5, :])
-        am.add_threshold_to_outputs()
+        am.add_cleanup_output()
 
         in_node = nengo.Node(output=input_func, label='input')
         inhib_node = nengo.Node(output=inhib_func, label='inhib')
@@ -194,9 +194,9 @@ def test_am_complex(Simulator, plt, seed, rng):
         nengo.Connection(inhib_node, am.inhibit)
 
         in_p = nengo.Probe(in_node)
-        out_p = nengo.Probe(am.output, synapse=0.03)
-        utils_p = nengo.Probe(am.utilities, synapse=0.05)
-        utils_th_p = nengo.Probe(am.thresholded_utilities, synapse=0.05)
+        out_p = nengo.Probe(am.cleaned_output, synapse=0.03)
+        utils_p = nengo.Probe(am.output_utilities, synapse=0.05)
+        utils_th_p = nengo.Probe(am.cleaned_output_utilities, synapse=0.05)
 
     with Simulator(m) as sim:
         sim.run(1.0)

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -94,7 +94,7 @@ class AssociativeMemory(Module):
                 self.am.add_wta_network(wta_inhibit_scale, wta_synapse)
 
             if threshold_output:
-                self.am.add_threshold_to_outputs()
+                self.am.add_cleanup_output()
 
             self.input = self.am.input
             self.output = self.am.output
@@ -102,9 +102,9 @@ class AssociativeMemory(Module):
             if inhibitable:
                 self.inhibit = self.am.inhibit
 
-            self.utilities = self.am.utilities
+            self.utilities = self.am.elem_utilities
             if threshold_output:
-                self.thresholded_utilities = self.am.thresholded_utilities
+                self.thresholded_utilities = self.am.cleaned_output_utilities
 
         self.inputs = dict(default=(self.input, input_vocab))
         self.outputs = dict(default=(self.output, output_vocab))

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -13,21 +13,27 @@ class AssociativeMemory(Module):
         The vocabulary (or list of vectors) to match.
     output_vocab: list or Vocabulary, optional (Default: None)
         The vocabulary (or list of vectors) to be produced for each match. If
-        None, the associative memory will act like an autoassociative memory
-        (cleanup memory).
-    input_keys : list, optional (Default: None)
-        A list of strings that correspond to the input vectors.
-    output_keys : list, optional (Default: None)
-        A list of strings that correspond to the output vectors.
-    default_output_key: str, optional (Default: None)
-        The semantic pointer string to be produced if the input value matches
-        none of vectors in the input vector list.
+        not given, the associative memory will act like an auto-associative
+        memory (cleanup memory).
+
+    input_keys: list of strings, optional (Default: None)
+        List of keys (ordered) from the input vocabulary to use as the input
+        semantic pointers for the associative memory.
+    output_keys: list of strings, optional (Default: None)
+        List of keys (ordered) from the output vocabulary to use as the output
+        semantic pointers for the associative memory.
+
+    default_output_vector: numpy.array, spa.SemanticPointer, optional (Default: None)
+        The vector to be produced if the input value matches none of vectors
+        in the input vector list.
     threshold: float, optional (Default: 0.3)
         The association activation threshold.
-    inhibitable: bool, optional (Default: False)
+
+    inhibitable: boolean, optional
         Flag to indicate if the entire associative memory module is
-        inhibitable (i.e., the entire module can be inhibited).
-    wta_output: bool, optional (Default: False)
+        inhibitable (entire thing can be shut off).
+
+    wta_output: boolean, optional (Default: False)
         Flag to indicate if output of the associative memory should contain
         more than one vector. If True, only one vector's output will be
         produced; i.e. produce a winner-take-all (WTA) output.
@@ -36,15 +42,13 @@ class AssociativeMemory(Module):
         Scaling factor on the winner-take-all (WTA) inhibitory connections.
     wta_synapse: float, optional (Default: 0.005)
         Synapse to use for the winner-take-all (wta) inhibitory connections.
-    threshold_output: bool, optional (Default: False)
-        Adds a threholded output if True.
-    label : str, optional (Default: None)
-        A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
-        The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
-        Determines if this Network will be added to the current container.
-        If None, will be true if currently within a Network.
+
+    cleanup_output: boolean, optional (Default: False)
+        Create the associative memory with cleaned outputs as well as the
+        standard outputs.
+    replace_output_with_cleaned_output: boolean, optional
+        Set to true to use the cleaned outputs as the default output of the
+        associative memory module.
     """
 
     def __init__(self, input_vocab, output_vocab=None,  # noqa: C901
@@ -52,8 +56,9 @@ class AssociativeMemory(Module):
                  default_output_key=None, threshold=0.3,
                  inhibitable=False, wta_output=False,
                  wta_inhibit_scale=3.0, wta_synapse=0.005,
-                 threshold_output=False, label=None, seed=None,
-                 add_to_container=None):
+                 cleanup_output=False,
+                 replace_output_with_cleaned_output=False,
+                 label=None, seed=None, add_to_container=None):
         super(AssociativeMemory, self).__init__(label, seed, add_to_container)
 
         if input_keys is None:
@@ -93,18 +98,22 @@ class AssociativeMemory(Module):
             if wta_output:
                 self.am.add_wta_network(wta_inhibit_scale, wta_synapse)
 
-            if threshold_output:
-                self.am.add_cleanup_output()
+            if cleanup_output:
+                self.am.add_cleanup_output(
+                    replace_output=replace_output_with_cleaned_output)
 
             self.input = self.am.input
             self.output = self.am.output
 
+            if cleanup_output and not replace_output_with_cleaned_output:
+                self.cleaned_output = self.am.cleaned_output
+
             if inhibitable:
                 self.inhibit = self.am.inhibit
 
-            self.utilities = self.am.elem_utilities
-            if threshold_output:
-                self.thresholded_utilities = self.am.cleaned_output_utilities
+            self.utilities = self.am.output_utilities
+            if cleanup_output:
+                self.cleaned_utilities = self.am.cleaned_output_utilities
 
         self.inputs = dict(default=(self.input, input_vocab))
         self.outputs = dict(default=(self.output, output_vocab))

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -57,7 +57,7 @@ class AssociativeMemory(Module):
                  inhibitable=False, wta_output=False,
                  wta_inhibit_scale=3.0, wta_synapse=0.005,
                  cleanup_output=False,
-                 replace_output_with_cleaned_output=False,
+                 replace_output_with_cleaned_output=True,
                  label=None, seed=None, add_to_container=None):
         super(AssociativeMemory, self).__init__(label, seed, add_to_container)
 

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -49,6 +49,14 @@ class AssociativeMemory(Module):
     replace_output_with_cleaned_output: boolean, optional
         Set to true to use the cleaned outputs as the default output of the
         associative memory module.
+
+    label : str, optional
+        A name to assign this AssociativeMemory. Used for visualization and
+        debugging. Also used as a label prefix for each of the internal
+        ensembles in the AssociativeMemory network.
+
+    Additional network parameters are passed to the Network constructor through
+    **module_kwargs
     """
 
     def __init__(self, input_vocab, output_vocab=None,  # noqa: C901
@@ -58,8 +66,8 @@ class AssociativeMemory(Module):
                  wta_inhibit_scale=3.0, wta_synapse=0.005,
                  cleanup_output=False,
                  replace_output_with_cleaned_output=True,
-                 label=None, seed=None, add_to_container=None):
-        super(AssociativeMemory, self).__init__(label, seed, add_to_container)
+                 label=None, **module_kwargs):
+        super(AssociativeMemory, self).__init__(label=label, **module_kwargs)
 
         if input_keys is None:
             input_keys = input_vocab.keys
@@ -88,9 +96,7 @@ class AssociativeMemory(Module):
             self.am = AssocMem(input_vectors=input_vectors,
                                output_vectors=output_vectors,
                                threshold=threshold,
-                               inhibitable=inhibitable,
-                               label=label, seed=seed,
-                               add_to_container=add_to_container)
+                               inhibitable=inhibitable)
 
             if default_output_vector is not None:
                 self.am.add_default_output_vector(default_output_vector)

--- a/nengo/spa/tests/test_assoc_mem.py
+++ b/nengo/spa/tests/test_assoc_mem.py
@@ -30,7 +30,7 @@ def test_am_spa_interaction(Simulator, seed, rng):
                                  threshold=0.5,
                                  inhibitable=True,
                                  wta_output=True,
-                                 threshold_output=True)
+                                 cleanup_output=True)
 
         nengo.spa.Actions('am = buf').build()
 


### PR DESCRIPTION
Rewrite of the AssociativeMemory code to support new features:
- Added input utilities output node.
- Utility mapping functions are now specifiable when creating an output mapping. This allows the user to specify utility mappings other than the default filtered_step_func mapping.
- Created several utility mapping helper functions
- Renamed 'threshold_output' to 'cleanup_output' to better illustrate the operation of that function.
- Improved documentation
- Updated test_assoc_mem.py to accommodate changes to assoc_mem.py code.
- Removed extra synapses on connections from nodes to ensembles.
