### PR TITLE
More robustly generate opensim warning in tests

### DIFF
--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -1,5 +1,3 @@
-import gc
-
 import numpy as np
 import pytest
 
@@ -105,13 +103,11 @@ def test_close_steps(RefSimulator):
         sim.step()
 
 
-def test_warn_on_opensim_gc(Simulator):
+def test_warn_on_opensim_del(Simulator):
     with nengo.Network() as net:
         nengo.Ensemble(10, 1)
 
     sim = Simulator(net)
-    assert sim
-
     with warns(ResourceWarning):
-        sim = None
-        gc.collect()
+        sim.__del__()
+    sim.close()


### PR DESCRIPTION
**Description:**
This makes the test of warning on open simulators pass 100% of the time instead of 99% of the time.

**Motivation and context:**
Previously, the test would try to force Python to garbage collect, but this doesn't seem to always work. Now we explicitly call `__del__`, which always works. At least it better! Reported in #1011.

**How has this been tested?**
Ran the test a bunch of times... hasn't failed yet!

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

These changes are not user facing, and don't touch any Nengo code, just tests, so they do not require docs or a changelog entry.