### PR TITLE
Implement SupportDefaultsMixin.

### DIFF
--- a/nengo/base.py
+++ b/nengo/base.py
@@ -1,15 +1,13 @@
-import sys
 import warnings
 
 import numpy as np
 
-from nengo.config import Config
+from nengo.config import SupportDefaultsMixin
 from nengo.exceptions import ValidationError
 from nengo.params import (
-    Default, FrozenObject, is_param, IntParam, NumberParam, Parameter,
-    StringParam, Unconfigurable)
-from nengo.rc import rc
-from nengo.utils.compat import is_integer, range, reraise, with_metaclass
+    FrozenObject, is_param, IntParam, NumberParam, Parameter, StringParam,
+    Unconfigurable)
+from nengo.utils.compat import is_integer, range, with_metaclass
 from nengo.utils.numpy import as_shape, maxint
 
 
@@ -34,7 +32,7 @@ class NetworkMember(type):
         return inst
 
 
-class NengoObject(with_metaclass(NetworkMember)):
+class NengoObject(with_metaclass(NetworkMember, SupportDefaultsMixin)):
     """A base class for Nengo objects.
 
     Parameters
@@ -71,17 +69,7 @@ class NengoObject(with_metaclass(NetworkMember)):
                 "Creating new attribute '%s' on '%s'. "
                 "Did you mean to change an existing attribute?" % (name, self),
                 SyntaxWarning)
-        if val is Default:
-            val = Config.default(type(self), name)
-
-        if rc.getboolean('exceptions', 'simplified'):
-            try:
-                super(NengoObject, self).__setattr__(name, val)
-            except ValidationError:
-                exc_info = sys.exc_info()
-                reraise(exc_info[0], exc_info[1], None)
-        else:
-            super(NengoObject, self).__setattr__(name, val)
+        super(NengoObject, self).__setattr__(name, val)
 
     def __str__(self):
         return self._str(

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -13,10 +13,12 @@ http://nbviewer.ipython.org/urls/gist.github.com/ChrisBeaumont/5758381/raw/descr
 """
 
 import inspect
+import sys
 
-from nengo.exceptions import ConfigError
-from nengo.params import is_param
-from nengo.utils.compat import itervalues
+from nengo.exceptions import ConfigError, ValidationError
+from nengo.params import Default, is_param
+from nengo.rc import rc
+from nengo.utils.compat import itervalues, reraise
 from nengo.utils.threading import ThreadLocalStack
 
 
@@ -348,3 +350,27 @@ class Config(object):
             raise TypeError("configures() takes 1 or more arguments (0 given)")
         for klass in classes:
             self.params[klass] = ClassParams(klass)
+
+
+class SupportDefaultsMixin(object):
+    """Mixin to support assigning ``Default`` to parameters.
+
+    Implements ``__setattr__`` to do so. If the inheriting class overrides this
+    method, it has to call the mixins `__setattr__`.
+
+    This mixin will also simplify the exception if the parameter value is
+    invalid given the `simplified` rc option is set
+    """
+
+    def __setattr__(self, name, val):
+        if val is Default:
+            val = Config.default(type(self), name)
+
+        if rc.getboolean('exceptions', 'simplified'):
+            try:
+                super(SupportDefaultsMixin, self).__setattr__(name, val)
+            except ValidationError:
+                exc_info = sys.exc_info()
+                reraise(exc_info[0], exc_info[1], None)
+        else:
+            super(SupportDefaultsMixin, self).__setattr__(name, val)


### PR DESCRIPTION
This makes it easy for other classes than NengoObject to support the
`Default` parameter value.

I'm finding that I want to have this in SPA modules too and with this change I can prevent code duplication.