### PR TITLE
Respect input dtype in Synapse.filt

### DIFF
--- a/nengo/base.py
+++ b/nengo/base.py
@@ -209,11 +209,12 @@ class Process(FrozenObject):
     default_dt = NumberParam('default_dt', low=0, low_open=True)
     seed = IntParam('seed', low=0, high=maxint, optional=True)
 
-    def __init__(self, default_size_in=0, default_size_out=1, seed=None):
+    def __init__(self, default_size_in=0, default_size_out=1,
+                 default_dt=0.001, seed=None):
         super(Process, self).__init__()
         self.default_size_in = default_size_in
         self.default_size_out = default_size_out
-        self.default_dt = 0.001
+        self.default_dt = default_dt
         self.seed = seed
 
     def get_rng(self, rng):

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -33,8 +33,8 @@ class WhiteNoise(Process):
     dist = DistributionParam('dist')
     scale = BoolParam('scale')
 
-    def __init__(self, dist=Gaussian(mean=0, std=1), scale=True, seed=None):
-        super(WhiteNoise, self).__init__(seed=seed)
+    def __init__(self, dist=Gaussian(mean=0, std=1), scale=True, **kwargs):
+        super(WhiteNoise, self).__init__(default_size_in=0, **kwargs)
         self.dist = dist
         self.scale = scale
 
@@ -85,8 +85,8 @@ class FilteredNoise(Process):
     scale = BoolParam('scale')
 
     def __init__(self, synapse=Lowpass(tau=0.005), synapse_kwargs={},
-                 dist=Gaussian(mean=0, std=1), scale=True, seed=None):
-        super(FilteredNoise, self).__init__(seed=seed)
+                 dist=Gaussian(mean=0, std=1), scale=True, **kwargs):
+        super(FilteredNoise, self).__init__(default_size_in=0, **kwargs)
         self.synapse = synapse
         self.synapse_kwargs = synapse_kwargs
         self.dist = dist
@@ -128,11 +128,11 @@ class BrownNoise(FilteredNoise):
     seed : int, optional
         Random number seed. Ensures noise will be the same each run.
     """
-    def __init__(self, dist=Gaussian(mean=0, std=1), seed=None):
+    def __init__(self, dist=Gaussian(mean=0, std=1), **kwargs):
         super(BrownNoise, self).__init__(
             synapse=LinearFilter([1], [1, 0]),
             synapse_kwargs=dict(method='euler'),
-            dist=dist, seed=seed)
+            dist=dist, **kwargs)
 
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self.dist)
@@ -166,8 +166,8 @@ class WhiteSignal(Process):
     high = NumberParam('high', low=0, low_open=True)
     rms = NumberParam('rms', low=0, low_open=True)
 
-    def __init__(self, period, high, rms=0.5, seed=None):
-        super(WhiteSignal, self).__init__(seed=seed)
+    def __init__(self, period, high, rms=0.5, **kwargs):
+        super(WhiteSignal, self).__init__(default_size_in=0, **kwargs)
         self.period = period
         self.high = high
         self.rms = rms
@@ -227,11 +227,11 @@ class PresentInput(Process):
     inputs = NdarrayParam('inputs', shape=('...',))
     presentation_time = NumberParam('presentation_time', low=0, low_open=True)
 
-    def __init__(self, inputs, presentation_time):
+    def __init__(self, inputs, presentation_time, **kwargs):
         self.inputs = inputs
         self.presentation_time = presentation_time
         super(PresentInput, self).__init__(
-            default_size_out=self.inputs[0].size)
+            default_size_in=0, default_size_out=self.inputs[0].size, **kwargs)
 
     def make_step(self, shape_in, shape_out, dt, rng):
         assert shape_in == (0,)

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -15,8 +15,10 @@ from nengo.utils.numpy import as_shape
 class Synapse(Process):
     """Abstract base class for synapse objects"""
 
-    def __init__(self, analog=True):
-        super(Synapse, self).__init__()
+    def __init__(self, analog=True, **kwargs):
+        kwargs.setdefault('default_size_in', 1)
+        kwargs.setdefault('default_size_out', kwargs['default_size_in'])
+        super(Synapse, self).__init__(**kwargs)
         self.analog = analog
 
     def filt(self, x, dt=None, axis=0, y0=None, copy=True, filtfilt=False):
@@ -98,8 +100,8 @@ class LinearFilter(Synapse):
     den = NdarrayParam('den', shape='*')
     analog = BoolParam('analog')
 
-    def __init__(self, num, den, analog=True):
-        super(LinearFilter, self).__init__(analog=analog)
+    def __init__(self, num, den, analog=True, **kwargs):
+        super(LinearFilter, self).__init__(analog=analog, **kwargs)
         self.num = num
         self.den = den
 
@@ -254,8 +256,8 @@ class Lowpass(LinearFilter):
     """
     tau = NumberParam('tau', low=0)
 
-    def __init__(self, tau):
-        super(Lowpass, self).__init__([1], [tau, 1])
+    def __init__(self, tau, **kwargs):
+        super(Lowpass, self).__init__([1], [tau, 1], **kwargs)
         self.tau = tau
 
     def __repr__(self):
@@ -292,8 +294,8 @@ class Alpha(LinearFilter):
     """
     tau = NumberParam('tau', low=0)
 
-    def __init__(self, tau):
-        super(Alpha, self).__init__([1], [tau**2, 2*tau, 1])
+    def __init__(self, tau, **kwargs):
+        super(Alpha, self).__init__([1], [tau**2, 2*tau, 1], **kwargs)
         self.tau = tau
 
     def __repr__(self):
@@ -318,8 +320,8 @@ class Triangle(Synapse):
     """
     t = NumberParam('t', low=0)
 
-    def __init__(self, t):
-        super(Triangle, self).__init__(analog=True)
+    def __init__(self, t, **kwargs):
+        super(Triangle, self).__init__(analog=True, **kwargs)
         self.t = t
 
     def __repr__(self):

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -19,15 +19,15 @@ class Synapse(Process):
         super(Synapse, self).__init__()
         self.analog = analog
 
-    def filt(self, x, dt=1., axis=0, y0=None, copy=True, filtfilt=False):
+    def filt(self, x, dt=None, axis=0, y0=None, copy=True, filtfilt=False):
         """Filter ``x`` with this synapse.
 
         Parameters
         ----------
         x : array_like
             The signal to filter.
-        dt : float, optional (default: 1)
-            The time-step of the input signal for analog synapses (default: 1).
+        dt : float, optional (default: ``self.default_dt``)
+            The time-step of the input signal for analog synapses.
         axis : integer, optional (default: 0)
             The axis along which to filter.
         y0 : array_like, optional (default: x0)
@@ -41,10 +41,7 @@ class Synapse(Process):
         """
         # This function is very similar to `Process.apply`, but allows for
         # a) filtering along any axis, and b) zero-phase filtering (filtfilt).
-
-        if self.analog and dt is None:
-            raise ValueError("`dt` must be provided for analog synapses.")
-
+        dt = self.default_dt if dt is None else dt
         filtered = np.array(x, copy=copy)
         filt_view = np.rollaxis(filtered, axis=axis)  # rolled view on filtered
 


### PR DESCRIPTION
This ensures that the output dtype is the same as the input dtype,
and fixes some tests that were failing in Nengo OCL.