### PR TITLE
Enable CI testing on Windows with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Miniconda"
+    - PYTHON: "C:\\Miniconda3"
+    - PYTHON: "C:\\Miniconda35-x64"
+
+init:
+  - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+
+install:
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda install numpy matplotlib jupyter pytest flake8
+
+build: false  # Not a C# project
+
+test_script:
+  - python setup.py -q install
+  - python setup.py test -a "nengo -v --durations=20"
+  - flake8 -v nengo

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -299,7 +299,7 @@ def test_dist_transform(Simulator, seed):
         conn = nengo.Connection(a, b)
 
     sim = Simulator(net)
-    assert np.all(w == sim.model.params[conn].weights)
+    assert np.allclose(w, sim.model.params[conn].weights)
 
 
 def test_weights(Simulator, nl, plt, seed):

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -322,8 +322,8 @@ def test_noise_gen(Simulator, nl_nodirect, seed, plt):
 
     assert np.all(sim.data[pos_p] >= sim.data[normal_p])
     assert np.all(sim.data[normal_p] >= sim.data[neg_p])
-    assert not np.all(sim.data[normal_p] == sim.data[pos_p])
-    assert not np.all(sim.data[normal_p] == sim.data[neg_p])
+    assert not np.allclose(sim.data[normal_p], sim.data[pos_p])
+    assert not np.allclose(sim.data[normal_p], sim.data[neg_p])
 
 
 def test_noise_copies_ok(Simulator, nl_nodirect, seed, plt):

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -208,7 +208,7 @@ def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt):
     plt.xlabel("Time (s)")
     plt.ylabel("Weights")
 
-    assert not np.all(sim.data[weights_p][0] == sim.data[weights_p][-1])
+    assert not np.allclose(sim.data[weights_p][0], sim.data[weights_p][-1])
 
 
 def learning_net(learning_rule, net, rng):
@@ -264,7 +264,7 @@ def test_dt_dependence(Simulator, plt, learning_rule, seed, rng):
     plt.ylabel("Presynaptic activity")
 
     assert np.allclose(trans_data[0], trans_data[1], atol=3e-3)
-    assert not np.all(sim.data[trans_p][0] == sim.data[trans_p][-1])
+    assert not np.allclose(sim.data[trans_p][0], sim.data[trans_p][-1])
 
 
 @pytest.mark.parametrize('learning_rule', [nengo.PES, nengo.BCM, nengo.Oja])
@@ -294,10 +294,10 @@ def test_reset(Simulator, learning_rule, plt, seed, rng):
     plt.plot(first_t_trans, first_trans_p[..., 0], c='b')
     plt.plot(sim.trange(dt=0.01), sim.data[trans_p][..., 0], c='g')
 
-    assert np.all(sim.trange() == first_t)
-    assert np.all(sim.trange(dt=0.01) == first_t_trans)
-    assert np.all(sim.data[activity_p] == first_activity_p)
-    assert np.all(sim.data[trans_p] == first_trans_p)
+    assert np.allclose(sim.trange(), first_t)
+    assert np.allclose(sim.trange(dt=0.01), first_t_trans)
+    assert np.allclose(sim.data[activity_p], first_activity_p)
+    assert np.allclose(sim.data[trans_p], first_trans_p)
 
 
 def test_learningruletypeparam():

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -126,7 +126,7 @@ def test_lif_zero_tau_ref(Simulator):
         p = nengo.Probe(ens.neurons)
     with Simulator(m) as sim:
         sim.run(0.02)
-    assert np.all(sim.data[p][1:] == max_rate)
+    assert np.allclose(sim.data[p][1:], max_rate)
 
 
 def test_alif_rate(Simulator, plt):
@@ -341,8 +341,8 @@ def test_reset(Simulator, nl_nodirect, seed, rng):
         sim.reset()
         sim.run(0.3)
 
-    assert np.all(sim.trange() == first_t)
-    assert np.all(sim.data[square_p] == first_square_p)
+    assert np.allclose(sim.trange(), first_t)
+    assert np.allclose(sim.data[square_p], first_square_p)
 
 
 def test_neurontypeparam():

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -228,7 +228,7 @@ def test_reset(Simulator, seed):
         y = np.array(sim.data[up])
 
     assert x.shape == y.shape
-    assert (x == y).all()
+    assert np.allclose(x, y)
 
 
 def test_frozen():

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -61,11 +61,6 @@ else:
         return s
 
 
-assert configparser
-assert pickle
-assert TextIO
-
-
 def is_integer(obj):
     return isinstance(obj, int_types + (np.integer,))
 

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -31,11 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import absolute_import
 
+import io
 import os
 import platform
-import sys
 import time
-import unicodedata
 import uuid
 
 import numpy as np
