### PR TITLE
Set ensemble params in test_set_eval_points

### DIFF
--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -692,7 +692,9 @@ def test_set_function(Simulator):
 
 def test_set_eval_points(Simulator):
     with nengo.Network() as model:
-        a = nengo.Ensemble(10, 2)
+        a = nengo.Ensemble(10, 2,
+                           encoders=nengo.dists.Choice([[1, 1]]),
+                           intercepts=nengo.dists.Uniform(-1, -0.1))
         b = nengo.Ensemble(10, 2)
         # ConnEvalPoints parameter checks that pre is an ensemble
         nengo.Connection(a, b, eval_points=[[0, 0], [0.5, 1]])


### PR DESCRIPTION
**Motivation and context:**
@jgosmann pointed out a random test failure on TravisCI in #1160.

The test failure can occur because we make a connection between two 10-neuron ensembles with two evaluation points. There's a small chance that none of the 10 neurons in the `pre` ensemble have randomly generated tuning curves such that there will be activity for those two evaluation points, and since we need activity to solve for decoders, the builder will error if there's no activity.

There are a several possible resolutions to this. Two possiblities are setting a seed for that network and picking more / better evaluation points, which drastically lowers the chance that the test will fail. However, there's still a chance the test will fail, so I instead set the `encoders` and `intercepts` of the `pre` ensemble so that there will always be activity for those eval points.

**How has this been tested?**
I printed the `scaled_encoders` of the pre population before and after this change. Before:

```
[[  7.22417888   1.29355952]
 [ 42.40111461 -33.0782198 ]
 [ -9.43712099  -1.3551235 ]
 [ -6.84484965   0.54664181]
 [ 12.22720089 -71.93689421]
 [  4.491869   -15.60968301]
 [-64.06777883  39.84594273]
 [  2.50942983  -4.83297035]
 [ 10.27007075 -19.17982976]
 [-32.43780085  -7.29714925]]
```

Note the presence of an element with two negative numbers; if there is negative bias then this neuron would not fire. When this is true for all 10 neurons, the test fails.

After:
```
[[  3.88160368   3.88160368]
 [  4.22316542   4.22316542]
 [ 20.26926916  20.26926916]
 [  6.96240375   6.96240375]
 [  3.75360633   3.75360633]
 [  4.30572499   4.30572499]
 [ 11.36022045  11.36022045]
 [  4.32718427   4.32718427]
 [  7.28858243   7.28858243]
 [ 13.75326124  13.75326124]]
```

All of the elements are positive, and the intercept is sampled between -1 and -0.1, meaning that the bias is always positive, so there is no way for these neuron to _not_ fire.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. [not necessary]
- [x] I have included a changelog entry. [not necessary]
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.