### PR TITLE
marker size change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Release History
 - Added ``ThresholdingPreset`` to configure ensembles for thresholding.
   (`#1058 <https://github.com/nengo/nengo/issues/1058>`_,
   `#1077 <https://github.com/nengo/nengo/pull/1077>`_)
+- Tweaked ``rasterplot`` so that spikes from different neurons don't overlap.
+  (`#1121 <https://github.com/nengo/nengo/pull/1121>`_)
 
 **Bug fixes**
 

--- a/nengo/utils/matplotlib.py
+++ b/nengo/utils/matplotlib.py
@@ -99,34 +99,34 @@ def implot(plt, x, y, Z, ax=None, colorbar=True, **kwargs):
 
 
 def rasterplot(time, spikes, ax=None, use_eventplot=False, **kwargs):  # noqa: C901
-    """Generate a raster plot of the provided spike data
+    """Generate a raster plot of the provided spike data.
 
     Parameters
     ----------
     time : array
         Time data from the simulation
-    spikes: array
+    spikes : array
         The spike data with columns for each neuron and 1s indicating spikes
-    ax: matplotlib.axes.Axes
-        The figure axes to plot into.
-    use_eventplot: boolean
+    ax : matplotlib.axes.Axes, optional (Default: None)
+        The figure axes to plot into. If None, we will use current axes.
+    use_eventplot : boolean, optional (Default: False)
         Whether to use the new Matplotlib `eventplot` routine. It is slower
         and makes larger image files, so we do not use it by default.
 
     Returns
     -------
-    ax: matplotlib.axes.Axes
+    ax : matplotlib.axes.Axes
         The axes that were plotted into
 
     Examples
     --------
     >>> import nengo
-    >>> model = nengo.Model("Raster")
-    >>> A = nengo.Ensemble(nengo.LIF(20), dimensions=1)
-    >>> A_spikes = nengo.Probe(A, "spikes")
-    >>> sim = nengo.Simulator(model)
-    >>> sim.run(1)
-    >>> rasterplot(sim.trange(), sim.data[A_spikes])
+    >>> with nengo.Network() as net:
+    ...     a = nengo.Ensemble(20, 1)
+    ...     p = nengo.Probe(a.neurons)
+    >>> with nengo.Simulator(net) as sim:
+    ...     sim.run(1)
+    >>> rasterplot(sim.trange(), sim.data[p])
     """
     n_times, n_neurons = spikes.shape
 
@@ -161,7 +161,7 @@ def rasterplot(time, spikes, ax=None, use_eventplot=False, **kwargs):  # noqa: C
         kwargs.setdefault('marker', '|')
         # Default markersize determined by matching eventplot
         ax_height = axis_size(ax)[1]
-        markersize = max(ax_height * 0.965 / n_neurons, 1)
+        markersize = max(ax_height * 0.8 / n_neurons, 1)
         # For 1 - 3 neurons, we need an extra fudge factor to match eventplot
         markersize -= max(4 - n_neurons, 0) ** 2 * ax_height * 0.005
         kwargs.setdefault('markersize', markersize)


### PR DESCRIPTION
**Description:**
Changes the size of markers on the spike rasters when plotting with rasterplot

**Motivation and context:**
Rasters are usually plotted without overlap of spikes from different neurons, this makes that the case for Nengo.

**How has this been tested?**
Ran raster plots for papers across a few models.  Only on Mac OSX.

**Where should a reviewer start?**
It's one line.  I'd start there. 🍶 

**How long should this take to review?**
10 seconds

**Types of changes:**
?
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
