### PR TITLE
WIP: Use pydocstyle to check docstrings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
       export PIP_DEPS="pytest coverage";
     elif [[ "$STATIC" == "true" ]]; then
       export CONDA_DEPS="";
-      export PIP_DEPS="flake8 pylint";
+      export PIP_DEPS="flake8 pylint pydocstyle";
     fi
   - if [[ -n "$NUMPY" && "$STATIC" == "false" ]]; then
       export CONDA_DEPS="$CONDA_DEPS numpy=$NUMPY";
@@ -62,7 +62,7 @@ script:
         coverage run --rcfile .coveragerc --source nengo -m py.test nengo -v --duration 20 && coverage report;
       fi
     else
-      flake8 -v nengo && pylint nengo;
+      flake8 -v nengo && pylint nengo && pydocstyle nengo;
     fi
 
 after_success:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,5 +19,9 @@ exclude = __init__.py, compat.py
 ignore = E123,E133,E226,E241,E242,E731,W503
 max-complexity = 10
 
+[pydocstyle]
+convention = pep257
+add-ignore = D105
+
 [upload_sphinx]
 upload-dir = doc/_build/html


### PR DESCRIPTION
Enable checking docstrings with [pydocstyle](http://pydocstyle.readthedocs.io/en/latest/index.html).

Still a WIP because this PR should also update the docstrings (or the `add-ignore` list) such that this branch passes the pydocstyle test.
