### PR TITLE
Added initial y0 to WhiteSignal process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Release History
   moved to `nengo_extras <https://github.com/nengo/nengo_extras>`_
   under the name ``FastLIF``.
   (`#975 <https://github.com/nengo/nengo/pull/975>`_)
+- Added ``y0`` attribute to ``WhiteSignal``, which adjusts the phase of each
+  dimension to begin with absolute value closest to ``y0``.
+  (`#1064 <https://github.com/nengo/nengo/pull/1064>`_)
 
 **Bug fixes**
 

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -159,6 +159,22 @@ def test_whitesignal_rms(Simulator, rms, seed, plt):
     assert np.allclose(val_psd[1:-1], rms, rtol=0.35)
 
 
+@pytest.mark.parametrize('y0,d', [(0, 1), (-0.3, 3), (0.4, 1)])
+def test_whitesignal_y0(Simulator, seed, y0, d):
+    t = .1
+    process = WhiteSignal(t, high=500, y0=y0)
+    with nengo.Network() as model:
+        u = nengo.Node(process, size_out=d)
+        up = nengo.Probe(u)
+
+    with Simulator(model, seed=seed) as sim:
+        sim.run(t)
+    values = sim.data[up]
+    error = np.min(abs(y0 - values), axis=0)
+
+    assert ((y0 - error <= values[0, :]) & (values[0, :] <= y0 + error)).all()
+
+
 @pytest.mark.parametrize('high,dt', [(10, 0.01), (5, 0.001), (50, 0.001)])
 def test_whitesignal_high_dt(Simulator, high, dt, seed, plt):
     t = 1.


### PR DESCRIPTION
I ran into a subtle issue with using `WhiteSignal` without a lowpass; you sometimes get a large infinite frequency at the start of the simulation. This can be problematic in some situations with principle 3 (can give details if needed). Setting `y0=0` helps prevent this problem.