### PR TITLE
Set ctime when accessing cache legacy file.

### DIFF
--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -235,6 +235,7 @@ class DecoderCache(object):
         """Checks if the legacy file is up to date."""
         legacy_file = os.path.join(self.cache_dir, self._LEGACY)
         if os.path.exists(legacy_file):
+            os.utime(legacy_file, None)
             with open(legacy_file, 'r') as lf:
                 text = lf.read()
             try:


### PR DESCRIPTION
**Description:**
Sets the modification time of the cache `legacy.txt` file when it is accessed (which happens once per build).

**Motivation and context:**
See #1154.

**Interactions with other PRs:**
none

**How has this been tested?**
Used this script:

``` python
import nengo

def create_model(seed):
    with nengo.Network(seed=seed) as model:
        a = nengo.Ensemble(10, 1)
        b = nengo.Ensemble(10, 1)
        nengo.Connection(a, b)
    return model


for i in range(1000):
    with nengo.Simulator(create_model(i)) as sim:
        pass
```

Ran it once to initialize cache with corresponding decoders. Then ran it with master and measured the execution time, then ran it with this branch again measuring the execution time. Both need 11 to 12 seconds on my computer, this branch was at most 500ms seconds slower. Thus, I don't think there can be made a strong argument that this impacts performance negatively.

Of course I checked the output of `ls -l --time=ctime ~/.cache/nengo/decoders/legacy.txt` too to verify that the ctime is actually set (which it is).

**How long should this take to review?**

<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->

<!--- Take into account both the size and complexity of the changes. -->

<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->

<!--- Leave only the line that applies below: -->
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

<!--- What types of changes does your code introduce? -->

<!--- Leave all lines that apply below: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

(either one of the above depending on your point of view)

**Checklist:**

<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->

<!--- If a box is not applicable, please justify below the checklist. -->

<!--- If you're unsure about any of these, don't hesitate to ask. -->

<!--- We're here to help! -->
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. [I don't think any changes are necessary.]
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes. [I could write a test for this, if we agree on making this change.]
- [x] All new and existing tests passed.