@@ -176,16 +175,14 @@ def export_py(nb, dest_path=None):
     """
     exporter = PythonExporter()
     body, resources = exporter.from_notebook_node(nb)
-    if sys.version_info[0] == 2:
-        body = unicodedata.normalize('NFKD', body).encode('ascii', 'ignore')
     # We'll remove %matplotlib inline magic, but leave the rest
-    body = body.replace("get_ipython().magic(u'matplotlib inline')\n", "")
-    body = body.replace("get_ipython().magic('matplotlib inline')\n", "")
+    body = body.replace(u"get_ipython().magic(u'matplotlib inline')\n", u"")
+    body = body.replace(u"get_ipython().magic('matplotlib inline')\n", u"")
     # Also remove the IPython notebook extension
-    body = body.replace("get_ipython().magic(u'load_ext nengo.ipynb')\n", "")
-    body = body.replace("get_ipython().magic('load_ext nengo.ipynb')\n", "")
+    body = body.replace(u"get_ipython().magic(u'load_ext nengo.ipynb')\n", u"")
+    body = body.replace(u"get_ipython().magic('load_ext nengo.ipynb')\n", u"")
     if dest_path is not None:
-        with open(dest_path, 'w') as f:
+        with io.open(dest_path, 'w', encoding='utf-8') as f:
             f.write(body)
     return body
 
@@ -234,7 +231,7 @@ def export_html(nb, dest_path=None, image_dir=None, image_rel_dir=None):
         html_out = export_images(resources, image_dir, image_rel_dir, html_out)
 
     if dest_path is not None:
-        with open(dest_path, 'w') as f:
+        with io.open(dest_path, 'w', encoding='utf-8') as f:
             f.write(html_out)
     return html_out
 

--- a/nengo/utils/magic.py
+++ b/nengo/utils/magic.py
@@ -144,9 +144,6 @@ class ObjectProxy(with_metaclass(ObjectProxyMeta)):
             type(self.__wrapped__).__name__,
             id(self.__wrapped__))
 
-    def __unicode__(self):
-        return unicode(self.__wrapped__)
-
 
 class BoundFunctionWrapper(ObjectProxy):
     """A descriptor to emulate a bound function.

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -191,8 +191,10 @@ class TerminalProgressBar(ProgressBar):
         line = "[{{}}] ETA: {eta}".format(
             eta=timestamp2timedelta(progress.eta()))
         percent_str = " {}% ".format(int(100 * progress.progress))
-
-        width, _ = get_terminal_size()
+        try:
+            width, _ = get_terminal_size()
+        except:
+            width = 80
         progress_width = max(0, width - len(line))
         progress_str = (
             int(progress_width * progress.progress) * "#").ljust(
@@ -207,7 +209,10 @@ class TerminalProgressBar(ProgressBar):
         return '\r' + line.format(progress_str)
 
     def _get_finished_line(self, progress):
-        width, _ = get_terminal_size()
+        try:
+            width, _ = get_terminal_size()
+        except:
+            width = 80
         line = "{} finished in {}.".format(
             self.task,
             timestamp2timedelta(progress.elapsed_seconds())).ljust(width)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ ignore =
     *.ipynb_checkpoints/*
 
 [flake8]
-exclude = __init__.py
+exclude = __init__.py, compat.py
 ignore = E123,E133,E226,E241,E242,E731,W503
 max-complexity = 10
 


### PR DESCRIPTION
I figured this would be helpful for ensuring #946 works well on Windows.

This PR ensures that all tests pass on Windows using AppVeyor. Right now, we're using conda (AppVeyor has 2.7, 3.4 and 3.5 versions of Miniconda installed by default). With the first two commits, the builds succeed [for all versions but one](https://ci.appveyor.com/project/nengo/nengo/build/1.0.7). Python 3.5 (32-bit) fails for `test_reset` with `LIFRate` neurons (see [here](https://ci.appveyor.com/project/nengo/nengo/build/1.0.7/job/9l62j27yo3ub85sm#L1002)). Any idea why this might be @hunse?

One thing up for discussion in this PR is how many test environments we actually want to run with AppVeyor.

The way I see it, TravisCI should be where we test as many situations as possible (since it allows us to run tests in parallel, which AppVeyor does not), while AppVeyor should be used just to make sure that things work in Windows. Still, I feel like there are enough Windows-specific differences between Python 2 and Python 3. So, I think I would prefer to test with the latest version of Python 2 and Python 3, but not all versions available, which is what is currently done in this PR.

The alternatives are to only run one test (which I think should be the latest version, so Python 3.5 right now), all tests (the six that are running right now), some other subset of the six tests (e.g., 32-bit and 64-bit Python 3.5), or to mirror exactly in AppVeyor what we do in TravisCI.

As I said above, testing in AppVeyor takes quite a bit longer than TravisCI (since you can use cool docker-based infrastructure in Windows), so I would err on the side of fewer tests.