### PR TITLE
Make writing of cache index atomic.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,10 @@ Release History
 
 **Bug fixes**
 
+- Fixed some situations where the cache index becomes corrupt by
+  writing the updated cache index atomically (in most cases).
+  (`#1097 <https://github.com/nengo/nengo/issues/1097>`_,
+  `#1107 <https://github.com/nengo/nengo/pull/1107>`_)
 - The synapse methods ``filt`` and ``filtfilt`` now support lists as input.
   (`#1123 <https://github.com/nengo/nengo/pull/1123>`_)
 

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -16,7 +16,7 @@ from nengo.exceptions import FingerprintError, TimeoutError
 from nengo.rc import rc
 from nengo.utils import nco
 from nengo.utils.cache import byte_align, bytes2human, human2bytes
-from nengo.utils.compat import is_string, pickle, PY2
+from nengo.utils.compat import is_string, pickle, replace, PY2
 from nengo.utils.lock import FileLock
 
 logger = logging.getLogger(__name__)
@@ -133,11 +133,12 @@ class CacheIndex(object):
                 for key in self._deletes:
                     del self._index[key]
 
-                with open(self.filename, 'wb') as f:
+                with open(self.filename + '.part', 'wb') as f:
                     pickle.dump(
                         {k: v for k, v in self._index.items()
                          if v[0] not in self._removed_files},
                         f, pickle.HIGHEST_PROTOCOL)
+                replace(self.filename + '.part', self.filename)
         except TimeoutError:
             warnings.warn(
                 "Decoder cache index could not acquire lock. "

--- a/nengo/utils/lock.py
+++ b/nengo/utils/lock.py
@@ -33,7 +33,7 @@ class FileLock(object):
     def release(self):
         if self._fd is not None:
             os.close(self._fd)
-            os.unlink(self.filename)
+            os.remove(self.filename)
             self._fd = None
 
     @property


### PR DESCRIPTION
**Description:**
 
Make writing of cache index atomic.

If the process is killed while writing the cache index pickle, we can't load it anymore and thus lose all index information. Thus, we write it to another file first, so we still have the old index in case the process gets killed. Once we're done writing we rename the file (which should be atomic on most file systems and operating systems, but will at least be a much faster operation reducing the likelihood of ending up with an invalid index).

**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adresses #1097.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Besides this we should make sure that the cache fails gracefully if the index cannot be read.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Tests still pass. The atomicity of the operation is hard to test as it is an implementation detail.

**Where should a reviewer start?**
<!--- Indicate the best part to start looking to understand the changes. -->
Should be obvious, it's just a two line change ...

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. (No changes necessary.)
- [x] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you stil plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

If the process is killed while writing the pickle, we can't load it
anymore and thus lose all index information. Thus, we write it to
another file first, so we still have the old index in case the process
gets killed. Once we're done writing we rename the file (which should
be atomic on most file systems and operating systems, but will at least
be a much faster operation reducing the likelihood of ending up with
an invalid index).

Addresses #1097.