### PR TITLE
WIP: simplified config

### DIFF
--- a/nengo/config.py
+++ b/nengo/config.py
@@ -21,227 +21,111 @@ from nengo.rc import rc
 from nengo.utils.threading import ThreadLocalStack
 
 
-class ClassParams:
-    """A class to store extra parameters and defaults on configured classes.
+class KeyAccessor:
+    def __init__(self, config, key):
+        self._config = config
+        self._key = key
 
-    This is used by `.Config` to associate defaults and new `.Parameter`
-    instances with existing objects. It should not be instantiated outside of
-    `.Config.configures`.
+        self._values = {}
+        self._params = {}
 
-    Parameters
-    ----------
-    configures : class
-        The class with which to associate new defaults and parameters.
-    """
+        self._is_class = inspect.isclass(key)
+        self._key_class = key if inspect.isclass(key) else type(key)
 
-    def __init__(self, configures):
-        assert inspect.isclass(configures)
-        self._configures = configures
-        self._extra_params = {}
-        self._default_params = tuple(
-            attr for attr in dir(self._configures)
-            if is_param(getattr(self._configures, attr)))
-
-    def __contains__(self, key):
-        return self in self.get_param(key)
-
-    def __delattr__(self, key):
-        if key.startswith("_"):
-            super().__delattr__(key)
-        else:
-            self.get_param(key).del_default(self)
-
-    def __getattr__(self, key):
-        if key.startswith("_"):
-            # If we get here, then that attribute hasn't been set
-            raise AttributeError("%r object has no attribute %r"
-                                 % (type(self).__name__, key))
-        return self.get_param(key).get_default(self)
-
-    def __setattr__(self, key, value):
-        """Overridden to handle instance descriptors manually.
-
-        Everything not starting with _ is assumed to be a parameter.
-        """
-        if key.startswith("_"):
-            super().__setattr__(key, value)
-        else:
-            param = self.get_param(key)
-            if not param.configurable:
-                raise ConfigError("Parameter '%s' is not configurable" % key)
-            param.set_default(self, value)
-
-    def __getstate__(self):
-        state = {'_configures': self._configures,
-                 '_default_params': self._default_params,
-                 '_extra_params': self._extra_params}
-
-        # Store all of the things we set in the params
-        for attr in self.params:
-            param = self.get_param(attr)
-            if self in param:
-                state[attr] = param.get_default(self)
-
-        return state
-
-    def __setstate__(self, state):
-        self._configures = state['_configures']
-        self._default_params = state['_default_params']
-        self._extra_params = state['_extra_params']
-
-        # Restore all of the things we set in the params
-        for attr in self.params:
-            if attr in state:
-                self.get_param(attr).set_default(self, state[attr])
+    @property
+    def _key_name(self):
+        return self._key.__name__ if self._is_class else str(self._key)
 
     def __str__(self):
-        name = self._configures.__name__
-        lines = ["Parameters configured for %s:" % name]
-        for attr in self.params:
-            if self in self.get_param(attr):
-                lines.append("  %s: %s" % (attr, getattr(self, attr)))
-        if len(lines) > 1:
-            return "\n".join(lines)
+        return "%s(%s)" % (self._key_name,
+                           ', '.join("%s=%s" % (k, v)
+                                     for k, v in self._values.items()))
+
+    def __contains__(self, item):
+        return item in self._values or item in self._params
+
+    def __getattr__(self, item):
+        assert not item.startswith('_')
+
+        # If we have the exact thing, we'll just return it
+        if item in self._values:
+            return self._values[item]
+        elif item in self._params:
+            return self._params[item].default
+
+        # If key is a class return a superclass's ClassParams
+        for cls in self._key_class.__mro__:
+            if item in self._config[cls]:
+                return getattr(self._config[cls], item)
+
+        if self._is_class:
+            return getattr(self._key, item).default
         else:
-            return "No parameters configured for %s." % name
+            raise ConfigError("No entry for this instance")
 
