### PR TITLE
Fixed deprecated filt and filtfilt functions

### DIFF
--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -351,7 +351,7 @@ def filt(signal, synapse, dt, axis=0, x0=None, copy=True):
     Deprecated: use ``synapse.filt`` instead.
     """
     warnings.warn("Use ``synapse.filt`` instead", DeprecationWarning)
-    synapse.filt(signal, dt=dt, axis=axis, y0=x0, copy=copy)
+    return synapse.filt(signal, dt=dt, axis=axis, y0=x0, copy=copy)
 
 
 def filtfilt(signal, synapse, dt, axis=0, x0=None, copy=True):
@@ -360,7 +360,7 @@ def filtfilt(signal, synapse, dt, axis=0, x0=None, copy=True):
     Deprecated: use ``synapse.filtfilt`` instead.
     """
     warnings.warn("Use ``synapse.filtfilt`` instead", DeprecationWarning)
-    synapse.filtfilt(signal, dt=dt, axis=axis, y0=x0, copy=copy)
+    return synapse.filtfilt(signal, dt=dt, axis=axis, y0=x0, copy=copy)
 
 
 class SynapseParam(Parameter):


### PR DESCRIPTION
Looks like a ```return``` got left out of https://github.com/nengo/nengo/commit/3fbbba9917e78e4a0ae4d3cdefa5dbeeff41b0d8

This allows the deprecated ```nengo.synapse.filt``` and ```nengo.synapse.filtfilt``` functions to actually return their filtered results, rather than throwing them away and returning None.

