### PR TITLE
Only cache things with explicit mark.

### DIFF
--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -16,7 +16,7 @@ from nengo.exceptions import FingerprintError, TimeoutError
 from nengo.rc import rc
 from nengo.utils import nco
 from nengo.utils.cache import byte_align, bytes2human, human2bytes
-from nengo.utils.compat import int_types, is_string, pickle, PY2
+from nengo.utils.compat import int_types, is_string, pickle, PY2, string_types
 from nengo.utils.lock import FileLock
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ class Fingerprint(object):
     __slots__ = ['fingerprint']
 
     NON_REFERENCE_TYPES = (
-        bool, float, complex, bytes, unicode, str) + int_types
+        bool, float, complex, bytes) + int_types + string_types
 
 
     def __init__(self, obj):

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -129,8 +129,16 @@ class NeuronType(FrozenObject):
         """
         raise NotImplementedError("Neurons must provide step_math")
 
+    def supports_fingerprint(self):
+        return False
 
-class Direct(NeuronType):
+
+class CacheableNeuronType(NeuronType):
+    def supports_fingerprint(self):
+        return True
+
+
+class Direct(CacheableNeuronType):
     """Signifies that an ensemble should simulate in direct mode.
 
     In direct mode, the ensemble represents and transforms signals perfectly,
@@ -160,7 +168,7 @@ class Direct(NeuronType):
 #       but still simulate very fast
 
 
-class RectifiedLinear(NeuronType):
+class RectifiedLinear(CacheableNeuronType):
     """A rectified linear neuron model.
 
     Each neuron is modeled as a rectified line. That is, the neuron's activity
@@ -181,7 +189,7 @@ class RectifiedLinear(NeuronType):
         output[...] = np.maximum(0., J)
 
 
-class Sigmoid(NeuronType):
+class Sigmoid(CacheableNeuronType):
     """A neuron model whose response curve is a sigmoid."""
 
     probeable = ('rates',)
@@ -209,7 +217,7 @@ class Sigmoid(NeuronType):
         output[...] = (1. / self.tau_ref) / (1.0 + np.exp(-J))
 
 
-class LIFRate(NeuronType):
+class LIFRate(CacheableNeuronType):
     """Non-spiking version of the leaky integrate-and-fire (LIF) neuron model.
 
     Parameters
@@ -421,7 +429,7 @@ class AdaptiveLIF(AdaptiveLIFRate, LIF):
         n += (dt / self.tau_n) * (self.inc_n * output - n)
 
 
