### PR TITLE
Add progress bar for the build process.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,10 @@ Release History
 - Added ``copy`` method to Nengo objects. Nengo objects can now be pickled.
   (`#977 <https://github.com/nengo/nengo/issues/977>`_,
   `#984 <https://github.com/nengo/nengo/pull/984>`_)
+- A progress bar now tracks the build process
+  in the terminal and Jupyter notebook.
+  (`#937 <https://github.com/nengo/nengo/issues/937>`_,
+  `#1151 <https://github.com/nengo/nengo/pull/1151>`_)
 
 **Changed**
 

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -87,6 +87,8 @@ class Model(object):
         self.time = Signal(np.array(0, dtype=np.float64), name='time')
         self.add_op(TimeUpdate(self.step, self.time))
 
+        self.build_callback = None
+
     def __str__(self):
         return "Model: %s" % self.label
 
@@ -116,7 +118,10 @@ class Model(object):
         obj : object
             The object to build into this model.
         """
-        return Builder.build(self, obj, *args, **kwargs)
+        built = Builder.build(self, obj, *args, **kwargs)
+        if self.build_callback is not None:
+            self.build_callback(obj)
+        return built
 
     def has_built(self, obj):
         """Returns true if the object has already been built in this model.

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -25,6 +25,8 @@ warnings.filterwarnings('once', category=MemoryLeakWarning)
 
 
 def timestamp2timedelta(timestamp):
+    if timestamp == -1:
+        return "Unknown"
     return timedelta(seconds=np.ceil(timestamp))
 
 
@@ -149,7 +151,7 @@ class ProgressBar(object):
 
     supports_fast_ipynb_updates = False
 
-    def __init__(self, task="Simulation"):
+    def __init__(self, task):
         self.task = task
 
     def update(self, progress):
@@ -169,15 +171,15 @@ class NoProgressBar(ProgressBar):
     Helpful in headless situations or when using Nengo as a library.
     """
 
+    def __init__(self, task=None):
+        super(NoProgressBar, self).__init__(task=task)
+
     def update(self, progress):
         pass
 
 
 class TerminalProgressBar(ProgressBar):
     """A progress bar that is displayed as ASCII output on `stdout`."""
-
-    def __init__(self, task="Simulation"):
-        super(TerminalProgressBar, self).__init__(task)
 
     def update(self, progress):
         if progress.finished:
@@ -190,7 +192,8 @@ class TerminalProgressBar(ProgressBar):
     def _get_in_progress_line(self, progress):
         line = "[{{}}] ETA: {eta}".format(
             eta=timestamp2timedelta(progress.eta()))
-        percent_str = " {}% ".format(int(100 * progress.progress))
+        percent_str = " {}... {}% ".format(
+            self.task, int(100 * progress.progress))
         try:
             width, _ = get_terminal_size()
         except:
@@ -231,7 +234,7 @@ class WriteProgressToFile(ProgressBar):
         Path to the file to write the progress to.
     """
 
-    def __init__(self, filename, task="Simulation"):
+    def __init__(self, filename, task):
         self.filename = filename
         super(WriteProgressToFile, self).__init__(task)
 
@@ -260,10 +263,10 @@ class AutoProgressBar(ProgressBar):
         The minimum ETA threshold for displaying the progress bar.
     """
 
-    def __init__(self, delegate, min_eta=1., task="Simulation"):
+    def __init__(self, delegate, min_eta=1.):
         self.delegate = delegate
 
-        super(AutoProgressBar, self).__init__(task)
+        super(AutoProgressBar, self).__init__(delegate.task)
 
         self.min_eta = min_eta
         self._visible = False
@@ -276,6 +279,14 @@ class AutoProgressBar(ProgressBar):
         elif long_eta or progress.finished:
             self._visible = True
             self.delegate.update(progress)
+
+    @property
+    def task(self):
+        return self.delegate.task
+
+    @task.setter
+    def task(self, value):
+        self.delegate.task = value
 
 
 class ProgressUpdater(object):
@@ -389,9 +400,10 @@ class ProgressTracker(object):
     progress_bar : :class:`ProgressBar` or :class:`ProgressUpdater`
         The progress bar to display the progress.
     """
-    def __init__(self, max_steps, progress_bar):
+    def __init__(self, max_steps, progress_bar, task):
         self.progress = Progress(max_steps)
-        self.progress_bar = wrap_with_progressupdater(progress_bar)
+        self.progress_bar = wrap_with_progressupdater(
+            task=task, progress_bar=progress_bar)
 
     def __enter__(self):
         self.progress.__enter__()
@@ -414,7 +426,7 @@ class ProgressTracker(object):
         self.progress_bar.update(self.progress)
 
 