-    def __repr__(self):
-        # Only print defaults if we've configured them
-        params = []
-        filled_defaults = [attr for attr in self.default_params
-                           if self in self.get_param(attr)]
-        for attr in filled_defaults + sorted(self.extra_params):
-            params.append("%s: %s" % (attr, getattr(self, attr)))
+    def __delattr__(self, item):
+        if item not in self:
+            raise ConfigError("No such attribute")
 
-        return "<%s[%s]{%s}>" % (type(self).__name__,
-                                 self._configures.__name__, ", ".join(params))
+        if item in self._values:
+            del self._values[item]
 
-    @property
-    def default_params(self):
-        return self._default_params
+        # if inspect.isclass(key):
+        #     for cls in key.__mro__:
+        #         if item in self._values.get(cls, {}):
+        #             del self._values[cls][item]
 
-    @property
-    def extra_params(self):
-        return tuple(self._extra_params)
+    def __setattr__(self, item, value):
+        if item.startswith('_'):
+            return super().__setattr__(item, value)
 
-    @property
-    def params(self):
-        return self.default_params + self.extra_params
+        for cls in self._key_class.__mro__:
+            param = self._config[cls]._params.get(item, None)
+            if param is not None:
+                self._values[item] = param.coerce(self._key, value)
+                return
 
-    def get_param(self, key):
-        if key in self._extra_params:
-            return self._extra_params[key]
+        if item not in dir(self._key):
+            raise ConfigError("'%s' is not a parameter in %s."
+                              % (item, self._key_name))
 
-        return getattr(self._configures, key)
+        if not self._is_class:
+            raise ConfigError(
+                "Cannot configure the parameter '%s' on an instance "
+                "of '%s'. Please set the attribute directly on the object."
+                % (item, type(self._key).__name__))
+        else:
+            self._values[item] = value
 