-class Izhikevich(NeuronType):
+class Izhikevich(CacheableNeuronType):
     """Izhikevich neuron model.
 
     This implementation is based on the original paper [1]_;

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -16,10 +16,8 @@ from nengo.utils.compat import int_types
 class SolverMock(object):
     n_calls = {}
 
-    def __init__(self, name='solver_mock'):
+    def __init__(self):
         self.n_calls[self] = 0
-        self.__module__ = __name__
-        self.__name__ = name
 
     def __call__(self, solver, neuron_type, gain, bias, x, targets,
                  rng=np.random, E=None):
@@ -30,11 +28,11 @@ class SolverMock(object):
             return np.random.rand(x.shape[1], E.shape[1]), {'info': 'v'}
 
 
-def get_solver_test_args():
+def get_solver_test_args(**kwargs):
     M = 100
     N = 10
     D = 2
-    return {
+    defaults = {
         'solver': nengo.solvers.LstsqL2nz(),
         'neuron_type': nengo.LIF(),
         'gain': np.ones(N),
@@ -43,6 +41,8 @@ def get_solver_test_args():
         'targets': np.ones((M, N)),
         'rng': np.random.RandomState(42),
     }
+    defaults.update(kwargs)
+    return defaults
 
 
 def get_weight_solver_test_args():
@@ -84,8 +84,9 @@ def test_decoder_cache(tmpdir):
     assert np.any(decoders1 != decoders3)
 
     # Test that the cache does not load results of another solver.
-    another_solver = SolverMock('another_solver')
-    cache.wrap_solver(another_solver)(**get_solver_test_args())
+    another_solver = SolverMock()
+    cache.wrap_solver(another_solver)(**get_solver_test_args(
+        solver=nengo.solvers.LstsqNoise()))
     assert SolverMock.n_calls[another_solver] == 1
 
 
@@ -136,9 +137,10 @@ def test_decoder_cache_size_includes_overhead(tmpdir):
 
 
 def test_decoder_cache_shrinking(tmpdir):
+    nengo.log('debug')
     cache_dir = str(tmpdir)
     solver_mock = SolverMock()
-    another_solver = SolverMock('another_solver')
+    another_solver = SolverMock()
 
     cache = DecoderCache(cache_dir=cache_dir)
     cache.wrap_solver(solver_mock)(**get_solver_test_args())
@@ -151,7 +153,8 @@ def test_decoder_cache_shrinking(tmpdir):
         os.utime(path, (timestamp, timestamp))
 
     cache = DecoderCache(cache_dir=cache_dir)
-    cache.wrap_solver(another_solver)(**get_solver_test_args())
+    cache.wrap_solver(another_solver)(**get_solver_test_args(
+        solver=nengo.solvers.LstsqNoise()))
 
     cache_size = cache.get_size_in_bytes()
     assert cache_size > 0
@@ -160,7 +163,8 @@ def test_decoder_cache_shrinking(tmpdir):
 
     # check that older cached result was removed
     assert SolverMock.n_calls[solver_mock] == 1
-    cache.wrap_solver(another_solver)(**get_solver_test_args())
+    cache.wrap_solver(another_solver)(**get_solver_test_args(
+        solver=nengo.solvers.LstsqNoise()))
     cache.wrap_solver(solver_mock)(**get_solver_test_args())
     assert SolverMock.n_calls[solver_mock] == 2
     assert SolverMock.n_calls[another_solver] == 1
@@ -170,7 +174,6 @@ def test_decoder_cache_shrink_threadsafe(monkeypatch, tmpdir):
     """Tests that shrink handles files deleted by other processes."""
     cache_dir = str(tmpdir)
     solver_mock = SolverMock()
-    another_solver = SolverMock('another_solver')
 
     cache = DecoderCache(cache_dir=cache_dir)
     cache.wrap_solver(solver_mock)(**get_solver_test_args())
@@ -184,7 +187,8 @@ def test_decoder_cache_shrink_threadsafe(monkeypatch, tmpdir):
         timestamp -= 60 * 60 * 24 * 2  # 2 days
         os.utime(path, (timestamp, timestamp))
 
-    cache.wrap_solver(another_solver)(**get_solver_test_args())
+    cache.wrap_solver(solver_mock)(**get_solver_test_args(
+        solver=nengo.solvers.LstsqNoise()))
 
     cache_size = cache.get_size_in_bytes()
     assert cache_size > 0
@@ -223,17 +227,19 @@ class DummyA(object):
     def __init__(self, attr=0):
         self.attr = attr
 
+    def supports_fingerprint(self):
+        return True
+
 
 class DummyB(object):
     def __init__(self, attr=0):
         self.attr = attr
 
+    def supports_fingerprint(self):
+        return True
 
-def dummy_fn_a(arg):
-    pass
 
-
-def dummy_fn_b(arg):
+def dummy_fn(arg):
     pass
 
 
@@ -245,16 +251,27 @@ def dummy_fn_b(arg):
     (b'a', b'a', b'b'),              # bytes
     (u'a', u'a', u'b'),              # unicode string
     (np.eye(2), np.eye(2), np.array([[0, 1], [1, 0]])),      # array
-    ({'a': 1, 'b': 2}, {'a': 1, 'b': 2}, {'a': 2, 'b': 1}),  # dict
-    ((1, 2), (1, 2), (2, 1)),        # tuple
-    ([1, 2], [1, 2], [2, 1]),        # list
     (DummyA(), DummyA(), DummyB()),  # object instance
     (DummyA(1), DummyA(1), DummyA(2)),     # object instance
-    (dummy_fn_a, dummy_fn_a, dummy_fn_b),  # function
 ) + tuple((typ(1), typ(1), typ(2)) for typ in int_types))
 def test_fingerprinting(reference, equal, different):
     assert str(Fingerprint(reference)) == str(Fingerprint(equal))
     assert str(Fingerprint(reference)) != str(Fingerprint(different))
+
+
+@pytest.mark.parametrize('obj', (
+    np.array([object()]),   # array
+    np.array([(1.,)], dtype=[('field1', 'f8')]),  # array
+    {'a': 1, 'b': 2},       # dict
+    (1, 2),                 # tuple
+    [1, 2],                 # list
+    object(),               # object instance
+    dummy_fn,               # function
+))
+def test_unsupported_fingerprinting(obj):
+    with pytest.raises(FingerprintError):
+        Fingerprint(obj)
+
 
 
 def test_fails_for_lambda_expression():

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -273,7 +273,6 @@ def test_unsupported_fingerprinting(obj):
         Fingerprint(obj)
 
 
-
 def test_fails_for_lambda_expression():
     with pytest.raises(FingerprintError):
         Fingerprint(lambda x: x)

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -26,8 +26,16 @@ class LeastSquaresSolver(object):
     def __call__(self, A, y, sigma, rng=None):
         raise NotImplementedError("LeastSquaresSolver must implement call")
 
+    def supports_fingerprint(self):
+        return False
 
-class Cholesky(LeastSquaresSolver):
+
+class CacheableLeastSquaresSolver(LeastSquaresSolver):
+    def supports_fingerprint(self):
+        return True
+
+
+class Cholesky(CacheableLeastSquaresSolver):
     """Solve a least-squares system using the Cholesky decomposition."""
 
     def __init__(self, transpose=None):
@@ -66,7 +74,7 @@ class Cholesky(LeastSquaresSolver):
         return x, info
 
 
-class ConjgradScipy(LeastSquaresSolver):
+class ConjgradScipy(CacheableLeastSquaresSolver):
     """Solve a least-squares system using Scipy's conjugate gradient."""
 
     def __init__(self, tol=1e-4):
