### PR TITLE
Only cache things in a registry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ Release History
   `#1107 <https://github.com/nengo/nengo/pull/1107>`_)
 - The synapse methods ``filt`` and ``filtfilt`` now support lists as input.
   (`#1123 <https://github.com/nengo/nengo/pull/1123>`_)
+- Added a registry system so that only stable objects are cached.
+  (`#1054 <https://github.com/nengo/nengo/issues/1054>`_,
+  `#1068 <https://github.com/nengo/nengo/pull/1068>`_)
 
 2.1.2 (June 27, 2016)
 =====================

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -265,6 +265,8 @@ def dummy_fn(arg):
     (1.0, 1.0, 2.0),                 # float
     (1.0 + 2.0j, 1 + 2j, 2.0 + 1j),  # complex
     (b'a', b'a', b'b'),              # bytes
+    ((0, 1), (0, 1), (0, 2)),        # tuple
+    ([0, 1], [0, 1], [0, 2]),        # list
     (u'a', u'a', u'b'),              # unicode string
     (np.eye(2), np.eye(2), np.array([[0, 1], [1, 0]])),      # array
     (DummyA(), DummyA(), DummyB()),  # object instance
@@ -280,8 +282,6 @@ def test_fingerprinting(reference, equal, different):
     np.array([object()]),   # array
     np.array([(1.,)], dtype=[('field1', 'f8')]),  # array
     {'a': 1, 'b': 2},       # dict
-    (1, 2),                 # tuple
-    [1, 2],                 # list
     object(),               # object instance
     dummy_fn,               # function
 ))


### PR DESCRIPTION
This is an alternative implementation of #1066 that uses a class registry in the `Fingerprint` rather than modifying frontend objects.

It occurred to me that the cache system (at least for now) is specific to the reference backend, so it would be best to keep any cache-specific code local to the cache, rather than modifying frontend objects. So that's what this branch does.

I think the amount of code is, in the end, about the same. `Fingerprint.__init__` is more clear this way (IMO) but we don't get the benefit of subclassing inheriting things, so each class that should be fingerprinted needs a separate call to `Fingerprint.whitelist`. But perhaps that's desirable anyhow?