### PR TITLE
Fix errors from flake8 upgrade

### DIFF
--- a/nengo/utils/builder.py
+++ b/nengo/utils/builder.py
@@ -177,8 +177,8 @@ def _create_replacement_connection(c_in, c_out):
     return c
 
 
-def remove_passthrough_nodes(objs, connections,  # noqa: C901
-        create_connection_fn=_create_replacement_connection):
+def remove_passthrough_nodes(  # noqa: C901
+        objs, connections, create_connection_fn=None):
     """Returns a version of the model without passthrough Nodes
 
     For some backends (such as SpiNNaker), it is useful to remove Nodes that
@@ -206,6 +206,8 @@ def remove_passthrough_nodes(objs, connections,  # noqa: C901
     will be replaced with equivalent Connections that don't interact with those
     Nodes.
     """
+    if create_connection_fn is None:
+        create_connection_fn = _create_replacement_connection
 
     inputs, outputs = find_all_io(connections)
     result_conn = list(connections)

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -207,7 +207,7 @@ class warns(WarningCatcher):
         super(warns, self).__exit__(type, value, traceback)
 
 
-def allclose(t, targets, signals,  # noqa:C901
+def allclose(t, targets, signals,  # noqa: C901
              atol=1e-8, rtol=1e-5, buf=0, delay=0,
              plt=None, show=False, labels=None, individual_results=False):
     """Ensure all signal elements are within tolerances.

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import numpy as np
-import mpl_toolkits.mplot3d  # noqa  Make 3d projection available.
+import mpl_toolkits.mplot3d  # noqa: F401
 import pytest
 
 import nengo


### PR DESCRIPTION
**Description:**
Flake8 3.0 was just released, which caused a few lines to fail the static checks (the main reason for this seems to be that it parses comment lines more strictly now).

**Motivation and context:**
The lastest [TravisCI master build failed](https://travis-ci.org/nengo/nengo/jobs/147236675), which is :crying_cat_face:.

**How has this been tested?**
Upgraded `flake8` with `pip install --upgrade flake8`. Ran `flake8 nengo` locally. Passed!

**Where should a reviewer start?**
It's a small diff, so the files tab.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.