### PR TITLE
Alternative generic learning rule implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ Release History
   `#1077 <https://github.com/nengo/nengo/pull/1077>`_)
 - Tweaked ``rasterplot`` so that spikes from different neurons don't overlap.
   (`#1121 <https://github.com/nengo/nengo/pull/1121>`_)
+- Added ``GenericRule`` to allow for easy implementation of new learning rules.
+  (`#553 <https://github.com/nengo/nengo/pull/553>`_)
 
 **Bug fixes**
 

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -24,7 +24,7 @@ from .node import Node
 from .neurons import (AdaptiveLIF, AdaptiveLIFRate, Direct, Izhikevich, LIF,
                       LIFRate, RectifiedLinear, Sigmoid)
 from .network import Network
-from .learning_rules import PES, BCM, Oja, Voja
+from .learning_rules import PES, BCM, Oja, Voja, GenericRule
 from .params import Default
 from .probe import Probe
 from .rc import rc, RC_DEFAULTS

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from nengo.builder import Builder, Operator, Signal
 from nengo.builder.operator import DotInc, ElementwiseInc, Reset
-from nengo.connection import LearningRule
+from nengo.learning_rules import LearningRule
 from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError
 from nengo.learning_rules import BCM, Oja, PES, Voja

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -512,6 +512,14 @@ class LearningRule(object):
         self._connection = weakref.ref(connection)
         self.learning_rule_type = learning_rule_type
 
+        if learning_rule_type.size_in is not None:
+            self.size_in = learning_rule_type.size_in
+        else:
+            # infer size_in from post
+            self.size_in = (self.connection.post_obj.ensemble.size_in
+                            if isinstance(self.connection.post_obj, Neurons)
+                            else self.connection.size_out)
+
     def __repr__(self):
         return "<LearningRule at 0x%x modifying %r with type %r>" % (
             id(self), self.connection, self.learning_rule_type)
@@ -526,11 +534,6 @@ class LearningRule(object):
         return self._connection()
 
     @property
-    def error_type(self):
-        """(str) The type of information expected by the learning rule."""
-        return self.learning_rule_type.error_type
-
-    @property
     def modifies(self):
         """(str) The variable modified by the learning rule."""
         return self.learning_rule_type.modifies
@@ -539,24 +542,6 @@ class LearningRule(object):
     def probeable(self):
         """(tuple) Signals that can be probed in the learning rule."""
         return self.learning_rule_type.probeable
-
-    @property
-    def size_in(self):
-        """(int) Dimensionality of the signal expected by the learning rule."""
-        if self.error_type == 'none':
-            return 0
-        elif self.error_type == 'scalar':
-            return 1
-        elif self.error_type == 'decoded':
-            return (self.connection.post_obj.ensemble.size_in
-                    if isinstance(self.connection.post_obj, Neurons) else
-                    self.connection.size_out)
-        elif self.error_type == 'neuron':
-            raise NotImplementedError()
-        else:
-            raise ValidationError(
-                "Unrecognized error type %r" % self.error_type,
-                attr='error_type', obj=self)
 
     @property
     def size_out(self):

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -74,16 +74,17 @@ class ConnectionLearningRuleTypeParam(LearningRuleTypeParam):
                     attr=self.name, obj=conn)
 
             # transform matrix must be 2D
-            pre_size = (
-                conn.pre_obj.n_neurons if isinstance(conn.pre_obj, Ensemble)
-                else conn.pre.size_out)
-            post_size = conn.post.size_in
-            if (not conn.solver.weights and
-                    conn.transform.shape != (post_size, pre_size)):
-                raise ValidationError(
-                    "Transform must be 2D array with shape post_neurons x "
-                    "pre_neurons (%d, %d)" % (pre_size, post_size),
-                    attr=self.name, obj=conn)
+            if not isinstance(conn.transform, Distribution):
+                pre_size = (conn.pre_obj.n_neurons
+                            if isinstance(conn.pre_obj, Ensemble)
+                            else conn.pre.size_out)
+                post_size = conn.post.size_in
+                if (not conn.solver.weights and
+                        conn.transform.shape != (post_size, pre_size)):
+                    raise ValidationError(
+                        "Transform must be 2D array with shape post_neurons x "
+                        "pre_neurons (%d, %d)" % (pre_size, post_size),
+                        attr=self.name, obj=conn)
 
 
 class ConnectionSolverParam(SolverParam):

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -338,20 +338,14 @@ class GenericRule(LearningRuleType):
         The dimensionality of the data vector input to the function
     modifies : 'weights' or 'decoders' or 'encoders'
         The signal targeted by the learning rule
