### PR TITLE
Cache probe data on access.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Release History
 2.2.1 (unreleased)
 ==================
 
+**Changed**
+
+- Access to probe data via ``nengo.Simulator.data`` is now cached,
+  making repeated access much faster.
+  (`#1076 <https://github.com/nengo/nengo/issues/1076>`_,
+  `#1175 <https://github.com/nengo/nengo/pull/1175>`_)
+
 **Deprecated**
 
 - Access to ``nengo.Simulator.model`` is deprecated. To access static data

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -30,13 +30,17 @@ class ProbeDict(Mapping):
 
     def __init__(self, raw):
         self.raw = raw
+        self._cache = {}
 
     def __getitem__(self, key):
-        rval = self.raw[key]
-        if isinstance(rval, list):
-            rval = np.asarray(rval)
-            rval.setflags(write=False)
-        return rval
+        if (key not in self._cache or
+                len(self._cache[key]) != len(self.raw[key])):
+            rval = self.raw[key]
+            if isinstance(rval, list):
+                rval = np.asarray(rval)
+                rval.setflags(write=False)
+            self._cache[key] = rval
+        return self._cache[key]
 
     def __iter__(self):
         return iter(self.raw)

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -53,6 +53,19 @@ def test_probedict():
     assert np.all(probedict.get("list") == np.asarray(raw.get("list")))
 
 
+def test_probedict_with_repeated_simulator_runs(RefSimulator):
+    with nengo.Network() as model:
+        ens = nengo.Ensemble(10, 1)
+        p = nengo.Probe(ens)
+
+    dt = 0.001
+    with RefSimulator(model, dt=dt) as sim:
+        sim.run(0.01)
+        assert len(sim.data[p]) == 10
+        sim.run(0.01)
+        assert len(sim.data[p]) == 20
+
+
 def test_close_function(Simulator):
     m = nengo.Network()
     with m:


### PR DESCRIPTION
**Motivation and context:**
Repeated access to probes is slow (see #1076). This caches the read-only NumPy array to make it faster.

**How has this been tested?**
Ran this script adopted from @arvoelke in #1076 on master and this branch:
```python
from __future__ import print_function

import time
import nengo

with nengo.Network() as model:
    x = nengo.Ensemble(1000, 1)
    p_neurons = nengo.Probe(x.neurons)

with nengo.Simulator(model) as sim:
    sim.run(10)

# Repeated probe accesses
start = time.time()
for m in range(x.n_neurons):
    sim.data[p_neurons][0, m]
print(time.time() - start)

# Only one probe access
start = time.time()
u = sim.data[p_neurons][0, :]
for m in range(x.n_neurons):
    u[m]
print(time.time() - start)
```
The repeated access block took 17s on master vs. 0.017s on this branch. The second single access block was reduced to 0.00017s from 0.017s. (I don't know what's up with all the 17s ... :ghost: )

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
The usual place: “Files changed”
Note that the cache does not need to use weak references because the `raw` dict in the `ProbeDict` class doesn't use weak references either. Thus, as long as the `ProbeDict` instance is around, there will always be a strong reference to each key.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have included a changelog entry.
- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [na] I have updated the documentation accordingly.
