### PR TITLE
Support any synapse for learning rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,17 @@ Release History
 2.7.1 (unreleased)
 ==================
 
+**Changed**
+
+- The order of parameters in learning rules has changed such that
+  ``learning_rate`` always comes first.
+  (`#1095 <https://github.com/nengo/nengo/pull/1095>`__)
+- Learning rules take ``pre_synapse``, ``post_synapse``, and ``theta_synapse``
+  instead of ``pre_tau``, ``post_tau``, and ``theta_tau`` respectively.
+  This allows arbitrary ``Synapse`` objects to be used as filters on
+  learning signals.
+  (`#1095 <https://github.com/nengo/nengo/pull/1095>`__)
+
 **Deprecated**
 
 - The ``nengo.ipynb`` IPython extension and the ``IPython2ProgressBar``
@@ -30,6 +41,10 @@ Release History
   Jupyter notebooks from IPython version 5.0 onwards.
   (`#1087 <https://github.com/nengo/nengo/issues/1087>`_,
   `#1375 <https://github.com/nengo/nengo/pull/1375>`_)
+- The ``pre_tau``, ``post_tau``, and ``theta_tau`` parameters
+  for learning rules are deprecated. Instead, use ``pre_synapse``,
+  ``post_synapse``, and ``theta_synapse`` respectively.
+  (`#1095 <https://github.com/nengo/nengo/pull/1095>`__)
 
 2.7.0 (March 7, 2018)
 =====================

--- a/examples/learning/learn_associations.ipynb
+++ b/examples/learning/learn_associations.ipynb
@@ -161,7 +161,7 @@
       "        n_neurons, d_key, intercepts=[intercept] * n_neurons)\n",
       "\n",
       "    # Learn the encoders/keys\n",
-      "    voja = nengo.Voja(post_tau=None, learning_rate=5e-2)\n",
+      "    voja = nengo.Voja(learning_rate=5e-2, post_synapse=None)\n",
       "    conn_in = nengo.Connection(\n",
       "        stim_keys, memory, synapse=None, learning_rule_type=voja)\n",
       "    nengo.Connection(learning, conn_in.learning_rule, synapse=None)\n",

--- a/examples/learning/learn_communication_channel.ipynb
+++ b/examples/learning/learn_communication_channel.ipynb
@@ -416,14 +416,46 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "We haven't yet discovered if there\n",
-      "are any general principles governing\n",
-      "how the decoders and connection weights change.\n",
-      "But, it's interesting to see the general trends;\n",
+      "For some general principles governing how the decoders change,\n",
+      "[Voelker, 2015](http://compneuro.uwaterloo.ca/publications/voelker2015.html)\n",
+      "and [Voelker & Eliasmith, 2017](http://compneuro.uwaterloo.ca/publications/voelker2017c.html)\n",
+      "give detailed analyses of the rule's dynamics.\n",
+      "It's also interesting to observe qualitative trends;\n",
       "often a few strong connection weights will\n",
       "dominate the others,\n",
       "while decoding weights tend to\n",
       "change or not change together."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## What is `post_synapse`?\n",
+      "\n",
+      "By default the `PES` object sets\n",
+      "`post_synapse=Lowpass(tau=0.005)`.\n",
+      "This is a lowpass filter with time-constant $\\tau = 5\\,\\text{ms}$\n",
+      "that is applied to the activities $a_i$\n",
+      "before computing each update $\\Delta {\\bf d}_i$.\n",
+      "\n",
+      "In general, longer time-constants\n",
+      "smooth over the spiking activity to produce more constant updates,\n",
+      "while shorter time-constants adapt more quickly\n",
+      "to rapidly changing inputs.\n",
+      "The right trade-off depends on\n",
+      "the particular demands of the model.\n",
+      "\n",
+      "This `Synapse` object can also be\n",
+      "any other linear filter (as are used in the `Connection` object);\n",
+      "for instance, `post_synapse=Alpha(tau=0.005)`\n",
+      "applies an alpha filter to the postsynaptic activity.\n",
+      "This will have the effect of delaying the bulk of the activities\n",
+      "by a rise-time of $\\tau$ before applying the update.\n",
+      "This may be useful for situations\n",
+      "where the error signal is delayed by the same amount,\n",
+      "since the error signal should be synchronized\n",
+      "with the same activities that produced said error."
      ]
     }
    ],
