### PR TITLE
Ensure cache doesn't crash Nengo

### DIFF
--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -278,7 +278,7 @@ def test_present_input(Simulator, rng):
         sim.run(1.0)
 
     t = sim.trange()
-    i = np.floor((t - sim.dt) / pres_time + 1e-7) % n
+    i = (np.floor((t - sim.dt) / pres_time + 1e-7) % n).astype(int)
     y = sim.data[up].reshape(len(t), c, ni, nj)
     for k, [ii, image] in enumerate(zip(i, y)):
         assert np.allclose(image, images[ii], rtol=1e-4, atol=1e-7), (k, ii)


### PR DESCRIPTION
I had an issue in which Nengo crashed opening the cache's index file. I had just run some examples in Python 3, which seems to save with pickle protocol 4; when I ran the same example in Python 2, I got a `ValueError` that the protocol was too high.

This PR patches that by effectively disabling the cache if we encounter a `ValueError`. But this isn't a great solution because it means you'll *never* be able to use the cache as it'll keep hitting the `ValueError`.

A few ways forward that I can see:

1. Detect a wrong pickle version earlier in the process so the cache can be invalidated and started over.
2. Use a format other than pickle (json, csv, npz, custom plaintext) so that the Python version doesn't matter (the NCO format should work the same regardless of Python version right?)

If we can implement any of these quickly, then I'd prefer to go with that than this PR. Especially pinging @jgosmann for thoughts / opinions!