### PR TITLE
Graceful handing of corrupted cache index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,8 +32,8 @@ Release History
 - Added ``y0`` attribute to ``WhiteSignal``, which adjusts the phase of each
   dimension to begin with absolute value closest to ``y0``.
   (`#1064 <https://github.com/nengo/nengo/pull/1064>`_)
-- Allow the `AssociativeMemory` to accept Semantic Pointer expressions as
-  `input_keys` and `output_keys`.
+- Allow the ``AssociativeMemory`` to accept Semantic Pointer expressions as
+  ``input_keys`` and ``output_keys``.
   (`#982 <https://github.com/nengo/nengo/pull/982>`_)
 
 **Bug fixes**
@@ -46,6 +46,10 @@ Release History
   (`#1053 <https://github.com/nengo/nengo/pull/1053>`_,
   `#1041 <https://github.com/nengo/nengo/issues/1041>`_,
   `#1048 <https://github.com/nengo/nengo/issues/1048>`_)
+- If the cache index is corrupted, we now fail gracefully by invalidating
+  the cache and continuing rather than raising an exception.
+  (`#1110 <https://github.com/nengo/nengo/pull/1110>`_,
+  `#1097 <https://github.com/nengo/nengo/issues/1097>`_)
 - The ``Nnls`` solver now works for weights. The ``NnlsL2`` solver is
   improved since we clip values to be non-negative before forming
   the Gram system.

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -107,6 +107,23 @@ def test_corrupted_decoder_cache(tmpdir):
         assert SolverMock.n_calls[solver_mock] == 2
 
 
+def test_corrupted_decoder_cache_index(tmpdir):
+    cache_dir = str(tmpdir)
+
+    with DecoderCache(cache_dir=cache_dir):
+        pass  # Initialize cache with required files
+    assert len(os.listdir(cache_dir)) == 2  # index, legacy.txt
+
+    # Write corrupted index
+    with open(os.path.join(cache_dir, DecoderCache._INDEX), 'w') as f:
+        f.write('(d')  # empty dict, but missing '.' at the end
+
+    # Try to load index
+    with DecoderCache(cache_dir=cache_dir):
+        pass
+    assert len(os.listdir(cache_dir)) == 2  # index, legacy.txt
+
+
 def test_decoder_cache_invalidation(tmpdir):
     cache_dir = str(tmpdir)
     solver_mock = SolverMock()


### PR DESCRIPTION
**Description:**
Gracefully handles a corrupted cache index by clearing the cache an creating a new index.

**Motivation and context:**
In some instances the cache index can get corrupted (i.e. killing the process while the cache index is being written) and that would give an exception whenever one tries to use the cache. See #1097.

**Interactions with other PRs:**
Related to #1107 which makes it less likely to end up with a corrupted index.

**How has this been tested?**
Added a regression test, made sure it fails and fixed the problem which makes the test pass.

**Where should a reviewer start?**
Either the test or the fix depending on personal preference.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. (no changes necessary imo)
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
