### PR TITLE
Disable IPython history in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,10 @@ install:
 
 # Run the tests
 script:
+  - mkdir -p "$HOME/.ipython/profile_default"
+  - "echo 'c.HistoryAccessor.enabled = False\n' > $HOME/.ipython/profile_default/ipython_config.py"
   - if [[ -n $SETUP_CMD ]]; then
-      python -c "import numpy; numpy.show_config()"
+      python -c "import numpy; numpy.show_config()";
       python setup.py -q install;
       eval python setup.py "$SETUP_CMD";
     fi


### PR DESCRIPTION
We are getting sporadic errors in TravisCI when two threads try to access the IPython history when exporting a notebook to a Python script. This disables the IPython history entirely.

This doesn't actually solve all of the problems; e.g., see [this build](https://travis-ci.org/nengo/nengo/jobs/118276959) which gives an error in an `atexit` function. However, I believe this error won't cause builds to fail, and is just a bug in IPython, which I will file upstream. This PR should fix the error that actually causes builds to fail.