### PR TITLE
Factored out `sample` function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,10 @@ Release History
   in the terminal and Jupyter notebook.
   (`#937 <https://github.com/nengo/nengo/issues/937>`_,
   `#1151 <https://github.com/nengo/nengo/pull/1151>`_)
+- Added ``nengo.dists.get_samples`` function for convenience
+  when working with distributions or samples.
+  (`#1181 <https://github.com/nengo/nengo/pull/1181>`_,
+  `docs <http://pythonhosted.org/nengo/frontend_api.html#nengo.dists.get_samples>`_)
 
 **Changed**
 

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -21,6 +21,34 @@ Nengo Objects
 
 .. autoclass:: nengo.Probe
 
+Distributions
+=============
+
+.. autoclass:: nengo.dists.Distribution
+   :exclude-members: sample
+
+   .. automethod:: nengo.dists.Distribution.sample(n, d=None, rng=np.random)
+
+.. autofunction:: nengo.dists.get_samples(dist_or_samples, n, d=None, rng=np.random)
+
+.. autoclass:: nengo.dists.Uniform
+
+.. autoclass:: nengo.dists.Gaussian
+
+.. autoclass:: nengo.dists.Exponential
+
+.. autoclass:: nengo.dists.UniformHypersphere
+
+.. autoclass:: nengo.dists.Choice
+
+.. autoclass:: nengo.dists.PDF
+
+.. autoclass:: nengo.dists.SqrtBeta
+
+.. autoclass:: nengo.dists.SubvectorLength
+
+.. autoclass:: nengo.dists.CosineSimilarity
+
 Neuron types
 ============
 

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -8,7 +8,7 @@ from nengo.builder.node import SimPyFunc
 from nengo.builder.operator import (
     DotInc, ElementwiseInc, PreserveValue, Reset, SlicedCopy)
 from nengo.connection import Connection
-from nengo.dists import Distribution
+from nengo.dists import get_samples
 from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError, ObsoleteError
 from nengo.neurons import Direct
@@ -222,9 +222,8 @@ def build_connection(model, conn):
     post_slice = conn.post_slice
 
     # Sample transform if given a distribution
-    transform = (conn.transform.sample(conn.size_out, conn.size_mid, rng=rng)
-                 if isinstance(conn.transform, Distribution) else
-                 np.array(conn.transform))
+    transform = get_samples(
+        conn.transform, conn.size_out, d=conn.size_mid, rng=rng)
 
     # Figure out the signal going across this connection
     in_signal = model.sig[conn]['in']

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -498,3 +498,40 @@ class DistOrArrayParam(NdarrayParam):
             Parameter.validate(self, instance, distorarray)
             return distorarray
         return super(DistOrArrayParam, self).validate(instance, distorarray)
+
+
+def get_samples(dist_or_samples, n, d=None, rng=np.random):
+    """Convenience function to sample a distribution or return samples.
+
+    Use this function in situations where you accept an argument that could
+    be a distribution, or could be an ``array_like`` of samples.
+
+    Examples
+    --------
+    >>> def mean(values, n=100):
+    ...     samples = get_samples(values, n=n)
+    ...     return np.mean(samples)
+    >>> mean([1, 2, 3, 4])
+    2.5
+    >>> mean(nengo.dists.Gaussian(0, 1))
+    0.057277898442269548
+
+    Parameters
+    ----------
+    dist_or_samples : `.Distribution` or (n, d) array_like
+        Source of the samples to be returned.
+    n : int
+        Number samples to take.
+    d : int or None, optional (Default: None)
+        The number of dimensions to return.
+    rng : RandomState, optional (Default: np.random)
+        Random number generator.
+
+    Returns
+    -------
+    samples : (n, d) array_like
+
+    """
+    if isinstance(dist_or_samples, Distribution):
+        return dist_or_samples.sample(n, d=d, rng=rng)
+    return np.array(dist_or_samples)

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -11,7 +11,7 @@ class Distribution(FrozenObject):
     """A base class for probability distributions.
 
     The only thing that a probabilities distribution need to define is a
-    ``sample`` function. This base class ensures that all distributions
+    `.sample` method. This base class ensures that all distributions
     accept the same arguments for the sample function.
     """
 
@@ -26,16 +26,16 @@ class Distribution(FrozenObject):
         ----------
         n : int
             Number samples to take.
-        d : int or None, optional
+        d : int or None, optional (Default: None)
             The number of dimensions to return. If this is an int, the return