-    def set_param(self, key, value):
-        if not is_param(value):
-            raise ConfigError("'%s' is not a parameter" % key)
-        elif key in dir(self._configures):
+    def _empty(self):
+        return (len(self._values) + len(self._params)) == 0
+
+    def _has(self, item):
+        if item in self:
+            return True
+
+        # If key is a class return a superclass's ClassParams
+        if self._is_class:
+            for cls in self._key.__mro__:
+                if item in self._config[cls]:
+                    return True
+
+        return False
+
+    def set_param(self, item, value):
+        if not self._is_class:
+            raise ConfigError(
+                "Cannot set a parameter on an instance of '%s'. Please"
+                " set the attribute directly on the object, or"
+                " configure the parameter on the class."
+                % (type(self._key).__name__,))
+        elif not is_param(value):
+            raise ConfigError("'%s' is not a parameter" % item)
+        elif item in dir(self._key):
             raise ConfigError("'%s' is already a parameter in %s. "
                               "Please choose a different name."
-                              % (key, self._configures.__name__))
-        self._extra_params[key] = value
-
-    def update(self, d):
-        """Sets a number of parameters at once given a dictionary."""
-        for key in d:
-            setattr(self, key, d[key])
-
-
-class InstanceParams:
-    """A class to store parameter value on configured objects.
-
-    In contrast to `.ClassParams`, the only thing that can be done with
-    ``InstanceParams`` is get and set parameter values. Use the corresponding
-    `.ClassParams` to set defaults and create new parameters.
-    """
-
-    def __init__(self, configures, clsparams):
-        self._configures = configures
-        self._clsparams = clsparams
-        assert not inspect.isclass(configures)
-
-    def __contains__(self, key):
-        return self in self._clsparams.get_param(key)
-
-    def __delattr__(self, key):
-        if key.startswith("_"):
-            super().__delattr__(key)
-        elif key in dir(self._configures):
-            # Disallow configuring attributes the instance already has
-            raise ConfigError(
-                "Cannot configure the built-in parameter '%s' on an instance "
-                "of '%s'. Please delete the attribute directly on the object."
-                % (key, type(self._configures).__name__))
-        else:
-            self._clsparams.get_param(key).__delete__(self)
-
-    def __getattr__(self, key):
-        if key in self._clsparams.default_params:
-            raise ConfigError(
-                "Cannot configure the built-in parameter '%s' on an instance "
-                "of '%s'. Please get the attribute directly from the object."
-                % (key, type(self._configures).__name__))
-        param = self._clsparams.get_param(key)
-        if self in param:
-            return param.__get__(self, type(self))
-        return getattr(self._clsparams, key)
-
-    def __setattr__(self, key, value):
-        """Everything not starting with _ is assumed to be a parameter."""
-        if key.startswith("_"):
-            super().__setattr__(key, value)
-        elif key in dir(self._configures):
-            # Disallow configuring attributes the instance already has
-            raise ConfigError(
-                "Cannot configure the built-in parameter '%s' on an instance "
-                "of '%s'. Please set the attribute directly on the object."
-                % (key, type(self._configures).__name__))
-        else:
-            self._clsparams.get_param(key).__set__(self, value)
-
-    def __getstate__(self):
-        state = {}
-
-        for key in iter_params(self._configures):
-            param = self._clsparams.get_param(key)
-            if self in param:
-                state[key] = param.__get__(self, type(self))
-
-        state.update(self.__dict__)
-        return state
-
-    def __setstate__(self, state):
-        for k, v in state.items():
-            setattr(self, k, v)
-
-    def __repr__(self):
-        params = []
-        filled_params = [attr for attr in self._clsparams.params
-                         if self in self._clsparams.get_param(attr)]
-        for attr in filled_params:
-            params.append("%s: %s" % (attr, getattr(self, attr)))
-
-        return "<%s[%s]{%s}>" % (type(self).__name__,
-                                 self._configures, ", ".join(params))
-
-    def __str__(self):
-        lines = ["Parameters set for %s:" % str(self._configures)]
-        for attr in self._clsparams.params:
-            if self in self._clsparams.get_param(attr):
-                lines.append("  %s: %s" % (attr, getattr(self, attr)))
-        return "\n".join(lines)
-
-    def get_param(self, key):
-        raise ConfigError("Cannot get parameters on an instance; use "
-                          "'config[%s].get_param' instead."
-                          % type(self._configures).__name__)
-
-    def set_param(self, key, value):
-        raise ConfigError("Cannot set parameters on an instance; use "
-                          "'config[%s].set_param' instead."
-                          % type(self._configures).__name__)
+                              % (item, self._key_name))
+        self._params[item] = value
 
 
 class Config:
@@ -307,10 +191,8 @@ class Config:
 
     context = ThreadLocalStack(maxsize=100)  # static stack of Config objects
 
-    def __init__(self, *configures):
-        self.params = {}
-        if len(configures) > 0:
-            self.configures(*configures)
+    def __init__(self):
+        self.accessors = {}
 
     def __enter__(self):
         Config.context.append(self)
@@ -332,40 +214,19 @@ class Config:
         raise TypeError("Cannot check if %r is in a config." % (key,))
 
     def __getitem__(self, key):
-        # If we have the exact thing, we'll just return it
-        if key in self.params:
-            return self.params[key]
+        if key not in self.accessors:
+            self.accessors[key] = KeyAccessor(self, key)
 
-        # If key is a class return a superclass's ClassParams
-        if inspect.isclass(key):
-            for cls in key.__mro__:
-                if cls in self.params:
-                    return self.params[cls]
-
-            # If no superclass ClassParams, KeyError
-            raise ConfigError(
-                "Type '%(name)s' is not set up for configuration. "
-                "Call 'configures(%(name)s)' first." % {'name': key.__name__})
-
-        # For new instances, if we configure a class in the mro we're good
-        for cls in type(key).__mro__:
-            if cls in self.params:
-                clsparams = self.params[cls]
-                instparams = InstanceParams(key, clsparams)
-                self.params[key] = instparams
-                return instparams
-
-        # If we don't configure the class, KeyError
-        raise ConfigError(
-            "Type '%(name)s' is not set up for configuration. Call "
-            "configures('%(name)s') first." % {'name': type(key).__name__})
+        return self.accessors[key]
 
     def __repr__(self):
