### PR TITLE
Add function to activate direct mode.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ Release History
 
 - Added documentation on config system quirks.
   (`#1224 <https://github.com/nengo/nengo/pull/1224>`_)
+- Added ``nengo.utils.network.activate_direct_mode`` function to make it
+  easier to activate direct mode in networks where some parts require neurons.
+  (`#1111 <https://github.com/nengo/nengo/issues/1111>`_,
+  `#1168 <https://github.com/nengo/nengo/pull/1168>`_)
 
 **Fixed**
 

--- a/nengo/utils/tests/test_network.py
+++ b/nengo/utils/tests/test_network.py
@@ -1,4 +1,7 @@
+import pytest
+
 import nengo
+from nengo.utils.network import activate_direct_mode
 
 
 def test_withself():
@@ -19,3 +22,46 @@ def test_withself():
             e2 = nengo.Ensemble(10, dimensions=1)
             assert e2 in ea1.ensembles
     assert len(nengo.Network.context) == 0
+
+
+def test_activate_direct_mode():
+    with nengo.Network() as model:
+        direct_mode_ens = [nengo.Ensemble(10, 1), nengo.Ensemble(10, 1)]
+        non_direct_pre = nengo.Ensemble(10, 1)
+        non_direct_post = nengo.Ensemble(10, 1)
+        non_direct_probe = nengo.Ensemble(10, 1)
+        non_direct_mode_ens = [
+            non_direct_pre, non_direct_post, non_direct_probe]
+
+        nengo.Connection(direct_mode_ens[0], direct_mode_ens[1])
+
+        nengo.Connection(non_direct_pre.neurons[0], direct_mode_ens[0])
+        nengo.Connection(direct_mode_ens[1], non_direct_post.neurons[0])
+        nengo.Probe(non_direct_probe.neurons)
+
+    activate_direct_mode(model)
+
+    for ens in direct_mode_ens:
+        assert type(ens.neuron_type) is nengo.Direct
+    for ens in non_direct_mode_ens:
+        assert type(ens.neuron_type) is not nengo.Direct
+
+
+@pytest.mark.parametrize('learning_rule, weights', (
+    (nengo.PES(), False),
+    (nengo.BCM(), True),
+    (nengo.Oja(), True),
+    (nengo.Voja(), False)
+))
+def test_activate_direct_mode_learning(RefSimulator, learning_rule, weights):
+    with nengo.Network() as model:
+        pre = nengo.Ensemble(10, 1)
+        post = nengo.Ensemble(10, 1)
+        conn = nengo.Connection(
+            pre, post, solver=nengo.solvers.LstsqL2(weights=weights))
+        conn.learning_rule_type = learning_rule
+
+    activate_direct_mode(model)
+
+    with RefSimulator(model) as sim:
+        sim.run(0.01)


### PR DESCRIPTION
**Motivation and context:**
Sometime I want to run networks in direct mode, but some parts use connections to or from neurons. In those cases it is not possible to set the top-level `neuron_type` to `Direct` because some ensembles need to still use neurons. This PR adds a function where direct mode is only activated for ensembles where this is possible.

Not sure whether this better fits into `nengo_extras`, but to me it seems like something pretty basic that one might need for many networks.

**How has this been tested?**
Added a unit test.

**How long should this take to review?**

<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->

<!--- Take into account both the size and complexity of the changes. -->

<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->

<!--- Leave only the line that applies below: -->
- Average (neither quick nor lengthy)

**Types of changes:**

<!--- What types of changes does your code introduce? -->

<!--- Leave all lines that apply below: -->
- New feature (non-breaking change which adds functionality)

**Checklist:**

<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->

<!--- If a box is not applicable, please justify below the checklist. -->

<!--- If you're unsure about any of these, don't hesitate to ask. -->

<!--- We're here to help! -->
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
