### PR TITLE
Do not run test_process.test_time on all backends

### DIFF
--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -33,7 +33,7 @@ class TimeProcess(Process):
             return lambda t, x: [t * np.sum(x)] * size_out
 
 
-def test_time(Simulator):
+def test_time(RefSimulator):
     trun = 1.
     c = 2.
     process = TimeProcess()
@@ -47,7 +47,7 @@ def test_time(Simulator):
         nengo.Connection(q, v, synapse=None)
         vp = nengo.Probe(v)
 
-    with Simulator(model) as sim:
+    with RefSimulator(model) as sim:
         sim.run(trun)
 
     nt = len(sim.trange())


### PR DESCRIPTION
It doesn't make sense for all backends to support the custom
TimeProcess process.