### PR TITLE
Declare entry point for nengo reference simulator.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Release History
 2.2.0 (unreleased)
 ==================
 
+**Improvements**
+
+- Added a ``nengo.backends`` entry point to make the reference simulator
+  discoverable for other Python packages. In the future all backends should
+  declare an entry point accordingly.
+  (`#1127 <https://github.com/nengo/nengo/pull/1127>`_)
+
 **Bug fixes**
 
 - The synapse methods ``filt`` and ``filtfilt`` now support lists as input.

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pkg_resources
 import pytest
 
 import nengo
@@ -111,3 +112,9 @@ def test_warn_on_opensim_del(Simulator):
     with warns(ResourceWarning):
         sim.__del__()
     sim.close()
+
+
+def test_entry_point(Simulator):
+    sims = [ep.load() for ep in
+            pkg_resources.iter_entry_points(group='nengo.backends')]
+    assert Simulator in sims

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,11 @@ setup(
         'all_solvers': ["scipy>=0.13", "scikit-learn"],
     },
     tests_require=['pytest>=2.3'],
+    entry_points={
+        'nengo.backends': [
+            'reference = nengo:Simulator'
+        ],
+    },
     classifiers=[  # https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
@@ -62,5 +67,5 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
-    ]
+    ],
 )


### PR DESCRIPTION
**Description:**
This adds an entry point for the reference simulator so that other Python packages (like nengo_gui) can discover the backend in a general way. Such an entry point should become best practice for all backends.

**Motivation and context:**
See description.

**How has this been tested?**
1. Checkout the branch and do a `python setup.py develop`.
2. Run the following Python code:

```python
from pkg_resources import iter_entry_points
print([ep.load() for ep in iter_entry_points(group='nengo.backends')])
```
It will print "[<class 'nengo.simulator.Simulator'>]".

**Where should a reviewer start?**
Click "Files changed".

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you stil plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- Add some documentation, but we need some general backend developer documentation first. I'll create an issue for that.