-def get_default_progressbar():
+def get_default_progressbar(task):
     """The default progress bar to use depending on the execution environment.
 
     Returns
@@ -424,7 +436,7 @@ def get_default_progressbar():
     try:
         pbar = rc.getboolean('progress', 'progress_bar')
         if pbar:
-            return AutoProgressBar(TerminalProgressBar())
+            return AutoProgressBar(TerminalProgressBar(task=task))
         else:
             return NoProgressBar()
     except ValueError:
@@ -432,12 +444,12 @@ def get_default_progressbar():
 
     pbar = rc.get('progress', 'progress_bar')
     if pbar.lower() == 'auto':
-        return AutoProgressBar(TerminalProgressBar())
+        return AutoProgressBar(TerminalProgressBar(task=task))
     if pbar.lower() == 'none':
         return NoProgressBar()
 
     try:
-        return _load_class(pbar)()
+        return _load_class(pbar)(task)
     except Exception as e:
         warnings.warn(str(e))
         return NoProgressBar()
@@ -471,7 +483,7 @@ def get_default_progressupdater(progress_bar):
             warnings.warn(str(e))
 
 
-def wrap_with_progressupdater(progress_bar=True):
+def wrap_with_progressupdater(task, progress_bar=True):
     """Wraps a progress bar with the default progress updater.
 
     If it is already wrapped by an progress updater, then this does nothing.
@@ -490,7 +502,9 @@ def wrap_with_progressupdater(progress_bar=True):
         return NoProgressBar()
 
     if progress_bar is True:
-        progress_bar = get_default_progressbar()
+        progress_bar = get_default_progressbar(task)
+
+    progress_bar.task = task
 
     if isinstance(progress_bar, ProgressUpdater):
         return progress_bar

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -6,9 +6,9 @@ from nengo.utils.progress import (
 
 
 class ProgressBarMock(ProgressBar):
-    def __init__(self):
+    def __init__(self, task="Testing"):
         self.n_update_calls = 0
-        super(ProgressBarMock, self).__init__()
+        super(ProgressBarMock, self).__init__(task)
 
     def update(self, progress):
         self.n_update_calls += 1
@@ -103,7 +103,7 @@ class TestUpdateN(object):
         progress_bar = ProgressBarMock()
         updater = UpdateN(progress_bar, max_updates=3)
 
-        with ProgressTracker(100, updater) as p:
+        with ProgressTracker(100, updater, "Testing") as p:
             for _ in range(100):
                 p.step()
 
@@ -116,7 +116,7 @@ class TestUpdateEveryN(object):
         progress_bar = ProgressBarMock()
         updater = UpdateEveryN(progress_bar, every_n=5)
 
-        with ProgressTracker(100, updater) as p:
+        with ProgressTracker(100, updater, "Testing") as p:
             progress_bar.n_update_calls = 0
             for _ in range(5):
                 p.step()
@@ -135,7 +135,7 @@ class TestUpdateEveryT(object):
         t = 1.
         monkeypatch.setattr(time, 'time', lambda: t)
 
-        with ProgressTracker(100, updater) as p:
+        with ProgressTracker(100, updater, "Testing") as p:
             p.step()  # Update is allowed to happen on first step.
 
             progress_bar.n_update_calls = 0


### PR DESCRIPTION
**Description:**
It adds a progress bar for the build process similar to the simulation progress bar.

**Motivation and context:**
Fixes #937. Gives you some indication of how long the build will take and you can look up how long it took after the fact. Like the simulation progress bar, this can be disabled by passing `progress_bar=False` to the `Simulator` or setting it in the nengorc file.

**Interactions with other PRs:**
nada

**How has this been tested?**
Used the question answering example which takes some time to build (if the ETA is less than a second no progress bar will be shown). Works with and without `%load_ext nengo.ipynb`.

**Where should a reviewer start?**
Files changed.

**How long should this take to review?**

<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->

<!--- Take into account both the size and complexity of the changes. -->

<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->

<!--- Leave only the line that applies below: -->
- Average (neither quick nor lengthy)

**Types of changes:**

<!--- What types of changes does your code introduce? -->

<!--- Leave all lines that apply below: -->
- New feature (non-breaking change which adds functionality)

**Checklist:**

<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->

<!--- If a box is not applicable, please justify below the checklist. -->

<!--- If you're unsure about any of these, don't hesitate to ask. -->

<!--- We're here to help! -->
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**

<!--- If this is a work in progress, note below what you stil plan to do. -->

<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
- [x] This adds a `progress_bar` argument to the constructor. Not sure if we want that. Other proposals are welcome (maybe use the config system?).
- [x] The `progress_bar` arguments on the `run` function is not required anymore with the argument on the constructor, but maybe still helpful? (Are there situation where a different setting for build and run is desired?) Deprecate it or keep it?
- [x] Not sure what people think of the callback from the builder, but some sort of callback will be required and this was the path of least resistance and is pretty general (no dependence on the progress bar class itself).
