### PR TITLE
Added ShapeParam to store shapes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Release History
   discoverable for other Python packages. In the future all backends should
   declare an entry point accordingly.
   (`#1127 <https://github.com/nengo/nengo/pull/1127>`_)
+- Added ``ShapeParam`` to store array shapes.
+  (`#1045 <https://github.com/nengo/nengo/pull/1045>`_)
 
 **Bug fixes**
 

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -292,6 +292,30 @@ class TupleParam(Parameter):
         super(TupleParam, self).validate(instance, value)
 
 
+class ShapeParam(TupleParam):
+    """A parameter where the value is a tuple of integers."""
+
+    equatable = True
+
+    def __init__(self, name, default=Unconfigurable, length=None, low=0,
+                 optional=False, readonly=None):
+        super(ShapeParam, self).__init__(name, default=default, length=length,
+                                         optional=optional, readonly=readonly)
+        self.low = low
+
+    def validate(self, instance, value):
+        super(ShapeParam, self).validate(instance, value)
+        for i, v in enumerate(value):
+            if not is_integer(v):
+                raise ValidationError("Element %d must be an int (got type %r)"
+                                      % (i, type(v).__name__),
+                                      attr=self.name, obj=instance)
+            if self.low is not None and v < self.low:
+                raise ValidationError(
+                    "Element %d must be >= %d (got %d)" % (i, self.low, v),
+                    attr=self.name, obj=instance)
+
+
 class DictParam(Parameter):
     """A parameter where the value is a dictionary."""
 

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -195,6 +195,40 @@ def test_enumparam():
         inst.ep = 3
 
 
+def test_tupleparam():
+    class Test(object):
+        tp = params.TupleParam('tp', default=(0, 0, 0))
+        tp3 = params.TupleParam('tp3', default=(0, 0, 0), length=3)
+
+    inst = Test()
+    inst.tp = (1, 2, 3)
+    inst.tp = (1, 2, 3, 4)
+    inst.tp3 = (1, 2, 3)
+    inst.tp3 = [1.2, 2.3, 3.4]
+    with pytest.raises(ValidationError):
+        inst.tp = 1
+    with pytest.raises(ValidationError):
+        inst.tp3 = (1, 2)
+    with pytest.raises(ValidationError):
+        inst.tp3 = (1, 2, 3, 4)
+
+
+def test_shapeparam():
+    class Test(object):
+        sp2 = params.ShapeParam('sp2', default=(0, 0), length=2, low=None)
+        sp3 = params.ShapeParam('sp3', default=(0, 0, 0), length=3)
+
+    inst = Test()
+    inst.sp2 = (-1, 2)
+    inst.sp3 = (0, 2, 3)
+    with pytest.raises(ValidationError):
+        inst.sp2 = (1, 2, 3)
+    with pytest.raises(ValidationError):
+        inst.sp3 = (-1, 2, 3)
+    with pytest.raises(ValidationError):
+        inst.sp3 = (1, 2.0, 3)
+
+
 def test_dictparam():
     """DictParams must be dictionaries."""
     class Test(object):


### PR DESCRIPTION
A variation of TupleParam that is specialized to storing shapes. Allows checking for the length of the shape, that all elements are ints (or castable to ints), and ensuring all values are greater than a given value (often 0 or 1).