-        classes = [key.__name__ for key in self.params if inspect.isclass(key)]
+        classes = [key.__name__ for key, acc in self.accessors.items()
+                   if acc._is_class and not acc._empty()]
         return "<%s(%s)>" % (type(self).__name__, ', '.join(classes))
 
     def __str__(self):
-        return "\n".join(str(v) for v in self.params.values())
+        return "\n".join(str(acc) for acc in self.accessors.values()
+                         if len(acc._values) > 0)
 
     @staticmethod
     def all_defaults(nengo_cls=None):
@@ -386,20 +247,23 @@ class Config:
         if nengo_cls is None:
             all_configured = set()
             for config in Config.context:
-                all_configured.update(key for key in config.params
-                                      if inspect.isclass(key))
+                all_configured.update(
+                    key for key, acc in config.accessors.items()
+                    if inspect.isclass(key) and not acc._empty())
             lines.extend([Config.all_defaults(key) for key in all_configured])
         else:
+            assert inspect.isclass(nengo_cls)
             lines.append("Current defaults for %s:" % nengo_cls.__name__)
             for attr in dir(nengo_cls):
                 desc = getattr(nengo_cls, attr)
                 if is_param(desc) and desc.configurable:
                     val = Config.default(nengo_cls, attr)
                     lines.append("  %s: %s" % (attr, val))
+
         return "\n".join(lines)
 
     @staticmethod
-    def default(nengo_cls, param):
+    def default(nengo_cls, key):
         """Look up the current default value for a parameter.
 
         The default is found by going through the config stack, from most
@@ -408,29 +272,19 @@ class Config:
         If no default is found there, then the parameter's default value
         is returned.
         """
-
         # Get the descriptor
-        desc = getattr(nengo_cls, param)
+        desc = getattr(nengo_cls, key)
         if not desc.configurable:
             raise ConfigError("Unconfigurable parameters have no defaults. "
                               "Please ensure you are not using the 'Default' "
                               "keyword with an unconfigurable parameter.")
 
         for config in reversed(Config.context):
-
-            # If a default has been set for this config, return it
-            if nengo_cls in config.params and config[nengo_cls] in desc:
-                return getattr(config[nengo_cls], param)
+            if config[nengo_cls]._has(key):
+                return getattr(config[nengo_cls], key)
 
         # Otherwise, return the param default
         return desc.default
-
-    def configures(self, *classes):
-        """Start configuring a particular class and its instances."""
-        if len(classes) == 0:
-            raise TypeError("configures() takes 1 or more arguments (0 given)")
-        for klass in classes:
-            self.params[klass] = ClassParams(klass)
 
 
 class SupportDefaultsMixin:
