### PR TITLE
Changed defaults to match spaopt

### DIFF
--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -195,8 +195,9 @@ def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
     with net:
         net.A = nengo.Node(size_in=dimensions, label="A")
         net.B = nengo.Node(size_in=dimensions, label="B")
+        net.input_magnitude = input_magnitude * 2 / np.sqrt(dimensions)
         net.product = Product(n_neurons, tr_out.shape[1],
-                              input_magnitude=input_magnitude * 2)
+                input_magnitude=net.input_magnitude)
         net.output = nengo.Node(size_in=dimensions, label="output")
 
         nengo.Connection(net.A, net.product.A, transform=tr_a, synapse=None)

--- a/nengo/spa/bind.py
+++ b/nengo/spa/bind.py
@@ -41,6 +41,7 @@ class Bind(Module):
                  invert_b=False, input_magnitude=1.0, label=None, seed=None,
                  add_to_container=None):
         super(Bind, self).__init__(label, seed, add_to_container)
+        self.input_magnitude = input_magnitude
         if vocab is None:
             # use the default vocab for this number of dimensions
             vocab = dimensions

--- a/nengo/spa/compare.py
+++ b/nengo/spa/compare.py
@@ -33,14 +33,16 @@ class Compare(Module):
                  input_magnitude=1.0, label=None, seed=None,
                  add_to_container=None):
         super(Compare, self).__init__(label, seed, add_to_container)
+        self.input_magnitude = input_magnitude
         if vocab is None:
             # use the default vocab for this number of dimensions
             vocab = dimensions
 
         with self:
+            mag = input_magnitude * 3.5 * np.sqrt(1.0/dimensions)
             self.product = nengo.networks.Product(
                 neurons_per_multiply, dimensions,
-                input_magnitude=input_magnitude)
+                input_magnitude=mag)
 
             self.inputA = nengo.Node(size_in=dimensions, label='inputA')
             self.inputB = nengo.Node(size_in=dimensions, label='inputB')

--- a/nengo/spa/state.py
+++ b/nengo/spa/state.py
@@ -47,8 +47,10 @@ class State(Module):
 
     def __init__(self, dimensions, subdimensions=16, neurons_per_dimension=50,
                  feedback=0.0, feedback_synapse=0.1, vocab=None, label=None,
-                 seed=None, add_to_container=None):
+                 represent_identity=False, seed=None, add_to_container=None):
         super(State, self).__init__(label, seed, add_to_container)
+
+        self.represent_identity = represent_identity
 
         if vocab is None:
             # use the default one for this dimensionality
@@ -72,8 +74,10 @@ class State(Module):
                 neurons_per_dimension * subdimensions,
                 dimensions // subdimensions,
                 ens_dimensions=subdimensions,
-                radius=np.sqrt(float(subdimensions) / dimensions),
+                radius=3.5 * np.sqrt(float(subdimensions) / dimensions),
                 label='state')
+            if represent_identity:
+                self.state_ensembles.ea_ensembles[0].radius = 1
             self.input = self.state_ensembles.input
             self.output = self.state_ensembles.output
 


### PR DESCRIPTION
**Description:**
This PR changes the default radius of spa.State, spa.Bind, and spa.Compare modules to match the improved defaults from @jgosmann 's spaopt-v4 branch.  It also introduces the represent_identity option for spa.State objects in that branch. (however, it uses False as the default, rather than True)

**Motivation and context:**
This change to the defaults is independent of the more complex changes in spaopt-v4, and can be considered separately.  This change to the defaults is also fairly controversial, as it changes existing models.

**Interactions with other PRs:**
This PR takes the idea from #941 and reimplements just that one change.

**How has this been tested?**
I looked at the radii generated by three branches, as follows:

``` python
# branch master
import nengo
import nengo.spa as spa
model = spa.SPA()
with model:
    model.a = spa.State(6, subdimensions=2)
    model.b = spa.State(6, subdimensions=3)    
    model.c = spa.Compare(6)
    model.cc = spa.Bind(6)
print 'a.radius:', [ens.radius for ens in model.a.all_ensembles]
print 'b.radius:', [ens.radius for ens in model.b.all_ensembles]
print 'c.radius:', [ens.radius for ens in model.c.all_ensembles]
print 'cc.radius:', [ens.radius for ens in model.cc.all_ensembles]

# branch spaopt-v4
import nengo
import nengo.spa as spa
model = spa.SPA()
with model:
    model.a = spa.State(6, subdimensions=2, represent_identity=False)
    model.b = spa.State(6, subdimensions=3)    
    model.c = spa.Compare(6)
    model.cc = spa.Bind(6)
print 'a.radius:', [ens.radius for ens in model.a.all_ensembles]
print 'b.radius:', [ens.radius for ens in model.b.all_ensembles]
print 'c.radius:', [ens.radius for ens in model.c.all_ensembles]
print 'cc.radius:', [ens.radius for ens in model.cc.all_ensembles]

# branch spa-improve-defaults
import nengo
import nengo.spa as spa
model = spa.SPA()
with model:
    model.a = spa.State(6, subdimensions=2)
    model.b = spa.State(6, subdimensions=3, represent_identity=True) 
    model.c = spa.Compare(6)
    model.cc = spa.Bind(6)
print 'a.radius:', [ens.radius for ens in model.a.all_ensembles]
print 'b.radius:', [ens.radius for ens in model.b.all_ensembles]
print 'c.radius:', [ens.radius for ens in model.c.all_ensembles]
print 'cc.radius:', [ens.radius for ens in model.cc.all_ensembles]    
```

**Where should a reviewer start?**
The technical changes is just a single commit.  However, it will have many effects on spa models.

**How long should this take to review?**
This is a small change, but I expect a lot of discussion, and the biggest issue is how it impacts existing models.
- Lengthy (more than 150 lines changed or changes are complicated)

**Types of changes:**
- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Still to do:**
- [ ] look at tests that should be changed (from #941 )
