### PR TITLE
Move cache context management to the builder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,10 +19,14 @@ Release History
    - Bugfixes
    - Documentation
 
-2.2.0 (unreleased)
+2.1.2 (unreleased)
 ==================
 
+**Bug fixes**
 
+- The DecoderCache is now more robust when used improperly, and no longer
+  requires changes to backends in order to use properly.
+  (`#1112 <https://github.com/nengo/nengo/pull/1112>`_)
 
 2.1.1 (June 24, 2016)
 =====================

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -184,16 +184,6 @@ class DecoderCache(object):
         self._index = None
         self._fd = None
 
-    def _get_fd(self):
-        if self._fd is None:
-            self._fd = open(self._key2path(str(uuid1())), 'wb')
-        return self._fd
-
-    def _close_fd(self):
-        if self._fd is not None:
-            self._fd.close()
-            self._fd = None
-
     def __enter__(self):
         try:
             self._remove_legacy_files()
@@ -218,6 +208,70 @@ class DecoderCache(object):
         if self._index is not None:
             return self._index.__exit__(exc_type, exc_value, traceback)
 
+    @staticmethod
+    def get_default_dir():
+        """Returns the default location of the cache.
+
+        Returns
+        -------
+        str
+        """
+        return rc.get('decoder_cache', 'path')
+
+    def _close_fd(self):
+        if self._fd is not None:
+            self._fd.close()
+            self._fd = None
+
+    def _get_fd(self):
+        if self._fd is None:
+            self._fd = open(self._key2path(str(uuid1())), 'wb')
+        return self._fd
+
+    def _check_legacy_file(self):
+        """Checks if the legacy file is up to date."""
+        legacy_file = os.path.join(self.cache_dir, self._LEGACY)
+        if os.path.exists(legacy_file):
+            with open(legacy_file, 'r') as lf:
+                text = lf.read()
+            try:
+                lv, pp = tuple(int(x.strip()) for x in text.split('.'))
+            except ValueError:
+                # Will be raised with old legacy.txt format
+                lv = pp = -1
+        else:
+            lv = pp = -1
+        return lv == self._LEGACY_VERSION and pp == self._PICKLE_PROTOCOL
+
+    def _remove_legacy_files(self):
+        """Remove files from now invalid locations in the cache.
+
+        This will not remove any files if a legacy file exists and is
+        up to date. Once legacy files are removed, a legacy file will be
+        written to avoid a costly ``os.listdir`` after calling this.
+        """
+        lock_filename = 'legacy.lock'
+        with FileLock(os.path.join(self.cache_dir, lock_filename)):
+            if self._check_legacy_file():
+                return
+
+            for f in os.listdir(self.cache_dir):
+                if f == lock_filename:
+                    continue
+                path = os.path.join(self.cache_dir, f)
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
+
+            self._write_legacy_file()
+
+    def _write_legacy_file(self):
+        """Writes a legacy file, indicating that legacy files do not exist."""
+        legacy_file = os.path.join(self.cache_dir, self._LEGACY)
+        with open(legacy_file, 'w') as lf:
+            lf.write("%d.%d\n" % (self._LEGACY_VERSION, self._PICKLE_PROTOCOL))
+
     def get_files(self):
         """Returns all of the files in the cache.
 
@@ -232,6 +286,15 @@ class DecoderCache(object):
                 files.extend(os.path.join(path, f) for f in os.listdir(path))
         return files
 
+    def get_size(self):
+        """Returns the size of the cache with units as a string.
+
+        Returns
+        -------
+        str
+        """
+        return bytes2human(self.get_size_in_bytes())
+
     def get_size_in_bytes(self):
         """Returns the size of the cache in bytes as an int.
 
@@ -243,14 +306,11 @@ class DecoderCache(object):
         return sum(byte_align(st.st_size, self._fragment_size)
                    for st in stats if st is not None)
 
-    def get_size(self):
-        """Returns the size of the cache with units as a string.
-
-        Returns
-        -------
-        str
-        """
-        return bytes2human(self.get_size_in_bytes())
+    def invalidate(self):
+        """Invalidates the cache (i.e. removes all cache files)."""
+        self._close_fd()
+        for path in self.get_files():
+            safe_remove(path)
 
     def shrink(self, limit=None):
         """Reduces the size of the cache to meet a limit.
@@ -291,66 +351,6 @@ class DecoderCache(object):
             safe_remove(path)
 
         self._index.sync()
-
-    def invalidate(self):
-        """Invalidates the cache (i.e. removes all cache files)."""
-        self._close_fd()
-        for path in self.get_files():
-            safe_remove(path)
-
-    def _check_legacy_file(self):
-        """Checks if the legacy file is up to date."""
-        legacy_file = os.path.join(self.cache_dir, self._LEGACY)
-        if os.path.exists(legacy_file):
-            with open(legacy_file, 'r') as lf:
-                text = lf.read()
-            try:
-                lv, pp = tuple(int(x.strip()) for x in text.split('.'))
-            except ValueError:
-                # Will be raised with old legacy.txt format
-                lv = pp = -1
-        else:
-            lv = pp = -1
-        return lv == self._LEGACY_VERSION and pp == self._PICKLE_PROTOCOL
-
-    def _write_legacy_file(self):
-        """Writes a legacy file, indicating that legacy files do not exist."""
-        legacy_file = os.path.join(self.cache_dir, self._LEGACY)
-        with open(legacy_file, 'w') as lf:
-            lf.write("%d.%d\n" % (self._LEGACY_VERSION, self._PICKLE_PROTOCOL))
-
-    def _remove_legacy_files(self):
-        """Remove files from now invalid locations in the cache.
-
-        This will not remove any files if a legacy file exists and is
-        up to date. Once legacy files are removed, a legacy file will be
-        written to avoid a costly ``os.listdir`` after calling this.
-        """
-        lock_filename = 'legacy.lock'
-        with FileLock(os.path.join(self.cache_dir, lock_filename)):
-            if self._check_legacy_file():
-                return
-
-            for f in os.listdir(self.cache_dir):
-                if f == lock_filename:
-                    continue
-                path = os.path.join(self.cache_dir, f)
-                if os.path.isdir(path):
-                    shutil.rmtree(path)
-                else:
-                    os.remove(path)
-
-            self._write_legacy_file()
-
-    @staticmethod
-    def get_default_dir():
-        """Returns the default location of the cache.
-
-        Returns
-        -------
-        str
-        """
-        return rc.get('decoder_cache', 'path')
 
     def wrap_solver(self, solver_fn):
         """Takes a decoder solver and wraps it to use caching.

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -119,24 +119,16 @@ class Simulator(object):
     def __init__(self, network, dt=0.001, seed=None, model=None):
         self.closed = False
 
