### PR TITLE
Remove code that was only there to support javaviz

### DIFF
--- a/nengo/spa/__init__.py
+++ b/nengo/spa/__init__.py
@@ -11,5 +11,5 @@ from .pointer import SemanticPointer
 from .spa import SPA
 from .state import State
 from .thalamus import Thalamus
-from .utils import enable_spa_params, similarity
+from .utils import similarity
 from .vocab import Vocabulary

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -6,7 +6,6 @@ import nengo
 from nengo.exceptions import SpaModuleError
 from nengo.spa.vocab import Vocabulary
 from nengo.spa.module import Module
-from nengo.spa.utils import enable_spa_params
 from nengo.utils.compat import iteritems
 
 
@@ -82,7 +81,6 @@ class SPA(nengo.Network):
                  vocabs=None):
         super(SPA, self).__init__(label, seed, add_to_container)
         vocabs = [] if vocabs is None else vocabs
-        enable_spa_params(self)
         self._modules = {}
         self._default_vocabs = {}
 
@@ -111,11 +109,9 @@ class SPA(nengo.Network):
             for k, (obj, v) in iteritems(value.inputs):
                 if type(v) == int:
                     value.inputs[k] = (obj, self.get_default_vocab(v))
-                self.config[obj].vocab = value.inputs[k][1]
             for k, (obj, v) in iteritems(value.outputs):
                 if type(v) == int:
                     value.outputs[k] = (obj, self.get_default_vocab(v))
-                self.config[obj].vocab = value.outputs[k][1]
 
             value.on_add(self)
 

--- a/nengo/spa/utils.py
+++ b/nengo/spa/utils.py
@@ -2,25 +2,9 @@
 
 import numpy as np
 
-import nengo
 import nengo.utils.numpy as npext
 from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_iterable
-
-
-def enable_spa_params(model):
-    """Enables the SPA specific parameters on a model.
-
-    Parameters
-    ----------
-    model : Network
-        Model to activate SPA specific parameters for.
-    """
-    from nengo.spa.vocab import VocabularyParam
-
-    for obj_type in [nengo.Node, nengo.Ensemble]:
-        model.config[obj_type].set_param(
-            'vocab', VocabularyParam('vocab', optional=True))
 
 
 def similarity(data, vocab, normalize=False):


### PR DESCRIPTION
**Motivation and context:**
This removes code that was only there to support Javaviz. We are not using javaviz anymore and the code has become outdated so that it would fail if it ever would be executed. (The `VocabularyParam` now requires an additional argument.)

**Interactions with other PRs:**
Supersedes #1005 that fixed the code before realizing that it is obsolete.

**How has this been tested?**
The same code has been removed in #1006. I have been using a branch based of those changes for quite a while now without problems.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
