### PR TITLE
Track offset in Signals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,9 @@ Release History
 - Added a registry system so that only stable objects are cached.
   (`#1054 <https://github.com/nengo/nengo/issues/1054>`_,
   `#1068 <https://github.com/nengo/nengo/pull/1068>`_)
+- Nodes now support array views as input.
+  (`#1156 <https://github.com/nengo/nengo/issues/1156>`_,
+  `#1157 <https://github.com/nengo/nengo/pull/1157>`_)
 
 2.1.2 (June 27, 2016)
 =====================

--- a/nengo/builder/tests/test_signal.py
+++ b/nengo/builder/tests/test_signal.py
@@ -1,6 +1,163 @@
 import numpy as np
+import pytest
 
-from nengo.builder.signal import Signal
+import nengo
+from nengo.builder import Model
+from nengo.builder.signal import Signal, SignalDict
+from nengo.exceptions import SignalError
+from nengo.utils.compat import itervalues
+
+
+def test_signaldict():
+    """Tests SignalDict's dict overrides."""
+    signaldict = SignalDict()
+
+    scalar = Signal(1.)
+
+    # Both __getitem__ and __setitem__ raise KeyError
+    with pytest.raises(KeyError):
+        signaldict[scalar]
+    with pytest.raises(KeyError):
+        signaldict[scalar] = np.array(1.)
+
+    signaldict.init(scalar)
+    assert np.allclose(signaldict[scalar], np.array(1.))
+    # __getitem__ handles scalars
+    assert signaldict[scalar].shape == ()
+
+    one_d = Signal([1.])
+    signaldict.init(one_d)
+    assert np.allclose(signaldict[one_d], np.array([1.]))
+    assert signaldict[one_d].shape == (1,)
+
+    two_d = Signal([[1.], [1.]])
+    signaldict.init(two_d)
+    assert np.allclose(signaldict[two_d], np.array([[1.], [1.]]))
+    assert signaldict[two_d].shape == (2, 1)
+
+    # __getitem__ handles views implicitly (note no .init)
+    two_d_view = two_d[0, :]
+    assert np.allclose(signaldict[two_d_view], np.array([1.]))
+    assert signaldict[two_d_view].shape == (1,)
+
+    # __setitem__ ensures memory location stays the same
+    memloc = signaldict[scalar].__array_interface__['data'][0]
+    signaldict[scalar] = np.array(0.)
+    assert np.allclose(signaldict[scalar], np.array(0.))
+    assert signaldict[scalar].__array_interface__['data'][0] == memloc
+
+    memloc = signaldict[one_d].__array_interface__['data'][0]
+    signaldict[one_d] = np.array([0.])
+    assert np.allclose(signaldict[one_d], np.array([0.]))
+    assert signaldict[one_d].__array_interface__['data'][0] == memloc
+
+    memloc = signaldict[two_d].__array_interface__['data'][0]
+    signaldict[two_d] = np.array([[0.], [0.]])
+    assert np.allclose(signaldict[two_d], np.array([[0.], [0.]]))
+    assert signaldict[two_d].__array_interface__['data'][0] == memloc
+
+    # __str__ pretty-prints signals and current values
+    # Order not guaranteed for dicts, so we have to loop
+    for k in signaldict:
+        assert "%s %s" % (repr(k), repr(signaldict[k])) in str(signaldict)
+
+
+def test_signaldict_reset():
+    """Tests SignalDict's reset function."""
+    signaldict = SignalDict()
+    two_d = Signal([[1.], [1.]])
+    signaldict.init(two_d)
+
+    two_d_view = two_d[0, :]
+    signaldict.init(two_d_view)
+
+    signaldict[two_d_view] = -0.5
+    assert np.allclose(signaldict[two_d], np.array([[-0.5], [1]]))
+
+    signaldict[two_d] = np.array([[-1], [-1]])
+    assert np.allclose(signaldict[two_d], np.array([[-1], [-1]]))
+    assert np.allclose(signaldict[two_d_view], np.array([-1]))
+
+    signaldict.reset(two_d_view)
+    assert np.allclose(signaldict[two_d_view], np.array([1]))
+    assert np.allclose(signaldict[two_d], np.array([[1], [-1]]))
+
+    signaldict.reset(two_d)
+    assert np.allclose(signaldict[two_d], np.array([[1], [1]]))
+
+
+def test_assert_named_signals():
+    """Make sure assert_named_signals works."""
+    Signal(np.array(0.))
+    Signal.assert_named_signals = True
+    with pytest.raises(AssertionError):
+        Signal(np.array(0.))
+
+    # So that other tests that build signals don't fail...
+    Signal.assert_named_signals = False
+
+
+def test_signal_values():
+    """Make sure Signal.initial_value works."""
+    two_d = Signal([[1.], [1.]])
+    assert np.allclose(two_d.initial_value, np.array([[1], [1]]))
+    two_d_view = two_d[0, :]
+    assert np.allclose(two_d_view.initial_value, np.array([1]))
+
+    # cannot change signal value after creation
+    with pytest.raises(SignalError):
+        two_d.initial_value = np.array([[0.5], [-0.5]])
+    with pytest.raises((ValueError, RuntimeError)):
+        two_d.initial_value[...] = np.array([[0.5], [-0.5]])
+
+
+def test_signal_reshape():
+    """Tests Signal.reshape"""
+    three_d = Signal(np.ones((2, 2, 2)))
+    assert three_d.reshape((8,)).shape == (8,)
+    assert three_d.reshape((4, 2)).shape == (4, 2)
+    assert three_d.reshape((2, 4)).shape == (2, 4)
+    assert three_d.reshape(-1).shape == (8,)
+    assert three_d.reshape((4, -1)).shape == (4, 2)
+    assert three_d.reshape((-1, 4)).shape == (2, 4)
+    assert three_d.reshape((2, -1, 2)).shape == (2, 2, 2)
+    assert three_d.reshape((1, 2, 1, 2, 2, 1)).shape == (1, 2, 1, 2, 2, 1)
+
+
+def test_signal_slicing(rng):
+    slices = [0, 1, slice(None, -1), slice(1, None), slice(1, -1),
+              slice(None, None, 3), slice(1, -1, 2)]
+
+    x = np.arange(12, dtype=float)
+    y = np.arange(24, dtype=float).reshape(4, 6)
+    a = Signal(x.copy())
+    b = Signal(y.copy())
+
+    for i in range(100):
+        si0, si1 = rng.randint(0, len(slices), size=2)
+        s0, s1 = slices[si0], slices[si1]
+        assert np.array_equiv(a[s0].initial_value, x[s0])
+        assert np.array_equiv(b[s0, s1].initial_value, y[s0, s1])
+
+    with pytest.raises(ValueError):
+        a[[0, 2]]
+    with pytest.raises(ValueError):
+        b[[0, 1], [3, 4]]
+
+
+def test_commonsig_readonly():
+    """Test that the common signals cannot be modified."""
+    net = nengo.Network(label="test_commonsig")
+    model = Model()
+    model.build(net)
+    signals = SignalDict()
+
+    for sig in itervalues(model.sig['common']):
+        signals.init(sig)
+        with pytest.raises((ValueError, RuntimeError)):
+            signals[sig] = np.array([-1])
+        with pytest.raises((ValueError, RuntimeError)):
+            signals[sig][...] = np.array([-1])
 
 
 def test_signal_offset():

