### PR TITLE
Restrict mention-bot to members of nengo org

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,3 @@
+{
+  "requiredOrgs": ["nengo"]
+}


### PR DESCRIPTION
Rather than having to maintain black/whitelists, this ensures that mention-bot will only ping people who are in the [nengo organization](https://github.com/orgs/nengo/people). If someone that we shouldn't ping gets pinged, then it's a sign we should remove them from the org -- win-win!