### PR TITLE
Fix IPython progress bar in notebook versions >= 4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Release History
 - Allow recurrence of the form ``a=b, b=a`` in basal ganglia SPA actions.
   (`#1098 <https://github.com/nengo/nengo/issues/1098>`_,
   `#1099 <https://github.com/nengo/nengo/pull/1099>`_)
+- Support a greater range of Jupyter notebook and ipywidgets versions with the
+  the ``ipynb`` extensions.
+  (`#1088 <https://github.com/nengo/nengo/pull/1088>`_,
+  `#1085 <https://github.com/nengo/nengo/issues/1085>`_)
 
 2.1.0 (April 27, 2016)
 ======================


### PR DESCRIPTION
**Description:**
Updates the Jupyter notebook extension to be compatible with notebook and ipywidget versions >= 4, including notebook 4.2 and ipywidgets 5. Also gives a better exception when `ipywidgets` is not installed.

**Motivation and context:**
They keep changing their API. 😡 
Fixes #1085. Adresses discussion in #1084 (but not the issue itself).

**How has this been tested?**
Manually by creating virtualenvs with different IPython/Jupyter/ipywidgets versions.

**Where should a reviewer start?**
The single file that has been changed. *duh*

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

