### PR TITLE
Distributions for neuron parameters

### DIFF
--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -528,6 +528,17 @@ class DistributionParam(Parameter):
 
     equatable = True
 
+    def __init__(self, name, default=Unconfigurable,
+                 optional=False, readonly=None, cast_number=False):
+        super().__init__(name, default=default, optional=optional,
+                         readonly=readonly)
+        self.cast_number = cast_number
+
+    def __set__(self, instance, value):
+        if self.cast_number and npext.is_number(value):
+            value = Choice([value])
+        super().__set__(instance, value)
+
     def coerce(self, instance, dist):
         self.check_type(instance, dist, Distribution)
         return super().coerce(instance, dist)


### PR DESCRIPTION
Working on allowing distributions for neuron parameters like `AdaptiveLIF.tau_n`, as requested in #1026.

This will require a number of changes, including making these into distribution parameters that get sampled when the neuron is built, and get passed to `gain_bias` and `step_math` as needed. One option is to package these together with `gain` and `bias` and just have a `params` object that gets passed around together (or don't package in `gain` and `bias`, but still have such an object.

We currently do checking to make sure e.g. `tau_rc > 0`, and it would be nice to have this for distributions. I think this is difficult/impossible to do exhaustively for distributions, but we could have either validation for some distributions when they're passed (e.g. Uniform, Choice), or validation once the samples are generated in the builder, or both.