--- a/nengo/builder/tests/test_signal.py
+++ b/nengo/builder/tests/test_signal.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from nengo.builder.signal import Signal
+
+
+def test_signal_offset():
+    value = np.eye(3)
+    s = Signal(value)
+    assert s.offset == 0
+    assert s[1].offset == value.strides[0]
+
+    value_view = value[1]
+    s = Signal(value_view)
+    assert s.offset == 0
+    assert s[0:].offset == 0
+    assert s[1:].offset == value.strides[1]

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -18,6 +18,7 @@ class DefaultType:
     def __repr__(self):
         return self.name
 
+
 Default = DefaultType("Default")
 ConnectionDefault = DefaultType("ConnectionDefault")
 Unconfigurable = DefaultType("Unconfigurable")

--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -101,5 +101,6 @@ class _RC(configparser.SafeConfigParser):
         self._init_defaults()
         self.read(filenames)
 
+
 # The current Nengo RC settings.
 rc = _RC()

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -245,12 +245,14 @@ class DummyA(object):
     def __init__(self, attr=0):
         self.attr = attr
 
+
 nengo.cache.Fingerprint.whitelist(DummyA)
 
 
 class DummyB(object):
     def __init__(self, attr=0):
         self.attr = attr
+
 
 nengo.cache.Fingerprint.whitelist(DummyB)
 

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -357,3 +357,14 @@ def test_seed_error():
     with nengo.Network():
         with pytest.raises(NotImplementedError):
             nengo.Node(seed=1)
+
+
+def test_node_with_offset_array_view(Simulator):
+    v = np.array([[1., 2.], [3., 4.]])
+    with nengo.Network() as model:
+        node = nengo.Node(v[1])
+        probe = nengo.Probe(node)
+        assert probe  # suppress never used warning
+
+    with Simulator(model):
+        pass

--- a/nengo/utils/matplotlib.py
+++ b/nengo/utils/matplotlib.py
@@ -98,7 +98,7 @@ def implot(plt, x, y, Z, ax=None, colorbar=True, **kwargs):
         plt.colorbar(image, ax=ax)
 
 
-def rasterplot(time, spikes, ax=None, use_eventplot=False, **kwargs):  # noqa: C901
+def rasterplot(time, spikes, ax=None, use_eventplot=False, **kwargs):  # noqa
     """Generate a raster plot of the provided spike data.
 
     Parameters

--- a/nengo/utils/tests/test_logging.py
+++ b/nengo/utils/tests/test_logging.py
@@ -1,7 +1,5 @@
 import logging
 
-import pytest
-
 import nengo
 import nengo.utils.logging
 
@@ -29,7 +27,3 @@ def test_log_to_file(tmpdir):
     assert logging.root.getEffectiveLevel() == logging.DEBUG
     assert len(logging.root.handlers) == n_handlers
     logging.root.handlers.remove(handler)
-
-if __name__ == "__main__":
-    import sys
-    pytest.main(sys.argv)


### PR DESCRIPTION
**Description:**
Makes Signals track the offset instead of computing it from the initial value.

**Motivation and context:**
See #1156, including [this comment](https://github.com/nengo/nengo/issues/1156#issuecomment-243519135).

**How has this been tested?**
Added two unit tests. One is just dependent on the Signal and tests the offset value. The other one reproduces the original problem with the node input from #1156 (a bit simplified).

**Where should a reviewer start?**
Probably best to understand the problem first, then to look at the changes in `signal.py`.

**How long should this take to review?**

<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->

<!--- Take into account both the size and complexity of the changes. -->

<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->

<!--- Leave only the line that applies below: -->
- Average (neither quick nor lengthy)

**Types of changes:**

<!--- What types of changes does your code introduce? -->

<!--- Leave all lines that apply below: -->
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->

<!--- If a box is not applicable, please justify below the checklist. -->

<!--- If you're unsure about any of these, don't hesitate to ask. -->

<!--- We're here to help! -->
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. [no changes necessary]
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