@@ -442,6 +296,8 @@ class SupportDefaultsMixin:
     This mixin may simplify the exception depending on the value of the
     ``simplified`` rc option.
     """
+
+    # TODO: test
 
     def __setattr__(self, name, val):
         if val is Default:

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -84,7 +84,7 @@ class Network:
     def __init__(self, label=None, seed=None, add_to_container=None):
         self.label = label
         self.seed = seed
-        self._config = self.default_config()
+        self._config = Config()
 
         self.objects = {
             Ensemble: [], Node: [], Connection: [], Network: [], Probe: [],
@@ -122,11 +122,6 @@ class Network:
         else:
             raise NetworkContextError("Objects of type %r cannot be added to "
                                       "networks." % type(obj).__name__)
-
-    @staticmethod
-    def default_config():
-        """Constructs a `~.Config` object for setting defaults."""
-        return Config(Connection, Ensemble, Node, Probe)
 
     def _all_objects(self, object_type):
         """Returns a list of all objects of the specified type."""

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -90,27 +90,23 @@ class Parameter:
         self.optional = optional
         self.readonly = readonly
 
-        # default values set by config system
-        self._defaults = WeakKeyIDDictionary()
-
         # param values set on objects
         self.data = WeakKeyIDDictionary()
 
     def __getstate__(self):
         state = {}
         state.update(self.__dict__)
-        state['_defaults'] = dict(state['_defaults'].items())
         state['data'] = dict(state['data'].items())
         return state
 
     def __setstate__(self, state):
         for k, v in state.items():
-            if k in ['_defaults', 'data']:
+            if k in ('data',):
                 v = WeakKeyIDDictionary(v)
             setattr(self, k, v)
 
     def __contains__(self, key):
-        return key in self.data or key in self._defaults
+        return key in self.data
 
     def __delete__(self, instance):
         del self.data[instance]
@@ -140,18 +136,6 @@ class Parameter:
     @property
     def configurable(self):
         return self.default is not Unconfigurable
-
-    def del_default(self, obj):
-        del self._defaults[obj]
-
-    def get_default(self, obj):
-        return self._defaults.get(obj, self.default)
-
-    def set_default(self, obj, value):
-        if not self.configurable:
-            raise ConfigError("Parameter '%s' is not configurable" % self)
-        self._defaults[obj] = (self.coerce(obj, value) if self.coerce_defaults
-                               else value)
 
     def check_type(self, instance, value, type_):
         if value is not None and not isinstance(value, type_):

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -40,10 +40,10 @@ def test_config_basic():
     del model.config[a].something
     assert model.config[a].something is None
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(ConfigError):
         model.config[a].something_else
         model.config[a2b].something
-    with pytest.raises(AttributeError):
+    with pytest.raises(ConfigError):
         model.config[a].something_else = 1
         model.config[a2b].something = 1
 
@@ -140,7 +140,7 @@ def test_configstack():
         e1 = nengo.Ensemble(5, dimensions=1)
         e2 = nengo.Ensemble(6, dimensions=1)
         excite = nengo.Connection(e1, e2)
-        with nengo.Config(nengo.Connection) as inhib:
+        with nengo.Config() as inhib:
             inhib[nengo.Connection].synapse = nengo.synapses.Lowpass(0.00848)
             inhibit = nengo.Connection(e1, e2)
     assert excite.synapse == nengo.Connection.synapse.default
@@ -153,7 +153,7 @@ def test_config_property():
     """Test that config can't be easily modified."""
     with nengo.Network() as net:
         with pytest.raises(ReadonlyError):
-            net.config = nengo.config.Config()
+            net.config = nengo.Config()
         with pytest.raises(AttributeError):
             del net.config
         assert nengo.config.Config.context[-1] is net.config
@@ -165,7 +165,7 @@ def test_external_class():
         thing = Parameter('thing', default='hey')
 
     inst = A()
-    config = nengo.Config(A)
+    config = nengo.Config()
     config[A].set_param('amount', Parameter('amount', default=1))
 
     # Extra param
@@ -184,7 +184,7 @@ def test_instance_fallthrough():
 
     inst1 = A()
     inst2 = A()
-    config = nengo.Config(A)
+    config = nengo.Config()
     config[A].set_param('amount', Parameter('amount', default=1))
     assert config[A].amount == 1
     assert config[inst1].amount == 1
@@ -210,6 +210,6 @@ def test_contains():
     class A:
         pass
 
-    cfg = nengo.Config(A)
+    cfg = nengo.Config()
     with pytest.raises(TypeError):
         A in cfg


### PR DESCRIPTION
The config system has seemed needlessly complicated to me for a while. Here's an idea of an easier way to do it.

I was prompted by #1043, because this method no longer requires a list of classes to configure when making a `Config` object.

There are still some things that need touching up, but I feel like this covers the vast majority of use cases for the config system. What are the drawbacks to this way of doing things?
