### PR TITLE
Add docs for config system and presets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,11 @@ Release History
 - Tweaked ``rasterplot`` so that spikes from different neurons don't overlap.
   (`#1121 <https://github.com/nengo/nengo/pull/1121>`_)
 
+**Documentation**
+
+- Added a page explaining the config system and preset configs.
+  (`#1150 <https://github.com/nengo/nengo/pull/1150>`_)
+
 **Bug fixes**
 
 - Fixed some situations where the cache index becomes corrupt by

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,3 @@
+code, .rst-content tt, .rst-content code {
+    white-space: pre-wrap;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,15 +3,16 @@
 # This file is execfile()d with the current directory set
 # to its containing dir.
 
+import os
 import sys
 
 try:
     import nengo
     import sphinx_rtd_theme
 except ImportError:
-    print ("To build the documentation, nengo and sphinx_rtd_theme must be "
-           "installed in the current environment. Please install these and "
-           "their requirements first. A virtualenv is recommended!")
+    print("To build the documentation, nengo and sphinx_rtd_theme must be "
+          "installed in the current environment. Please install these and "
+          "their requirements first. A virtualenv is recommended!")
     sys.exit(1)
 
 extensions = [
@@ -62,7 +63,10 @@ pygments_style = 'default'
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_title = "Nengo {0} docs".format(release)
-# html_static_path = ['_static']
+html_static_path = ['_static']
+html_context = {
+    'css_files': [os.path.join('_static', 'custom.css')],
+}
 html_use_smartypants = True
 htmlhelp_basename = 'Nengodoc'
 html_last_updated_fmt = ''  # Suppress 'Last updated on:' timestamp

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,45 @@
+*******************************
+Setting parameters with Configs
+*******************************
+
+.. default-role:: obj
+
+Building models with the :doc:`modelling API <frontend_api>`
+involves constructing many objects,
+each with many parameters that can be set.
+To make setting all of these parameters easier,
+Nengo has a ``config`` system and
+pre-set configurations.
+
+The ``config`` system
+=====================
+
+Nengo's ``config`` system is used for two important functions:
+
+1. Setting default parameters with a hierarchy of defaults.
+2. Associating new information with Nengo classes and objects
+   without modifying the classes and objects themselves.
+
+A tutorial-style introduction to the ``config`` system
+can be found below:
+
+.. toctree::
+
+   examples/config
+
+``config`` system API
+---------------------
+
+.. autoclass:: nengo.Config
+
+.. autoclass:: nengo.config.ClassParams
+
+.. autoclass:: nengo.config.InstanceParams
+
+Preset configs
+==============
+
+Nengo includes preset configurations that can be
+dropped into your model to enable specific neural circuits.
+
+.. autofunction:: nengo.presets.ThresholdingEnsembles

--- a/docs/networks.rst
+++ b/docs/networks.rst
@@ -20,12 +20,7 @@ The following examples will help you to build your own networks:
    examples/network_design
    examples/network_design_advanced
 
-You may also find the following documentation on the ``config`` system
-useful:
-
-.. toctree::
-
-   examples/config
+You may also find the :doc:`config system documentation <config>` useful.
 
 .. autoclass:: nengo.networks.EnsembleArray
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -6,6 +6,7 @@ User Guide
    :maxdepth: 2
 
    frontend_api
+   config
    networks
    spa
    backend_api


### PR DESCRIPTION
**Description:**
This adds a new page to the user docs explaining the config system and the presets (currently just the `ThresholdingEnsembles` preset). Note that this tries not to overlap too much with the `config.ipynb` notebook, but links to it instead.

**Motivation and context:**
We discussed at the last dev meeting that these should be added to the docs before the 2.2.0 release.

**How has this been tested?**
I've built the docs with these changes. They build without warnings and look pretty deece.

**Where should a reviewer start?**
Files changed tab.

 **How long should this take to review?**

- Average (neither quick nor lengthy)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue) -- sort of

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. :wink: 
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes. (nothing to test)
- [x] All new and existing tests passed.