### PR TITLE
List probeable attributes on probe error

### DIFF
--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -28,8 +28,9 @@ class AttributeParam(StringParam):
                                 "into 'weights'. Probe 'weights' instead.",
                                 since="v2.1.0")
         if attr not in probe.obj.probeable:
-            raise ValidationError("Attribute %r is not probeable on %s."
-                                  % (attr, probe.obj),
+            raise ValidationError("Attribute %r is not probeable on %s.\n"
+                                  "Probeable attributes: %s"
+                                  % (attr, probe.obj, probe.obj.probeable),
                                   attr=self.name, obj=probe)
 
 


### PR DESCRIPTION
**Motivation and context:**
It's annoying to look up documentation on an object you're trying to probe when you've made a typo. Consequently, I thought it would be a good idea to list the probeable attributes of an object when an error happens.

**How has this been tested?**
Ran this branch with the following code:

```
import nengo

with nengo.Network() as model:
    nd = nengo.Node([0])
    ens = nengo.Ensemble(100, 1)

    voja = nengo.Voja(post_tau=None, learning_rate=5e-2)
    conn_in = nengo.Connection(nd, ens, synapse=None,
                               learning_rule_type=voja)

    p_enc = nengo.Probe(conn_in.learning_rule, 'scaled encoders')
```

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**

<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->

<!--- If a box is not applicable, please justify below the checklist. -->

<!--- If you're unsure about any of these, don't hesitate to ask. -->

<!--- We're here to help! -->
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] All new and existing tests passed.

This is such a small change it doesn't need a changelog entry, nor extra documentation in my opinion.
