### PR TITLE
Fix memory leak in parameter system

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,9 @@ Release History
   the Gram system.
   (`#1027 <https://github.com/nengo/nengo/pull/1027>`_,
   `#1019 <https://github.com/nengo/nengo/issues/1019>`_)
+- Eliminate memory leak in the parameter system.
+  (`#1089 <https://github.com/nengo/nengo/issues/1089>`_,
+  `#1090 <https://github.com/nengo/nengo/pull/1090>`_)
 
 2.1.0 (April 27, 2016)
 ======================

--- a/nengo/utils/tests/test_stdlib.py
+++ b/nengo/utils/tests/test_stdlib.py
@@ -1,3 +1,6 @@
+import sys
+import weakref
+
 import numpy as np
 import pytest
 
@@ -207,3 +210,16 @@ def test_weakkeydict_bad_delitem():
         d[13]
     with pytest.raises(TypeError):
         d[13] = 13
+
+
+def test_weakkeydict_frees_values():
+    d = WeakKeyIDDictionary()
+    k = C()
+    v = C()
+    d[k] = v
+    weak_v = weakref.ref(v)
+    del v
+    assert sys.getrefcount(weak_v()) > 1  # function argument might make it > 1
+    del k
+    v = weak_v()
+    assert v is None,  "Value in WeakKeyIDDictionary not garbage collected."


### PR DESCRIPTION
**Description:**
Fixes #1089.

We create a weak reference to the key with a callback here that will free the value when no strong references to the key are left. To be able to do this we need the id of the key which will be retrieved
with the _ref2id dictionary. Note that weak reference use the hash function of the object they are referencing. Thus, we have to use the id of the weak reference to index that dictionary. Finally, to support
the del operation we need to be able to map the object id to the weak reference which requires another dictionary _id2ref (instantiating another weak ref would give us an object with a different id). This dictionary has another important function: It stores strong references the weak reference to ensure that the callback gets called (it would not if the weak reference gets garbage collected beforehand and we
need to store ids as keys in the _ref2id dictionary).

**Motivation and context:**
See #1089.

**How has this been tested?**
Added a unit test checking that values in the `WeakKeyIDDictionary` are cleaned up.

**Where should a reviewer start?**
Look at #1089 and the test to understand the problem, then look at the changes to `WeakKeyIDDictionary` and information above to see how this is fixed.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. -> no documentation changes required
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.