### PR TITLE
Fix synapse filt to allow list as input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,10 @@ Release History
 2.2.0 (unreleased)
 ==================
 
+**Bug fixes**
 
+- The synapse methods ``filt`` and ``filtfilt`` now support lists as input.
+  (`#1123 <https://github.com/nengo/nengo/pull/1123>`_)
 
 2.1.2 (June 27, 2016)
 =====================

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -93,7 +93,7 @@ class Synapse(Process):
 
         shape_in = shape_out = as_shape(filt_view[0].shape, min_dim=1)
         step = self.make_step(
-            shape_in, shape_out, dt, None, y0=y0, dtype=x.dtype)
+            shape_in, shape_out, dt, None, y0=y0, dtype=filtered.dtype)
 
         for i, signal_in in enumerate(filt_view):
             filt_view[i] = step(i * dt, signal_in)

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -119,7 +119,8 @@ def test_filt(plt, rng):
     k = 1. / tau * np.exp(-tk / tau)
     x = np.convolve(u, k, mode='full')[:nt]
 
-    y = Lowpass(0.1).filt(u, dt=dt, y0=0)
+    # support lists as input
+    y = Lowpass(0.1).filt(list(u), dt=dt, y0=0)
 
     plt.plot(t, x)
     plt.plot(t, y, '--')


### PR DESCRIPTION
**Description:**
Fixes a bug where `Synapse.filt` could not accept a list as input. 

**Motivation and context:**
`Lowpass(0.005).filt([1, 0, 0])` would raise the error `AttributeError: 'list' object has no attribute 'dtype'`. There is no issue for this bug.

**How has this been tested?**
Changed a test from `u` -> `list(u)`.

**Where should a reviewer start?**
One line in `synapses.py`.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.