-    pass_model_params : bool
-        Selects whether or not the compiled model parameters will be passed
-        to the learning rule function
     """
 
     probeable = ('target', 'data', 'delta')
 
-    pass_model_params = BoolParam('pass_model_params')
-
     def __init__(self, function, learning_rate=1.0, size_in=0,
-                 modifies="decoders", pass_model_params=False):
+                 modifies="decoders"):
         self.modifies = modifies
         self.function = function
-        self.pass_model_params = pass_model_params
 
         super(GenericRule, self).__init__(learning_rate=learning_rate,
                                           size_in=size_in)

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -343,9 +343,10 @@ class GenericRule(LearningRuleType):
     probeable = ('target', 'data', 'delta')
 
     def __init__(self, function, learning_rate=1.0, size_in=0,
-                 modifies="decoders"):
+                 modifies="decoders", filters={}):
         self.modifies = modifies
         self.function = function
+        self.filters = filters
 
         super(GenericRule, self).__init__(learning_rate=learning_rate,
                                           size_in=size_in)

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -1,8 +1,63 @@
 import warnings
+import weakref
 
+from nengo.ensemble import Neurons
 from nengo.exceptions import ValidationError
 from nengo.params import FrozenObject, NumberParam, Parameter, IntParam
 from nengo.utils.compat import is_iterable, itervalues
+
+
+class LearningRule(object):
+    """An interface for making connections to a learning rule.
+
+    Connections to a learning rule are to allow elements of the network to
+    affect the learning rule. For example, learning rules that use error
+    information can obtain that information through a connection.
+
+    Learning rule objects should only ever be accessed through the
+    ``learning_rule`` attribute of a connection.
+    """
+
+    def __init__(self, connection, learning_rule_type):
+        self._connection = weakref.ref(connection)
+        self.learning_rule_type = learning_rule_type
+
+        if learning_rule_type.size_in is not None:
+            self.size_in = learning_rule_type.size_in
+        else:
+            # infer size_in from post
+            self.size_in = (self.connection.post_obj.ensemble.size_in
+                            if isinstance(self.connection.post_obj, Neurons)
+                            else self.connection.size_out)
+
+    def __repr__(self):
+        return "<LearningRule at 0x%x modifying %r with type %r>" % (
+            id(self), self.connection, self.learning_rule_type)
+
+    def __str__(self):
+        return "<LearningRule modifying %s with type %s>" % (
+            self.connection, self.learning_rule_type)
+
+    @property
+    def connection(self):
+        """(Connection) The connection modified by the learning rule."""
+        return self._connection()
+
+    @property
+    def modifies(self):
+        """(str) The variable modified by the learning rule."""
+        return self.learning_rule_type.modifies
+
+    @property
+    def probeable(self):
+        """(tuple) Signals that can be probed in the learning rule."""
+        return self.learning_rule_type.probeable
+
+    @property
+    def size_out(self):
+        """(int) Cannot connect from learning rules, so always 0."""
+        return 0  # since a learning rule can't connect to anything
+        # TODO: allow probing individual learning rules
 
 
 class LearningRuleType(FrozenObject):

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -497,7 +497,7 @@ def test_generic_rule(Simulator, nl_nodirect, seed, modifies):
                                  pre.get_input('neurons.out')) - target * reg)
 
         rule = GenericRule(regularized_pes, learning_rate=1e-3,
-                           size_in=2, modifies=modifies,
+                           size_in=None, modifies=modifies,
                            filters={'pre.neurons.out': 0.005})
 
         conn = nengo.Connection(

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -497,7 +497,8 @@ def test_generic_rule(Simulator, nl_nodirect, seed, modifies):
                                  pre.get_input('neurons.out')) - target * reg)
 
         rule = GenericRule(regularized_pes, learning_rate=1e-3,
-                           size_in=2, modifies=modifies)
+                           size_in=2, modifies=modifies,
+                           filters={'pre.neurons.out': 0.005})
 
         conn = nengo.Connection(
             a if modifies == "decoders" else a.neurons,
@@ -507,8 +508,6 @@ def test_generic_rule(Simulator, nl_nodirect, seed, modifies):
             learning_rule_type=rule)
         nengo.Connection(b, conn.learning_rule)
         nengo.Connection(u, conn.learning_rule)
-        # nengo.Connection(a.neurons, conn.learning_rule[2:], synapse=0.005)
-        # FIXME filter
 
         b_p = nengo.Probe(b, synapse=0.1)
         weights_p = nengo.Probe(conn, attr="weights")
@@ -556,10 +555,7 @@ def test_generic_encoders(Simulator, nl_nodirect, rng, seed):
             u, x, synapse=None,
             learning_rule_type=GenericRule(
                 generic_voja, learning_rate=1e-1, modifies="encoders",
-                size_in=0))
-        # nengo.Connection(u, conn.learning_rule[n:], synapse=None)
-        # nengo.Connection(x.neurons, conn.learning_rule[:n], synapse=0.005)
-        # FIXME synapse
+                size_in=0, filters={'post.neurons.out': 0.005}))
 
     with Simulator(m) as sim:
         sim.run(1.0)

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -3,7 +3,8 @@ import pytest
 
 import nengo
 from nengo.dists import UniformHypersphere
-from nengo.learning_rules import LearningRuleTypeParam, PES, BCM, Oja, Voja
+from nengo.learning_rules import (LearningRuleTypeParam, PES, BCM, Oja, Voja,
+                                  GenericRule)
 from nengo.processes import WhiteSignal
 
 
@@ -466,3 +467,113 @@ def test_frozen():
 
     with pytest.raises((ValueError, RuntimeError)):
         a.learning_rate = 1e-1
+
+
+@pytest.mark.parametrize('modifies', ["decoders", "weights"])
+def test_generic_rule(Simulator, nl_nodirect, seed, modifies):
+    n = 100
+    input_vector = np.asarray([0.5, -0.5])
+    dt = 0.001
+    reg = 0.1
+
+    m = nengo.Network(seed=seed)
+    with m:
+        m.config[nengo.Ensemble].neuron_type = nl_nodirect()
+        u = nengo.Node(output=input_vector)
+        a = nengo.Ensemble(n, dimensions=2)
+        b = nengo.Ensemble(n, dimensions=2)
+
+        nengo.Connection(u, a)
+
+        if modifies == "decoders":
+            def regularized_pes(target, data):
+                return -dt / n * np.outer(data[:2], data[2:]) - target * reg
+        else:
+            def regularized_pes(target, data, params):
+                encoders = params[b].encoders
+                gains = params[b].gain
+                return (-dt / n *
+                        np.outer(np.dot(encoders, data[:2]) * gains,
+                                 data[2:]) - target * reg)
+
+        rule = GenericRule(regularized_pes, learning_rate=1e-3,
+                           size_in=2 + n, modifies=modifies,
+                           pass_model_params=modifies == "weights")
+
+        conn = nengo.Connection(
+            a if modifies == "decoders" else a.neurons,
+            b if modifies == "decoders" else b.neurons,
+            transform=1 if modifies == "decoders" else
+            nengo.dists.Gaussian(0, 0.001),
+            learning_rule_type=rule)
+        nengo.Connection(b, conn.learning_rule[:2])
+        nengo.Connection(u, conn.learning_rule[:2])
+        nengo.Connection(a.neurons, conn.learning_rule[2:], synapse=0.005)
+
+        b_p = nengo.Probe(b, synapse=0.1)
+        weights_p = nengo.Probe(conn, attr="weights")
+
+    with Simulator(m, dt=dt) as sim:
+        sim.run(1.)
+
+    tmask = sim.trange() > .9
+    assert (np.sum(np.abs(sim.data[weights_p][:10])) >
+            np.sum(np.abs(sim.data[weights_p][-10:])))
+    assert np.allclose(sim.data[b_p][tmask], -input_vector, atol=0.05)
+
+
+def test_generic_encoders(Simulator, nl_nodirect, rng, seed):
+    """Voja test implemented via generic rule."""
+
+    n = 200
+    learned_vector = np.asarray([0.3, -0.4, 0.6])
+    learned_vector /= np.linalg.norm(learned_vector)
+    n_change = n // 2  # modify first half of the encoders
+    dt = 1e-3
+
+    # Set the first half to always fire with random encoders, and the
+    # remainder to never fire due to their encoder's dot product with the input
+    intercepts = np.asarray([-1] * n_change + [0.99] * (n - n_change))
+    rand_encoders = UniformHypersphere(surface=True).sample(
+        n_change, len(learned_vector), rng=rng)
+    encoders = np.append(
+        rand_encoders, [-learned_vector] * (n - n_change), axis=0)
+
+    m = nengo.Network(seed=seed)
+    with m:
+        m.config[nengo.Ensemble].neuron_type = nl_nodirect()
+        u = nengo.Node(output=learned_vector)
+        x = nengo.Ensemble(n, dimensions=len(learned_vector),
+                           intercepts=intercepts, encoders=encoders,
+                           radius=2.0)  # to test encoder scaling
+
+        def generic_voja(enc, data, params):
+            scale = (params[x].gain / x.radius)[:, None]
+            return (scale * np.outer(data[:n], data[n:]) -
+                    data[:n, None] * enc)
+
+        conn = nengo.Connection(
+            u, x, synapse=None,
+            learning_rule_type=GenericRule(
+                generic_voja, learning_rate=1e-1 * dt, modifies="encoders",
+                size_in=len(learned_vector) + n, pass_model_params=True))
+        nengo.Connection(u, conn.learning_rule[n:], synapse=None)
+        nengo.Connection(x.neurons, conn.learning_rule[:n], synapse=0.005)
+
+    with Simulator(m, dt=dt) as sim:
+        sim.run(1.0)
+
+        scaled_encoders = sim.signals[sim.model.sig[x]['encoders']]
+
+    encoder_scale = (sim.model.params[x].gain / x.radius)[:, np.newaxis]
+
+    # Check that the last half kept the same encoders throughout the simulation
+    assert np.allclose(sim.model.params[x].scaled_encoders[n_change:],
+                       scaled_encoders[n_change:])
+    # and that they are also equal to their originally assigned value
+    assert np.allclose(sim.model.params[x].scaled_encoders[n_change:] /
+                       encoder_scale[n_change:], -learned_vector)
+
+    # Check that the first half converged to the input
+    assert np.allclose(scaled_encoders[:n_change] / encoder_scale[:n_change],
+                       learned_vector, atol=0.01)


### PR DESCRIPTION
**Description:**
Like #553 this implements a `GenericRule` for easy proto-typing of learning rules with Python functions.

This is the third variant and they differ mostly in how the input data is specified to the learning rules. All versions have an error or data input that is passed to the Python function implementing the rule. One connects to it by connecting to the learning rules. However, most learning rules depend not only on an error signal, but some aspects of the pre- and post-synaptic objects.
1. In the original implementation one would connect all of these things into the `data` input which then is a concatenated vector of those things. The reason why I dislike this:
   - It's hard to understand because `data[2:]` and `data[:2]` are not descriptive names. To me it seems to make it also more likely to introduce bugs and make it hard to find those.
   - Not everything can be connected from. For example, it is not possible to implement a learning rule based on the internal voltage of neurons.
   - Requires to pass in `model.params` to the learning rule function in some cases which is backend dependent.
2. The current implementation in `genericrule`/#553 extends probes. This seems better to me, but still has some problems.
   - This is tied to the discussion happening in #1145 and #933 about the general API to retrieve static values determined at build time. I think there should be one official way to access these. If we go with probes, the access via `sim.data`/`sim.model.params` should be deprecated, but that mean for the `tuning_curves` function one has to define a probe in the model, making the API slightly harder to use.
   - Probes for the `GenericRule` need to be build out of order. Technically not a real problem, but to quote @drasmuss "it just doesn't feel great."
   - The probes explicitly reference objects in the model which means that one `GenericRule` instance can only be used for one connection. My understanding is that other learning rule instances can be used in multiple connections.

Let's turn to the approach in this PR. Here the learning rule functions gets passed arguments  `pre` and `post` which are objects that allow to access all the required things on the pre- and post-synaptic objects. (Other objects in the model should not be relevant to the learning rule, but if, one can still resort to connecting these into a concatenated data signal.) For example one could do things like:

``` python
pre.get_input('out')  # Ensemble output
pre.get_input('neurons.out')  # Neuron output
pre.get_input('neurons.voltage')  # Neuron voltage
pre.built_params.encoders  # Encoders
pre.obj  # The pre Ensemble object
```

This doesn't depend on the backend. Other backends can create their own objects in an appropriate way providing this interface. (And in any implementation they have to implement some specific code for the `GenericRule` if they want to support it.)

This implementation also requires the user to write less front end code because most things can easily be accessed in the learning function. It might require some more complexity in the backend (but so do the static probes) and given that `GenericRule` is for quick proto-typing, I rather have that complexity in the backend where code gets probably better tested than having to deal with all that complexity when prototyping.

One slight problem might be that the names used depend on the signal names which are not really documented, but we could document general names like `in` and `out` as part of that interface the `pre` and `post` object need to provide. (Maybe it also makes sense to introduce some default that makes it possible to write `get_input('neurons')` instead `get_input('neurons.out'` to get a better correspondence to usual connections.) I think, the neuron signals correspond to the `probeable` names anyways so that we don't have to list each single one.

One final thing is that sometimes inputs to the learning rule should be filtered. This is were connections or probes have a slight advantage because they directly support this. Here I solved this with a `filters` argument to the generic learning rule that allows to specify the filters with a dictionary of the sort `{'pre.out': synapse1, 'post.neurons.voltage': synapse2}`.

Because the `GenericRule` does not reference any of the objects in the model, this implementation allows to assign the same instance to multiple connections.

**Motivation and context:**
See description.

**Interactions with other PRs:**
Alternate implementation of #553.
Discussion in #1145 and #933 has some relevance to this.

**How has this been tested?**
The adapted tests from #553.

**Where should a reviewer start?**
The first few commits have been extracted from #553, Look at the last two commits (either together or independently, first one is the basic implementation, second one adds filtering)

**How long should this take to review?**

<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->

<!--- Take into account both the size and complexity of the changes. -->

<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->

<!--- Leave only the line that applies below: -->
- Average (neither quick nor lengthy)

**Types of changes:**

<!--- What types of changes does your code introduce? -->

<!--- Leave all lines that apply below: -->
- New feature (non-breaking change which adds functionality)

**Checklist:**

<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->

<!--- If a box is not applicable, please justify below the checklist. -->

<!--- If you're unsure about any of these, don't hesitate to ask. -->

<!--- We're here to help! -->
- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**

<!--- If this is a work in progress, note below what you stil plan to do. -->

<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
- [ ] Come up with decent names. The current names for the classes added are quite horrible I think. I'm also not sure about the name `get_input`.
- [ ] Document this.
