### PR TITLE
Updated parameter definition to new syntax

### DIFF
--- a/nengo/spa/__init__.py
+++ b/nengo/spa/__init__.py
@@ -11,5 +11,5 @@ from .pointer import SemanticPointer
 from .spa import SPA
 from .state import State
 from .thalamus import Thalamus
-from .utils import enable_spa_params, similarity
+from .utils import similarity
 from .vocab import Vocabulary

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -6,7 +6,6 @@ import nengo
 from nengo.exceptions import SpaModuleError
 from nengo.spa.vocab import Vocabulary
 from nengo.spa.module import Module
-from nengo.spa.utils import enable_spa_params
 from nengo.utils.compat import iteritems
 
 
@@ -82,7 +81,6 @@ class SPA(nengo.Network):
                  vocabs=None):
         super(SPA, self).__init__(label, seed, add_to_container)
         vocabs = [] if vocabs is None else vocabs
-        enable_spa_params(self)
         self._modules = {}
         self._default_vocabs = {}
 
@@ -111,11 +109,9 @@ class SPA(nengo.Network):
             for k, (obj, v) in iteritems(value.inputs):
                 if type(v) == int:
                     value.inputs[k] = (obj, self.get_default_vocab(v))
-                self.config[obj].vocab = value.inputs[k][1]
             for k, (obj, v) in iteritems(value.outputs):
                 if type(v) == int:
                     value.outputs[k] = (obj, self.get_default_vocab(v))
-                self.config[obj].vocab = value.outputs[k][1]
 
             value.on_add(self)
 

--- a/nengo/spa/utils.py
+++ b/nengo/spa/utils.py
@@ -8,21 +8,6 @@ from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_iterable
 
 
-def enable_spa_params(model):
-    """Enables the SPA specific parameters on a model.
-
-    Parameters
-    ----------
-    model : Network
-        Model to activate SPA specific parameters for.
-    """
-    from nengo.spa.vocab import VocabularyParam
-
-    for obj_type in [nengo.Node, nengo.Ensemble]:
-        model.config[obj_type].set_param(
-            'vocab', VocabularyParam('vocab', None, optional=True))
-
-
 def similarity(data, vocab, normalize=False):
     """Return the similarity between some data and the vocabulary.
 

--- a/nengo/spa/utils.py
+++ b/nengo/spa/utils.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-import nengo
 import nengo.utils.numpy as npext
 from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_iterable

--- a/nengo/spa/utils.py
+++ b/nengo/spa/utils.py
@@ -20,7 +20,7 @@ def enable_spa_params(model):
 
     for obj_type in [nengo.Node, nengo.Ensemble]:
         model.config[obj_type].set_param(
-            'vocab', VocabularyParam('vocab', optional=True))
+            'vocab', VocabularyParam('vocab', None, optional=True))
 
 
 def similarity(data, vocab, normalize=False):


### PR DESCRIPTION
I'm not sure why this didn't cause an error before, but this update is needed due to adding the ```name``` into the Parameter system.