-        if model is None or model.decoder_cache is None:
-            cache = get_default_decoder_cache()
+        if model is None:
+            self.model = Model(dt=float(dt),
+                               label="%s, dt=%f" % (network, dt),
+                               decoder_cache=get_default_decoder_cache())
         else:
-            cache = model.decoder_cache
+            self.model = model
 
-        with cache:
-            if model is None:
-                self.model = Model(dt=float(dt),
-                                   label="%s, dt=%f" % (network, dt),
-                                   decoder_cache=cache)
-            else:
-                self.model = model
-
-            if network is not None:
-                # Build the network into the model
-                self.model.build(network)
-
-            cache.shrink()
+        if network is not None:
+            # Build the network into the model
+            self.model.build(network)
 
         # -- map from Signal.base -> ndarray
         self.signals = SignalDict()

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -12,6 +12,7 @@ from nengo.cache import DecoderCache, Fingerprint, get_fragment_size
 from nengo.exceptions import FingerprintError
 from nengo.solvers import LstsqL2
 from nengo.utils.compat import int_types
+from nengo.utils.testing import warns
 
 
 class SolverMock(object):
@@ -546,3 +547,17 @@ cache = nengo.cache.DecoderCache()
 
         plt.scatter(np.ones_like(d1), d1, c='b')
         plt.scatter(2 * np.ones_like(d2), d2, c='g')
+
+
+def test_warns_out_of_context(tmpdir):
+    cache_dir = str(tmpdir)
+    cache = DecoderCache(cache_dir=cache_dir)
+
+    with warns(UserWarning):
+        cache.shrink()
+
+    solver_mock = SolverMock()
+    solver = cache.wrap_solver(solver_mock)
+    with warns(UserWarning):
+        solver(**get_solver_test_args())
+    assert SolverMock.n_calls[solver_mock] == 1

--- a/nengo/version.py
+++ b/nengo/version.py
@@ -7,7 +7,7 @@ a release version. Release versions are git tagged with the version.
 """
 
 name = "nengo"
-version_info = (2, 2, 0)  # (major, minor, patch)
+version_info = (2, 1, 2)  # (major, minor, patch)
 dev = 0
 
 version = "{v}{dev}".format(v='.'.join(str(v) for v in version_info),


### PR DESCRIPTION
**Description:**
This makes the cache more robust in a few ways. First, if the cache is used when not in the cache's context, it no longer crashes, just warns and does nothing. Second, I moved the cache context management (i.e., the `with model.decoder_cache` block) from `Simulator.__init__` to `build_network`.

**Motivation and context:**
@PeterSuma noticed that his model would fail with nengo_ocl 1.0 and nengo 2.1.1. This is because `nengo_ocl.Simulator.__init__` hasn't updated to include the `with model.decoder_cache` block. However, there isn't really any reason why backends should have to update on account of our cache changes; this should be localized to the builder. So I moved it to the builder.

In doing so, I also noticed that we don't do anything defensive to ensure that the cache isn't used outside of a `with` block, so I added those things in too. I don't believe that `invalidate` or the other public methods require early exits, but let me know if I'm wrong about that.

**How has this been tested?**
I ran all of the cache tests with

```bash
py.test nengo/tests/test_cache.py --slow --plots --analytics --logs
```

in both Python 2 and 3. The benchmarking test uses the actual cache so this should be a sufficient test.

**Where should a reviewer start?**
I would read through this commit-by-commit; each commit is pretty small and understandable. The first commit just switches the order or some things according to [our style guide](http://pythonhosted.org/nengo/contributing.html#class-member-order); no other changes were made, so that commit can be mostly ignored.

**How long should this take to review?**

- Average (neither quick nor lengthy)

Note that, if people are okay with these changes, I'd like to do a quick 2.1.2 release after merging to fix compatibility with nengo_ocl 1.0. So prioritize this if you can!

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly (not necessary).
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**

Not a todo per se, but a discussion point:

In my initial version of this PR, I did this with finer granularity:

1. Do `with cache` in `builder/connection.py` right before `wrap_solver`.
2. Do `with cache` in `builder/network.py` at the end (if it's the toplevel network) to shrink the cache.

In the end I switched to the current solution, which should act exactly the same as what is in master now, only without requiring changes to backends that use the builder. However, would it be better to do with this finer granularity, as just described? I figured that continually reacquiring the index lock would end up causing more conflicts when two builds are happening simultaneously, and take more time when building one model. Does that make sense or are my assumptions wrong?