### PR TITLE
Make indexing and slicing consistent with Python.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,10 @@ Release History
 
 **Changed**
 
+- Integer indexing of Nengo objects out of range raises an ``IndexError``
+  now to be consistent with standard Python behaviour.
+  (`#1176 <https://github.com/nengo/nengo/issues/1176>`_,
+  `#1183 <https://github.com/nengo/nengo/pull/1183>`_)
 - Documentation that applies to all Nengo projects has been moved to
   https://nengo.github.io/.
   (`#1251 <https://github.com/nengo/nengo/pull/1251>`_)

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -148,28 +148,29 @@ class ObjView(object):
 
     def __init__(self, obj, key=slice(None)):
         self.obj = obj
+
+        # Node.size_in != size_out, so one of these can be invalid
+        try:
+            self.size_in = np.arange(self.obj.size_in)[key].size
+        except IndexError:
+            self.size_in = None
+        try:
+            self.size_out = np.arange(self.obj.size_out)[key].size
+        except IndexError:
+            self.size_out = None
+        if self.size_in is None and self.size_out is None:
+            raise IndexError("Invalid slice '%s' of %s" % (key, self.obj))
+
         if is_integer(key):
             # single slices of the form [i] should be cast into
             # slice objects for convenience
             if key == -1:
                 # special case because slice(-1, 0) gives the empty list
-                key = slice(key, None)
+                self.slice = slice(key, None)
             else:
-                key = slice(key, key+1)
-        self.slice = key
-
-        # Node.size_in != size_out, so one of these can be invalid
-        try:
-            self.size_in = np.arange(self.obj.size_in)[self.slice].size
-        except IndexError:
-            self.size_in = None
-        try:
-            self.size_out = np.arange(self.obj.size_out)[self.slice].size
-        except IndexError:
-            self.size_out = None
-        if self.size_in is None and self.size_out is None:
-            raise ValidationError("Invalid slice '%s' of %s"
-                                  % (self.slice, self.obj), attr='key')
+                self.slice = slice(key, key+1)
+        else:
+            self.slice = key
 
     def copy(self):
         return copy(self)

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -256,13 +256,28 @@ def test_len():
     assert len(ens1) == 1
     assert len(ens5) == 5
     assert len(ens1[0]) == 1
+    assert len(ens1[-1]) == 1
     assert len(ens5[:3]) == 3
+    assert len(ens5[:100]) == 5
 
     # Neurons.__len__
     assert len(ens1.neurons) == 10
     assert len(ens5.neurons) == 100
     assert len(ens1.neurons[0]) == 1
     assert len(ens5.neurons[90:]) == 10
+    assert len(ens5.neurons[90:150]) == 10
+
+
+def test_invalid_indices():
+    with nengo.Network():
+        ens = nengo.Ensemble(10, dimensions=2)
+
+    with pytest.raises(IndexError):
+        assert ens[5]
+    with pytest.raises(IndexError):
+        assert ens[-5]
+    with pytest.raises(IndexError):
+        assert ens.neurons[20]
 
 
 def test_invalid_rates(Simulator):


### PR DESCRIPTION
**Motivation and context:**
Refer to the discussion in #1176. Basically, Nengo was converting integer indices on Nengo objects into slice and thus no `IndexError` was raised for out of bound indices. One particular problem with this behaviour was that iteration over Nengo objects would produce an infinite loop.

With this PR integer indexing will raise the appropriate `IndexError` and slice indexing will truncate to match default Python behaviour. There is also array indexing which will behave like integer indexing. This changes make the iteration example from #1176 work without producing an inifinite loop.

**How has this been tested?**
Added a few more test cases to check out of range indices and corner cases like negative indices. Also run the infinite loop example from #1176 which did not produce an infinite loop anymore.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that causes existing functionality to change)

Not entirely sure. I think of it as a bug fix, but in theory someone could have relied on the old truncating behaviour of integer indices, so the change could break existing models.

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
