### PR TITLE
Only allow one WarningCatcher block at a time.

### DIFF
--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -185,13 +185,21 @@ class Logger(Recorder):
 
 
 class WarningCatcher(object):
+    lock = threading.Lock()
+
     def __enter__(self):
-        self.catcher = warnings.catch_warnings(record=True)
-        self.record = self.catcher.__enter__()
-        warnings.simplefilter('always')
+        self.lock.acquire()
+        try:
+            self.catcher = warnings.catch_warnings(record=True)
+            self.record = self.catcher.__enter__()
+            warnings.simplefilter('always')
+        except:
+            self.lock.release()
+            raise
 
     def __exit__(self, type, value, traceback):
         self.catcher.__exit__(type, value, traceback)
+        self.lock.release()
 
 
 class warns(WarningCatcher):


### PR DESCRIPTION
**Description:**
This prevents multiple threads from activating a `WarningCatcher` at the same time. `WarningCatcher` relies on `warnings.catch_warnings` which is not thread-safe as it relies on global state. With this change it should be possible to use `WarningCatcher` safely in a threaded environment (e.g. pytest-xdist).

**Motivation and context:**
Fixes #1011.

**How has this been tested?**
Ran the tests. Only time will tell whether #1011 is indeed fixed (it seems to only occur on Travis-CI and even there only rarely).

**Where should a reviewer start?**
:point_right: Files changed

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. (No changes neccessary?)
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**

Do we need a changelog entry? It's not really frontend related ...