### PR TITLE
Learning rule error size is connection size out

### DIFF
--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -450,14 +450,9 @@ class LearningRule(object):
         elif self.error_type == 'scalar':
             return 1
         elif self.error_type == 'decoded':
-            if isinstance(self.connection.pre_obj, Neurons):
-                return self.connection.pre_obj.ensemble.dimensions
-            elif isinstance(self.connection.pre_obj, Ensemble):
-                return self.connection.size_out
-            else:
-                tname = self.connection.pre_obj.__class__.__name__
-                raise ValidationError("Cannot learn on type %r" % tname,
-                                      attr='size_in', obj=self)
+            return (self.connection.post_obj.ensemble.size_in
+                    if isinstance(self.connection.post_obj, Neurons) else
+                    self.connection.size_out)
         elif self.error_type == 'neuron':
             raise NotImplementedError()
         else:


### PR DESCRIPTION
As discussed in #957, our error signal should always be in the
dimensionality of the transform output. This fixes the learning
rule error size to adhere to that.

Even though this removes a ValidationError, we're already checking that the pre object is an Ensemble or Neurons in ConnectionLearningRuleTypeParam above, so I think we're fine.