### PR TITLE
Deprecate `sim.model.params` in favour of `sim.data`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,12 +15,21 @@ Release History
 
    - Added
    - Changed
+   - Deprecated
    - Removed
    - Fixed
 
 2.2.1 (unreleased)
 ==================
 
+**Deprecated**
+
+- Access to ``nengo.Simulator.model`` is deprecated. To access static data
+  generated during the build use ``nengo.Simulator.data``. It provides access
+  to everything that ``nengo.Simulator.model.params`` used to provide access to
+  and is the canonical way to access this data across different backends.
+  (`#1145 <https://github.com/nengo/nengo/issues/1145>`_,
+  `#1173 <https://github.com/nengo/nengo/pull/1173>`_)
 
 
 2.2.0 (September 12, 2016)

--- a/examples/learning/learn_associations.ipynb
+++ b/examples/learning/learn_associations.ipynb
@@ -303,7 +303,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "scale = (sim.model.params[memory].gain / memory.radius)[:, np.newaxis]\n",
+      "scale = (sim.data[memory].gain / memory.radius)[:, np.newaxis]\n",
       "\n",
       "def plot_2d(text, xy):\n",
       "    plt.figure()\n",

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -68,7 +68,7 @@ def get_eval_points(model, conn, rng):
             conn.pre_obj, conn.eval_points, rng, conn.scale_eval_points)
 
 
-def get_targets(model, conn, eval_points):
+def get_targets(conn, eval_points):
     if conn.function is None:
         targets = eval_points[:, conn.pre_slice]
     elif isinstance(conn.function, np.ndarray):
@@ -83,14 +83,14 @@ def get_targets(model, conn, eval_points):
 
 def build_linear_system(model, conn, rng):
     eval_points = get_eval_points(model, conn, rng)
-    activities = get_activities(model, conn.pre_obj, eval_points)
+    activities = get_activities(model.params, conn.pre_obj, eval_points)
     if np.count_nonzero(activities) == 0:
         raise BuildError(
             "Building %s: 'activites' matrix is all zero for %s. "
             "This is because no evaluation points fall in the firing "
             "ranges of any neurons." % (conn, conn.pre_obj))
 
-    targets = get_targets(model, conn, eval_points)
+    targets = get_targets(conn, eval_points)
     return eval_points, activities, targets
 
 
@@ -100,7 +100,7 @@ def build_decoders(model, conn, rng, transform):
     bias = model.params[conn.pre_obj].bias
 
     eval_points = get_eval_points(model, conn, rng)
-    targets = get_targets(model, conn, eval_points)
+    targets = get_targets(conn, eval_points)
 
     x = np.dot(eval_points, encoders.T / conn.pre_obj.radius)
     E = None

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -82,10 +82,9 @@ def gen_eval_points(ens, eval_points, rng, scale_eval_points=True):
     return eval_points
 
 
-def get_activities(model, ens, eval_points):
-    x = np.dot(eval_points, model.params[ens].encoders.T / ens.radius)
-    return ens.neuron_type.rates(
-        x, model.params[ens].gain, model.params[ens].bias)
+def get_activities(params, ens, eval_points):
+    x = np.dot(eval_points, params[ens].encoders.T / ens.radius)
+    return ens.neuron_type.rates(x, params[ens].gain, params[ens].bias)
 
 
 def get_gain_bias(ens, rng=np.random):

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -175,6 +175,19 @@ class Simulator(object):
         return self._n_steps
 
     @property
+    def model(self):
+        """The built `.Model` used to simulate the network.
+
+        .. note:: This attribute is deprecated as of Nengo 2.3.0.
+                  Use ``Simulator.data`` instead.
+        """
+        warnings.warn(
+            "The 'model' attribute is deprecated. If you are trying to access "
+            "build information via `model.params`, use the `Simulator.data` "
+            "attribute instead.", DeprecationWarning)
+        return self._model
+
+    @property
     def time(self):
         """(float) The current time of the simulator."""
         return self._time

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -282,15 +282,15 @@ def test_dist_transform(Simulator, seed):
 
     sim = Simulator(net)
 
-    w = sim.model.params[conn1].weights
+    w = sim.data[conn1].weights
     assert np.allclose(np.mean(w), 0.5, atol=0.01)
     assert np.allclose(np.std(w), 1, atol=0.01)
     assert w.shape == (101, 100)
 