-            value will be of shape ``(n, d)``. If None (default), the return
+            value will be of shape ``(n, d)``. If None, the return
             value will be of shape ``(n,)``.
-        rng : RandomState, optional
+        rng : `numpy.random.RandomState`, optional
             Random number generator state.
 
         Returns
         -------
-        ndarray
+        samples : (n,) or (n, d) array_like
             Samples as a 1d or 2d array depending on ``d``. The second
             dimension enumerates the dimensions of the process.
         """
@@ -99,7 +99,7 @@ class Uniform(Distribution):
         The closed lower bound of the uniform distribution; samples >= low
     high : Number
         The open upper bound of the uniform distribution; samples < high
-    integer : boolean, optional
+    integer : boolean, optional (Default: False)
         If true, sample from a uniform distribution of integers. In this case,
         low and high should be integers.
     """
@@ -141,7 +141,7 @@ class Gaussian(Distribution):
 
     Raises
     ------
-    ValidationError if ``std <= 0``
+    ValidationError if std is <= 0
 
     """
     mean = NumberParam('mean')
@@ -163,16 +163,19 @@ class Gaussian(Distribution):
 class Exponential(Distribution):
     """An exponential distribution (optionally with high values clipped).
 
-    If `high` is left to its default value of infinity, this is a standard
-    exponential distribution. If `high` is set, then any sampled values at
-    or above `high` will be clipped so they are slightly below `high`. This is
-    useful for thresholding and by extension, the AssociativeMemory.
+    If ``high`` is left to its default value of infinity, this is a standard
+    exponential distribution. If ``high`` is set, then any sampled values at
+    or above ``high`` will be clipped so they are slightly below ``high``.
+    This is useful for thresholding and, by extension,
+    `.networks.AssociativeMemory`.
 
-    The probability distribution function (PDF) is given by
+    The probability distribution function (PDF) is given by::
+
                |  0                                 if x < shift
         p(x) = | 1/scale * exp(-(x - shift)/scale)  if x >= shift and x < high
                |  n                                 if x == high - eps
                |  0                                 if x >= high
+
     where `n` is such that the PDF integrates to one, and `eps` is an
     infintesimally small number such that samples of `x` are strictly less than
     `high` (in practice, `eps` depends on the floating point precision).
@@ -182,10 +185,10 @@ class Exponential(Distribution):
     scale : float
         The scale parameter (inverse of the rate parameter lambda). Larger
         values make the distribution narrower (sharper peak).
-    shift : float, optional
+    shift : float, optional (Default: 0)
         Amount to shift the distribution by. There will be no values smaller
         than this shift when sampling from the distribution.
-    high : float, optional
+    high : float, optional (Default: np.inf)
         All values larger than or equal to this value will be clipped to
         slightly less than this value.
     """
@@ -215,11 +218,10 @@ class UniformHypersphere(Distribution):
 
     Parameters
     ----------
-    surface : bool
+    surface : bool, optional (Default: False)
         Whether sample points should be distributed uniformly
         over the surface of the hyperphere (True),
         or within the hypersphere (False).
-        Default: False
     """
 
     surface = BoolParam('surface')
@@ -258,13 +260,13 @@ class Choice(Distribution):
 
     Parameters
     ----------
-    options : array_like (N, ...)
+    options : (N, ...) array_like
         The options (choices) to choose between. The choice is always done
         along the first axis, so if `options` is a matrix, the options are
         the rows of that matrix.
-    weights : array_like (N,) (optional)
+    weights : (N,) array_like, optional (Default: None)
         Weights controlling the probability of selecting each option. Will
-        automatically be normalized. Defaults to a uniform distribution.
+        automatically be normalized. If None, weights be uniformly distributed.
     """
 
     options = NdarrayParam('options', shape=('*', '...'))
@@ -312,17 +314,19 @@ class Choice(Distribution):
 class SqrtBeta(Distribution):
     """Distribution of the square root of a Beta distributed random variable.
 
-    Given `n + m` dimensional random unit vectors, the length of subvectors
-    with `m` elements will be distributed according to this distribution.
+    Given ``n + m`` dimensional random unit vectors, the length of subvectors
+    with ``m`` elements will be distributed according to this distribution.
 
     Parameters
     ----------
-    n, m : Number
-        Shape parameters of the distribution.
+    n: int
+        Number of subvectors.
+    m: int, optional (Default: 1)
+        Length of each subvector.
 
     See also
     --------