@@ -431,4 +463,3 @@
   }
  ]
 }
-

--- a/examples/usage/strings.ipynb
+++ b/examples/usage/strings.ipynb
@@ -148,14 +148,14 @@
      "collapsed": false,
      "input": [
       "print(nengo.PES())\n",
-      "print(nengo.PES(pre_tau=0.01, learning_rate=1e-6))\n",
+      "print(nengo.PES(learning_rate=1e-6, pre_synapse=0.01))\n",
       "print(nengo.BCM())\n",
       "print(nengo.BCM(\n",
-      "    pre_tau=0.01, post_tau=0.005, theta_tau=10.0, learning_rate=1e-8))\n",
+      "    learning_rate=1e-8, pre_synapse=0.01, post_synapse=0.005, theta_synapse=10.0))\n",
       "print(nengo.Oja())\n",
-      "print(nengo.Oja(pre_tau=0.01, post_tau=0.005, beta=0.5, learning_rate=1e-5))\n",
+      "print(nengo.Oja(learning_rate=1e-5, pre_synapse=0.01, post_synapse=0.005, beta=0.5))\n",
       "print(nengo.Voja())\n",
-      "print(nengo.Voja(post_tau=None, learning_rate=1e-5))"
+      "print(nengo.Voja(learning_rate=1e-5, post_synapse=None))"
      ],
      "language": "python",
      "metadata": {},

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -7,7 +7,6 @@ from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError
 from nengo.learning_rules import BCM, Oja, PES, Voja
 from nengo.node import Node
-from nengo.synapses import Lowpass
 
 
 class SimBCM(Operator):
@@ -331,6 +330,11 @@ def get_post_ens(conn):
             else conn.post_obj.ensemble)
 
 
