### PR TITLE
Make non-view/non-scalar signal data C contiguous

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@ Release History
   (`#1191 <https://github.com/nengo/nengo/issues/1191>`_,
   `#1267 <https://github.com/nengo/nengo/pull/1267>`_)
 
+**Fixed**
+
+- Properly handle non C-contiguous node outputs.
+  (`#1184 <https://github.com/nengo/nengo/issues/1184>`_,
+  `#1185 <https://github.com/nengo/nengo/pull/1185>`_)
+
 2.3.1 (February 18, 2017)
 =========================
 

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -41,7 +41,10 @@ class Signal(object):
 
     def __init__(self, initial_value,
                  name=None, base=None, readonly=False, offset=0):
-        self._initial_value = np.asarray(initial_value).view()
+        if not np.isscalar(initial_value) and base is None:
+            self._initial_value = np.ascontiguousarray(initial_value).view()
+        else:
+            self._initial_value = np.asarray(initial_value).view()
         self._initial_value.setflags(write=False)
 
         if base is not None:

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -364,7 +364,18 @@ def test_node_with_offset_array_view(Simulator):
     with nengo.Network() as model:
         node = nengo.Node(v[1])
         probe = nengo.Probe(node)
-        assert probe  # suppress never used warning
+        assert probe
+
+    with Simulator(model):
+        pass
+
+
+def test_node_with_unusual_strided_view(Simulator, seed):
+    v = np.array([1., 2.], dtype=complex)  # 16 byte itemsize
+    with nengo.Network(seed=seed) as model:
+        node = nengo.Node(v.real)  # 8 byte itemsize, but 16 byte strides
+        probe = nengo.Probe(node)
+        assert probe
 
     with Simulator(model):
         pass


### PR DESCRIPTION
**Motivation and context:**
If input to a model is provided as non-contiguous view with weird strides, building the model can fail (see #1184 for more details). This PR ensures that the `initial_value` of signals are contiguous where possible (we can't make scalars contiguous as some parts of the code require them to be 0d arrays, contiguous arrays are always at least 1d; we want to keep signal views as views).

**Interactions with other PRs:**
#1156 which was fixed by #1157 falls into the same class of problems (views with weird offsets/strides in signals). Both fixes are required to fix both problems. Apart from some merge conflicts the changes should not influence each other.

**How has this been tested?**
Added a test based on the example code in #1184.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.