### PR TITLE
Iterating over NengoObject raises error

### DIFF
--- a/nengo/base.py
+++ b/nengo/base.py
@@ -63,6 +63,9 @@ class NengoObject(with_metaclass(NetworkMember, SupportDefaultsMixin)):
     def __setstate__(self, state):
         raise NotImplementedError("Nengo objects do not support pickling")
 
+    def __iter__(self):
+        raise NotImplementedError("NengoObject is not iterable")
+
     def __setattr__(self, name, val):
         if hasattr(self, '_initialized') and not hasattr(self, name):
             warnings.warn(
@@ -137,6 +140,9 @@ class ObjView(object):
 
     def __setstate__(self, state):
         raise NotImplementedError("Nengo objects do not support pickling")
+
+    def __iter__(self):
+        raise TypeError("ObjView is not iterable")
 
     def __len__(self):
         return self.size_out


### PR DESCRIPTION
**Motivation and context:**

<!--- Why is this change required? What problem does it solve? -->

<!--- If it addresses an open issue, please link to the issue here. -->

Iterating over a `NengoObject` would cause infinite loops. See #1176.

**How has this been tested?**

<!--- Please describe in detail how you tested your changes. -->

<!--- Reviewers will test your PR in at least this way. -->

Tested on a few toy examples. Now multiplying a NengoObject by a Numpy array, for example, causes an error.

**How long should this take to review?**

<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->

<!--- Take into account both the size and complexity of the changes. -->

<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->

<!--- Leave only the line that applies below: -->
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

<!--- What types of changes does your code introduce? -->

<!--- Leave all lines that apply below: -->
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->

<!--- If a box is not applicable, please justify below the checklist. -->

<!--- If you're unsure about any of these, don't hesitate to ask. -->

<!--- We're here to help! -->
- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I don't think this needs additional tests. I also think it's fine without a changelog entry, though one wouldn't hurt (please go ahead).

The only possible thing to do would be to make sure we don't have any other objects in Nengo that this could cause an issue for. I already checked `Network` and it's fine.