+def build_or_passthrough(model, obj, signal):
+    """Builds the obj on signal, or returns the signal if obj is None."""
+    return signal if obj is None else model.build(obj, signal)
+
+
 @Builder.register(LearningRule)
 def build_learning_rule(model, rule):
     """Builds a `.LearningRule` object into a model.
@@ -412,10 +416,11 @@ def build_bcm(model, bcm, rule):
 
     conn = rule.connection
     pre_activities = model.sig[get_pre_ens(conn).neurons]['out']
-    pre_filtered = model.build(Lowpass(bcm.pre_tau), pre_activities)
     post_activities = model.sig[get_post_ens(conn).neurons]['out']
-    post_filtered = model.build(Lowpass(bcm.post_tau), post_activities)
-    theta = model.build(Lowpass(bcm.theta_tau), post_filtered)
+    pre_filtered = build_or_passthrough(model, bcm.pre_synapse, pre_activities)
+    post_filtered = build_or_passthrough(
+        model, bcm.post_synapse, post_activities)
+    theta = build_or_passthrough(model, bcm.theta_synapse, post_activities)
 
     model.add_op(SimBCM(pre_filtered,
                         post_filtered,
@@ -454,8 +459,9 @@ def build_oja(model, oja, rule):
     conn = rule.connection
     pre_activities = model.sig[get_pre_ens(conn).neurons]['out']
     post_activities = model.sig[get_post_ens(conn).neurons]['out']
-    pre_filtered = model.build(Lowpass(oja.pre_tau), pre_activities)
-    post_filtered = model.build(Lowpass(oja.post_tau), post_activities)
+    pre_filtered = build_or_passthrough(model, oja.pre_synapse, pre_activities)
+    post_filtered = build_or_passthrough(
+        model, oja.post_synapse, post_activities)
 
     model.add_op(SimOja(pre_filtered,
                         post_filtered,
@@ -495,11 +501,8 @@ def build_voja(model, voja, rule):
 
     # Filtered post activity
     post = conn.post_obj
-    if voja.post_tau is not None:
-        post_filtered = model.build(
-            Lowpass(voja.post_tau), model.sig[post]['out'])
-    else:
-        post_filtered = model.sig[post]['out']
+    post_filtered = build_or_passthrough(
+        model, voja.post_synapse, model.sig[post]['out'])
 
     # Learning signal, defaults to 1 in case no connection is made
     # and multiplied by the learning_rate * dt
@@ -562,7 +565,9 @@ def build_pes(model, pes, rule):
     model.add_op(Reset(error))
     model.sig[rule]['in'] = error  # error connection will attach here
 
-    acts = model.build(Lowpass(pes.pre_tau), model.sig[conn.pre_obj]['out'])
+    # Filter pre-synaptic activities with pre_synapse
+    acts = build_or_passthrough(model, pes.pre_synapse,
+                                model.sig[conn.pre_obj]['out'])
 
     # Compute the correction, i.e. the scaled negative error
     correction = Signal(np.zeros(error.shape), name="PES:correction")

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -1,7 +1,10 @@
 import warnings
 
+from nengo.config import SupportDefaultsMixin
 from nengo.exceptions import ValidationError
-from nengo.params import IntParam, FrozenObject, NumberParam, Parameter
+from nengo.params import (Default, IntParam, FrozenObject, NumberParam,
+                          Parameter, Unconfigurable)
+from nengo.synapses import Lowpass, SynapseParam
 from nengo.utils.compat import is_iterable, is_string, itervalues
 
 
@@ -20,7 +23,7 @@ class LearningRuleTypeSizeInParam(IntParam):
                 instance, size_in)  # IntParam validation
 
 
-class LearningRuleType(FrozenObject):
+class LearningRuleType(FrozenObject, SupportDefaultsMixin):
     """Base class for all learning rule objects.
 
     To use a learning rule, pass it as a ``learning_rule_type`` keyword
@@ -70,21 +73,47 @@ class LearningRuleType(FrozenObject):
     modifies = None
     probeable = ()
 
-    learning_rate = NumberParam('learning_rate', low=0)
+    learning_rate = NumberParam(
+        'learning_rate', low=0, readonly=True, default=1e-6)
     size_in = LearningRuleTypeSizeInParam('size_in', low=0)
 
-    def __init__(self, learning_rate=1e-6, size_in=0):
+    def __init__(self, learning_rate=Default, size_in=0):
         super(LearningRuleType, self).__init__()
         self.learning_rate = learning_rate
         self.size_in = size_in
 
     def __repr__(self):
-        return '%s(%s)' % (type(self).__name__, ", ".join(self._argreprs))
+        r = []
+        for name, default in self._argdefaults:
+            value = getattr(self, name)
+            if value != default:
+                r.append("%s=%r" % (name, value))
+        return '%s(%s)' % (type(self).__name__, ", ".join(r))
 
     @property
-    def _argreprs(self):
-        return (["learning_rate=%g" % self.learning_rate]
-                if self.learning_rate != 1e-6 else [])
+    def _argdefaults(self):
+        return ('learning_rate', LearningRuleType.learning_rate.default),
+
+
+def _deprecated_tau(old_attr, new_attr):
+    def get_tau(self):
+        return (None if getattr(self, new_attr) is None else
+                getattr(self, new_attr).tau)
+
+    def set_tau(self, val):
+        if val is Unconfigurable:
+            return
+
+        since = "v2.8.0"
+        url = "https://github.com/nengo/nengo/pull/1095"
+        msg = ("%s has been deprecated, use %s instead (since %s).\n"
+               "For more information, please visit %s" % (
+                   old_attr, new_attr, since, url))
+        warnings.warn(msg, DeprecationWarning)
+
+        setattr(self, new_attr, None if val is None else Lowpass(val))
+
+    return property(get_tau, set_tau)
 
 
 class PES(LearningRuleType):