-    assert sim.model.params[conn2].weights.shape == (10, 101)
-    assert sim.model.params[conn3].weights.shape == (102, 101)
-    assert sim.model.params[conn4].weights.shape == (1, 2)
-    assert sim.model.params[conn5].weights.shape == (103, 102)
+    assert sim.data[conn2].weights.shape == (10, 101)
+    assert sim.data[conn3].weights.shape == (102, 101)
+    assert sim.data[conn4].weights.shape == (1, 2)
+    assert sim.data[conn5].weights.shape == (103, 102)
 
     # make sure the seed works (gives us the same transform)
     with nengo.Network(seed=seed) as net:
@@ -300,7 +300,7 @@ def test_dist_transform(Simulator, seed):
         conn = nengo.Connection(a, b)
 
     sim = Simulator(net)
-    assert np.allclose(w, sim.model.params[conn].weights)
+    assert np.allclose(w, sim.data[conn].weights)
 
 
 def test_weights(Simulator, nl, plt, seed):

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -395,7 +395,7 @@ def test_voja_encoders(Simulator, nl_nodirect, rng, seed):
     # during the build process, because it modifies the scaled_encoders signal
     # proportional to this factor. Therefore, we should check that its
     # assumption actually holds.
-    encoder_scale = (sim.model.params[x].gain / x.radius)[:, np.newaxis]
+    encoder_scale = (sim.data[x].gain / x.radius)[:, np.newaxis]
     assert np.allclose(sim.data[x].encoders,
                        sim.data[x].scaled_encoders / encoder_scale)
 

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -118,3 +118,10 @@ def test_entry_point(Simulator):
     sims = [ep.load() for ep in
             pkg_resources.iter_entry_points(group='nengo.backends')]
     assert Simulator in sims
+
+
+def test_model_attribute_is_deprecated(RefSimulator):
+    with warns(DeprecationWarning):
+        with RefSimulator(nengo.Network()) as sim:
+            pass
+        assert sim.model

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -102,7 +102,7 @@ def eval_point_decoding(conn, sim, eval_points=None):
         eval_points = np.asarray(eval_points)
 
     weights = sim.data[conn].weights
-    activities = get_activities(sim.model, conn.pre_obj, eval_points)
+    activities = get_activities(sim.data, conn.pre_obj, eval_points)
     decoded = np.dot(activities, weights.T)
-    targets = get_targets(sim.model, conn, eval_points)
+    targets = get_targets(conn, eval_points)
     return eval_points, targets, decoded

--- a/nengo/utils/ensemble.py
+++ b/nengo/utils/ensemble.py
@@ -54,7 +54,7 @@ def tuning_curves(ens, sim, inputs=None):
         inputs = np.asarray(inputs).T
 
     eval_points = inputs.reshape((-1, ens.dimensions))
-    activities = get_activities(sim.model, ens, eval_points)
+    activities = get_activities(sim.data, ens, eval_points)
     return inputs, activities.reshape(inputs.shape[:-1] + (-1,))
 
 


### PR DESCRIPTION
**Motivation and context:**
As discussed and decided in #1145 static data generated during the build (e.g. eval points, encoders) should be accessed via the `sim.data` attribute. This PR deprecates the access to `sim.model` (a `DeprecationWarning` will be issued when accessing the attribute).

One thing that might be controversial is whether there might be legit use cases to access `sim.model` (as it provides more than just `sim.model.params`). But to me it seems like the model does not necessarily belong in the public interface of the simulator and all tests were easily adjusted for the change.

Just deprecating `sim.model.params` would be more complicated because it should only be deprecated when accessed via `sim.model.params`, but not when accessed within the build process.

**How has this been tested?**
The first commit completely removes the access to `sim.model` to make all tests where it is used fail. All those places where fixed in the same commit. Thus all tests (including `--slow` tests) pass without the need to access `sim.model`. The second commit reintroduces `sim.model` with a deprecation warning and a test for this warning.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Breaking change (fix or feature that causes existing functionality to change)


**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**

In theory, it should be documented that backends should provide access to certain things via `sim.data`. But we do not have a general guide for backend developers yet, so I have no idea where I put this information.

We should also add some documentation on how to “probe” those static build data, but couldn't figure out a good place for that so far.