### PR TITLE
Ensure flake8 errors fail TravisCI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,12 +59,10 @@ script:
       if [[ "$COVERAGE" == "false" ]]; then
         py.test nengo -n 2 -v --duration 20;
       else
-        coverage run --rcfile .coveragerc --source nengo -m py.test nengo -v --duration 20;
-        coverage report;
-      fi;
+        coverage run --rcfile .coveragerc --source nengo -m py.test nengo -v --duration 20 && coverage report;
+      fi
     else
-      flake8 -v nengo;
-      pylint nengo;
+      flake8 -v nengo && pylint nengo;
     fi
 
 after_success:


### PR DESCRIPTION
I noticed that in some other PRs, flake8 errors weren't resulting in a TravisCI failure.

TravisCI can only inspect the return code of the last command run in the `script` list, so in our big if/else chain, we need to ensure that the last command returns what we consider to be success or failure.

In the static case, we were not looking at the return value of flake8. This PR uses `&&` to use both return values.