-    SubvectorLength
+    nengo.dists.SubvectorLength
     """
 
     n = IntParam('n', low=0)
@@ -343,16 +347,16 @@ class SqrtBeta(Distribution):
     def cdf(self, x):
         """Cumulative distribution function.
 
-        Requires Scipy.
+        .. note:: Requires SciPy.
 
         Parameters
         ----------
-        x : ndarray
+        x : array_like
             Evaluation points in [0, 1].
 
         Returns
         -------
-        ndarray
+        cdf : array_like
             Probability that `X <= x`.
         """
         from scipy.special import betainc
@@ -364,17 +368,17 @@ class SqrtBeta(Distribution):
     def pdf(self, x):
         """Probability distribution function.
 
-        Requires Scipy.
+        .. note:: Requires SciPy.
 
         Parameters
         ----------
-        x : ndarray
+        x : array_like
             Evaluation points in [0, 1].
 
         Returns
         -------
-        ndarray
-            Probability density at `x`.
+        pdf : array_like
+            Probability density at ``x``.
         """
         from scipy.special import beta
         return (2 / beta(self.m / 2.0, self.n / 2.0) * x ** (self.m - 1) *
@@ -383,17 +387,17 @@ class SqrtBeta(Distribution):
     def ppf(self, y):
         """Percent point function (inverse cumulative distribution).
 
-        Requires Scipy.
+        .. note:: Requires SciPy.
 
         Parameters
         ----------
-        y : ndarray
+        y : array_like
             Cumulative probabilities in [0, 1].
 
         Returns
         -------
-        ndarray
-            Evaluation points `x` in [0, 1] such that `P(X <= x) = y`.
+        ppf : array_like
+            Evaluation points ``x`` in [0, 1] such that ``P(X <= x) = y``.
         """
         from scipy.special import betaincinv
         sq_x = betaincinv(self.m / 2.0, self.n / 2.0, y)
@@ -407,12 +411,12 @@ class SubvectorLength(SqrtBeta):
     ----------
     dimensions : int
         Dimensionality of the complete unit vector.
-    subdimensions : int, optional
+    subdimensions : int, optional (Default: 1)
         Dimensionality of the subvector.
 
     See also
     --------
-    SqrtBeta
+    nengo.dists.SqrtBeta
     """
 
     def __init__(self, dimensions, subdimensions=1):
@@ -433,12 +437,12 @@ class CosineSimilarity(SubvectorLength):
     simply the distribution of their dot product.
 
     This is also equivalent to the distribution of a single coefficient from a
-    unit vector (a single dimension of `UniformHypersphere(surface=True)`).
+    unit vector (a single dimension of ``UniformHypersphere(surface=True)``).
 
-    This can be used to calculate an intercept `c = ppf(1 - p)` such that
-    `dot(u, v) >= c` with probability `p`, for random unit vectors `u` and `v`.
-    In other words, a neuron with intercept `ppf(1 - p)` will fire with
-    probability `p` for a random unit length input.
+    This can be used to calculate an intercept ``c = ppf(1 - p)`` such that
+    ``dot(u, v) >= c`` with probability ``p``, for random unit vectors ``u``
+    and ``v``. In other words, a neuron with intercept ``ppf(1 - p)`` will
+    fire with probability ``p`` for a random unit length input.
 
     Parameters
     ----------
@@ -447,7 +451,7 @@ class CosineSimilarity(SubvectorLength):
 
     See also
     --------
-    SqrtBeta
+    nengo.dists.SqrtBeta
     """
 
     def __init__(self, dimensions):


### PR DESCRIPTION
**Motivation and context:**
The ensemble tuning function in #871 needed access to the builder's `sample` function. We're moving #871 to `nengo_extras`, but it's a good idea to move the `sample` function anyhow, as it's used in several places.

Originally @drasmuss moved this to `nengo.utils.builder`; I figured it's not bad to have in `nengo.dists`. Though, since it's not quite the same as `Distribution.sample` we should perhaps rename it to something? `sample_if_needed` or something?

**Interactions with other PRs:**
Supercedes #871.

**How has this been tested?**
Ran the test suite locally. Doesn't require additional testing.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [NA] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
- [x] We should decide if we're okay with having this in `nengo.dists`, and whether we should keep it named `sample` or something more explicit.
- [x] Changelog entry (once we decide the point above) since it maybe become part of the frontend API.