@@ -97,37 +126,44 @@ class PES(LearningRuleType):
     ----------
     learning_rate : float, optional (Default: 1e-4)
         A scalar indicating the rate at which weights will be adjusted.
-    pre_tau : float, optional (Default: 0.005)
-        Filter constant on activities of neurons in pre population.
+    pre_synapse : `.Synapse`, optional \
+                  (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+        Synapse model used to filter the pre-synaptic activities.
 
     Attributes
     ----------
     learning_rate : float
         A scalar indicating the rate at which weights will be adjusted.
-    pre_tau : float
-        Filter constant on activities of neurons in pre population.
+    pre_synapse : `.Synapse`
+        Synapse model used to filter the pre-synaptic activities.
     """
 
     modifies = 'decoders'
     probeable = ('error', 'correction', 'activities', 'delta')
 
-    pre_tau = NumberParam('pre_tau', low=0, low_open=True)
+    learning_rate = NumberParam(
+        'learning_rate', low=0, readonly=True, default=1e-4)
+    pre_synapse = SynapseParam(
+        'pre_synapse', default=Lowpass(tau=0.005), readonly=True)
 
-    def __init__(self, learning_rate=1e-4, pre_tau=0.005):
-        if learning_rate >= 1.0:
+    pre_tau = _deprecated_tau("pre_tau", "pre_synapse")
+
+    def __init__(self, learning_rate=Default, pre_synapse=Default,
+                 pre_tau=Unconfigurable):
+        super(PES, self).__init__(learning_rate, size_in='post_state')
+        if learning_rate is not Default and learning_rate >= 1.0:
             warnings.warn("This learning rate is very high, and can result "
                           "in floating point errors from too much current.")
-        self.pre_tau = pre_tau
-        super(PES, self).__init__(learning_rate, size_in='post_state')
+
+        if pre_tau is Unconfigurable:
+            self.pre_synapse = pre_synapse
+        else:
+            self.pre_tau = pre_tau
 
     @property
-    def _argreprs(self):
-        args = []
-        if self.learning_rate != 1e-4:
-            args.append("learning_rate=%g" % self.learning_rate)
-        if self.pre_tau != 0.005:
-            args.append("pre_tau=%g" % self.pre_tau)
-        return args
+    def _argdefaults(self):
+        return (('learning_rate', PES.learning_rate.default),
+                ('pre_synapse', PES.pre_synapse.default))
 
 
 class BCM(LearningRuleType):
@@ -149,54 +185,74 @@ class BCM(LearningRuleType):
 
     Parameters
     ----------
-    theta_tau : float, optional (Default: 1.0)
-        A scalar indicating the time constant for theta integration.
-    pre_tau : float, optional (Default: 0.005)
-        Filter constant on activities of neurons in pre population.
-    post_tau : float, optional (Default: None)
-        Filter constant on activities of neurons in post population.
-        If None, post_tau will be the same as pre_tau.
     learning_rate : float, optional (Default: 1e-9)
         A scalar indicating the rate at which weights will be adjusted.
+    pre_synapse : `.Synapse`, optional \
+                  (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+        Synapse model used to filter the pre-synaptic activities.
+    post_synapse : `.Synapse`, optional (Default: ``None``)
+        Synapse model used to filter the post-synaptic activities.
+        If None, ``post_synapse`` will be the same as ``pre_synapse``.
+    theta_synapse : `.Synapse`, optional \
+                    (Default: ``nengo.synapses.Lowpass(tau=1.0)``)
+        Synapse model used to filter the theta signal.
 
     Attributes
     ----------
     learning_rate : float
         A scalar indicating the rate at which weights will be adjusted.
-    post_tau : float
-        Filter constant on activities of neurons in post population.
-    pre_tau : float
-        Filter constant on activities of neurons in pre population.
-    theta_tau : float
-        A scalar indicating the time constant for theta integration.
+    post_synapse : `.Synapse`
+        Synapse model used to filter the post-synaptic activities.
+    pre_synapse : `.Synapse`
+        Synapse model used to filter the pre-synaptic activities.
+    theta_synapse : `.Synapse`
+        Synapse model used to filter the theta signal.
     """
 
     modifies = 'weights'
     probeable = ('theta', 'pre_filtered', 'post_filtered', 'delta')
 
-    pre_tau = NumberParam('pre_tau', low=0, low_open=True)
-    post_tau = NumberParam('post_tau', low=0, low_open=True)
-    theta_tau = NumberParam('theta_tau', low=0, low_open=True)
+    learning_rate = NumberParam(
+        'learning_rate', low=0, readonly=True, default=1e-9)
+    pre_synapse = SynapseParam(
+        'pre_synapse', default=Lowpass(tau=0.005), readonly=True)
+    post_synapse = SynapseParam(
+        'post_synapse', default=None, readonly=True)
+    theta_synapse = SynapseParam(
+        'theta_synapse', default=Lowpass(tau=1.0), readonly=True)
 
-    def __init__(self, pre_tau=0.005, post_tau=None, theta_tau=1.0,
-                 learning_rate=1e-9):
-        self.theta_tau = theta_tau
-        self.pre_tau = pre_tau
-        self.post_tau = post_tau if post_tau is not None else pre_tau
+    pre_tau = _deprecated_tau("pre_tau", "pre_synapse")
+    post_tau = _deprecated_tau("post_tau", "post_synapse")
+    theta_tau = _deprecated_tau("theta_tau", "theta_synapse")
+
+    def __init__(self, learning_rate=Default, pre_synapse=Default,
+                 post_synapse=Default, theta_synapse=Default,
+                 pre_tau=Unconfigurable, post_tau=Unconfigurable,
+                 theta_tau=Unconfigurable):
         super(BCM, self).__init__(learning_rate, size_in=0)
 
+        if pre_tau is Unconfigurable:
+            self.pre_synapse = pre_synapse
+        else:
+            self.pre_tau = pre_tau
+
+        if post_tau is Unconfigurable:
+            self.post_synapse = (self.pre_synapse if post_synapse is Default
+                                 else post_synapse)
+        else:
+            self.post_tau = post_tau
+
+        if theta_tau is Unconfigurable:
+            self.theta_synapse = theta_synapse
+        else:
+            self.theta_tau = theta_tau
+
     @property
-    def _argreprs(self):
-        args = []
-        if self.pre_tau != 0.005:
-            args.append("pre_tau=%g" % self.pre_tau)
-        if self.post_tau != self.pre_tau:
-            args.append("post_tau=%g" % self.post_tau)
-        if self.theta_tau != 1.0:
-            args.append("theta_tau=%g" % self.theta_tau)
-        if self.learning_rate != 1e-9:
-            args.append("learning_rate=%g" % self.learning_rate)
-        return args
+    def _argdefaults(self):
+        return (('learning_rate', BCM.learning_rate.default),
+                ('pre_synapse', BCM.pre_synapse.default),
+                ('post_synapse', self.pre_synapse),
+                ('theta_synapse', BCM.theta_synapse.default))
 
 
 class Oja(LearningRuleType):
@@ -219,15 +275,16 @@ class Oja(LearningRuleType):
 
     Parameters
     ----------
-    pre_tau : float, optional (Default: 0.005)
-        Filter constant on activities of neurons in pre population.
-    post_tau : float, optional (Default: None)
-        Filter constant on activities of neurons in post population.
-        If None, post_tau will be the same as pre_tau.
-    beta : float, optional (Default: 1.0)
-        A scalar weight on the forgetting term.
     learning_rate : float, optional (Default: 1e-6)
         A scalar indicating the rate at which weights will be adjusted.
+    pre_synapse : `.Synapse`, optional \
+                  (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+        Synapse model used to filter the pre-synaptic activities.
+    post_synapse : `.Synapse`, optional (Default: ``None``)
+        Synapse model used to filter the post-synaptic activities.
+        If None, ``post_synapse`` will be the same as ``pre_synapse``.
+    beta : float, optional (Default: 1.0)
+        A scalar weight on the forgetting term.
 
     Attributes
     ----------
@@ -235,38 +292,50 @@ class Oja(LearningRuleType):
         A scalar weight on the forgetting term.
     learning_rate : float
         A scalar indicating the rate at which weights will be adjusted.
-    post_tau : float
-        Filter constant on activities of neurons in post population.
-    pre_tau : float
-        Filter constant on activities of neurons in pre population.
+    post_synapse : `.Synapse`
+        Synapse model used to filter the post-synaptic activities.
+    pre_synapse : `.Synapse`
+        Synapse model used to filter the pre-synaptic activities.
     """
 
     modifies = 'weights'
     probeable = ('pre_filtered', 'post_filtered', 'delta')
 
-    pre_tau = NumberParam('pre_tau', low=0, low_open=True)
-    post_tau = NumberParam('post_tau', low=0, low_open=True)
-    beta = NumberParam('beta', low=0)
+    learning_rate = NumberParam(
+        'learning_rate', low=0, readonly=True, default=1e-6)
+    pre_synapse = SynapseParam(
+        'pre_synapse', default=Lowpass(tau=0.005), readonly=True)
+    post_synapse = SynapseParam(
+        'post_synapse', default=None, readonly=True)
+    beta = NumberParam('beta', low=0, readonly=True, default=1.0)
 
-    def __init__(self, pre_tau=0.005, post_tau=None, beta=1.0,
-                 learning_rate=1e-6):
-        self.pre_tau = pre_tau
-        self.post_tau = post_tau if post_tau is not None else pre_tau
-        self.beta = beta
+    pre_tau = _deprecated_tau("pre_tau", "pre_synapse")
+    post_tau = _deprecated_tau("post_tau", "post_synapse")
+
+    def __init__(self, learning_rate=Default, pre_synapse=Default,
+                 post_synapse=Default, beta=Default,
+                 pre_tau=Unconfigurable, post_tau=Unconfigurable):
         super(Oja, self).__init__(learning_rate, size_in=0)
 
+        self.beta = beta
+
+        if pre_tau is Unconfigurable:
+            self.pre_synapse = pre_synapse
+        else:
+            self.pre_tau = pre_tau
+
+        if post_tau is Unconfigurable:
+            self.post_synapse = (self.pre_synapse if post_synapse is Default
+                                 else post_synapse)
+        else:
+            self.post_tau = post_tau
+
     @property
-    def _argreprs(self):
-        args = []
-        if self.pre_tau != 0.005:
-            args.append("pre_tau=%g" % self.pre_tau)
-        if self.post_tau != self.pre_tau:
-            args.append("post_tau=%g" % self.post_tau)
-        if self.beta != 1.0:
-            args.append("beta=%g" % self.beta)
-        if self.learning_rate != 1e-6:
-            args.append("learning_rate=%g" % self.learning_rate)
-        return args
+    def _argdefaults(self):
+        return (('learning_rate', Oja.learning_rate.default),
+                ('pre_synapse', Oja.pre_synapse.default),
+                ('post_synapse', self.pre_synapse),
+                ('beta', Oja.beta.default))
 
 
 class Voja(LearningRuleType):
@@ -280,38 +349,43 @@ class Voja(LearningRuleType):
 
     Parameters
     ----------
-    post_tau : float, optional (Default: 0.005)
-        Filter constant on activities of neurons in post population.
     learning_rate : float, optional (Default: 1e-2)
         A scalar indicating the rate at which encoders will be adjusted.
+    post_synapse : `.Synapse`, optional \
+                   (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+        Synapse model used to filter the post-synaptic activities.
 
     Attributes
     ----------
     learning_rate : float
         A scalar indicating the rate at which encoders will be adjusted.
-    post_tau : float
-        Filter constant on activities of neurons in post population.
+    post_synapse : `.Synapse`
+        Synapse model used to filter the post-synaptic activities.
     """
 
     modifies = 'encoders'
     probeable = ('post_filtered', 'scaled_encoders', 'delta')
 
-    post_tau = NumberParam('post_tau', low=0, low_open=True, optional=True)
+    learning_rate = NumberParam(
+        'learning_rate', low=0, readonly=True, default=1e-2)
+    post_synapse = SynapseParam(
+        'post_synapse', default=Lowpass(tau=0.005), readonly=True)
 
-    def __init__(self, post_tau=0.005, learning_rate=1e-2):
-        self.post_tau = post_tau
+    post_tau = _deprecated_tau("post_tau", "post_synapse")
+
+    def __init__(self, learning_rate=Default, post_synapse=Default,
+                 post_tau=Unconfigurable):
         super(Voja, self).__init__(learning_rate, size_in=1)
 
+        if post_tau is Unconfigurable:
+            self.post_synapse = post_synapse
+        else:
+            self.post_tau = post_tau
+
     @property
-    def _argreprs(self):
-        args = []
-        if self.post_tau is None:
-            args.append("post_tau=%s" % self.post_tau)
-        elif self.post_tau != 0.005:
-            args.append("post_tau=%g" % self.post_tau)
-        if self.learning_rate != 1e-2:
-            args.append("learning_rate=%g" % self.learning_rate)
-        return args
+    def _argdefaults(self):
+        return (('learning_rate', Voja.learning_rate.default),
+                ('post_synapse', Voja.post_synapse.default))
 
 
 class LearningRuleTypeParam(Parameter):

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -494,7 +494,7 @@ class FrozenObject(object):
     def __init__(self):
         self._paramdict = {
             k: v for k, v in inspect.getmembers(type(self))
-            if isinstance(v, Parameter)}
+            if isinstance(v, Parameter) and not isinstance(v, ObsoleteParam)}
         for p in self._params:
             if not p.readonly:
                 msg = "All parameters of a FrozenObject must be readonly"


### PR DESCRIPTION
**Description:**
- Replaces `pre_tau`, `post_tau`, and `theta_tau` with `pre_synapse`, `post_synapse`, and `theta_synapse` respectively on all learning rules. This supports the use of arbitrary synapse models on the activities used for learning.
- Makes the `learning_rate` parameter always first in the list for consistency.
- Fixes `theta_tau` to only do one level of filtering (used to be filtered twice).

**Motivation and context:**
We might not always want to filter the activities with a `Lowpass`. This allows arbitrary filters for learning (e.g. `Alpha`). I found this useful for RL in a dynamic context (the filter defines a kernel, which determines the state to update with respect to the reward). This also incidentally fixes a bug (missing issue) where we couldn't pass `pre_tau=None` or `pre_tau=0` as a parameter.

**How has this been tested?**
A test was added for PES using `pre_synapse=Alpha(...)`, which checks that the probed activities from the learning rule are identical to the alpha-filtered neural activities.  The other learning rules use the same code paths (i.e. `build_or_passthrough`), that are also tested with `Lowpass` synapses.

**Where should a reviewer start?**
Start in `learning_rules.py`, in particular the `PES` class. Then move on to `builder/learning_rules.py`.

**How long should this take to review?**
- Average (neither quick nor lengthy)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
- [x] Add this URL to `ObsoleteParam`.
- [x] Add tests.
- [x] Add documenting example.
- [x] Apply changes to PES.
- [x] Apply changes to BCM.
- [x] Apply changes to Oja.
- [x] Apply changes to Voja.