@@ -97,7 +105,7 @@ class ConjgradScipy(LeastSquaresSolver):
         return X if matrix_in else X.flatten(), info
 
 
-class LSMRScipy(LeastSquaresSolver):
+class LSMRScipy(CacheableLeastSquaresSolver):
     """Solve a least-squares system using Scipy's LSMR."""
 
     def __init__(self, tol=1e-4):
@@ -118,7 +126,7 @@ class LSMRScipy(LeastSquaresSolver):
         return X if matrix_in else X.flatten(), info
 
 
-class Conjgrad(LeastSquaresSolver):
+class Conjgrad(CacheableLeastSquaresSolver):
     """Solve a least-squares system using conjugate gradient."""
 
     def __init__(self, tol=1e-2, maxiters=None, X0=None):
@@ -178,7 +186,7 @@ class Conjgrad(LeastSquaresSolver):
         return x, i+1
 
 
-class BlockConjgrad(LeastSquaresSolver):
+class BlockConjgrad(CacheableLeastSquaresSolver):
     """Solve a multiple-RHS least-squares system using block conj. gradient."""
 
     def __init__(self, tol=1e-2, X0=None):
@@ -222,7 +230,7 @@ class BlockConjgrad(LeastSquaresSolver):
         return X if matrix_in else X.flatten(), info
 
 
-class SVD(LeastSquaresSolver):
+class SVD(CacheableLeastSquaresSolver):
     """Solve a least-squares system using full SVD."""
 
     def __call__(self, A, Y, sigma, rng=None):
@@ -234,7 +242,7 @@ class SVD(LeastSquaresSolver):
         return X if matrix_in else X.flatten(), info
 
 
-class RandomizedSVD(LeastSquaresSolver):
+class RandomizedSVD(CacheableLeastSquaresSolver):
     """Solve a least-squares system using a randomized (partial) SVD.
 
     Parameters


### PR DESCRIPTION
Addresses #1054.

Code can change and we can't detect it, so we allow only things that
are marked as supporting fingerprints to be cached and only mark
objects that should be stable as supporting this. Note that an object
marked as supporting fingerprints will retain this mark even if it
references objects that are not marked as supporting fingerprints
(because the fingerprint is created by pickling and we cannot hook into
that process).

This also removes the solver_fn from the fingerprint because it is not
needed in there. It should always be the same function which is part of
the builder (the solver itself is still part of the fingerprint of
course). This in turn allows to simplify the SolverMock in the test
code a little bit. (It actually is slightly misnamed as it mocks the
solver_fn and not a Solver.)