### PR TITLE
Added n_neurons property to Network.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,20 @@ Release History
 2.4.1 (unreleased)
 ==================
 
+**Added**
 
+- Added a ``n_neurons`` property to ``Network``, which gives the
+  number of neurons in the network, including all subnetworks.
+  (`#435 <https://github.com/nengo/nengo/issues/435>`_,
+  `#1186 <https://github.com/nengo/nengo/pull/1186>`_)
+
+**Changed**
+
+- ``EnsembleArray.n_neurons`` now gives the total number of neurons
+  in all ensembles, including those in subnetworks.
+  To get the number of neurons in each ensemble,
+  use ``EnsembleArray.n_neurons_per_ensemble``.
+  (`#1186 <https://github.com/nengo/nengo/pull/1186>`_)
 
 2.4.0 (April 18, 2017)
 ======================

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -179,6 +179,11 @@ class Network(object):
     def config(self, dummy):
         raise ReadonlyError(attr='config', obj=self)
 
+    @property
+    def n_neurons(self):
+        """(int) Number of neurons in this network, including subnetworks."""
+        return sum(ens.n_neurons for ens in self.all_ensembles)
+
     def __contains__(self, obj):
         return type(obj) in self.objects and obj in self.objects[type(obj)]
 

--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -64,7 +64,7 @@ class EnsembleArray(nengo.Network):
         A node that provides input to all of the ensembles in the array.
     n_ensembles : int
         The number of sub-ensembles to create.
-    n_neurons : int
+    n_neurons_per_ensemble : int
         The number of neurons in each sub-ensemble.
     neuron_input : Node or None
         A node that provides input to all the neurons in the ensemble array.
@@ -97,7 +97,7 @@ class EnsembleArray(nengo.Network):
 
         label_prefix = "" if label is None else label + "_"
 
-        self.n_neurons = n_neurons
+        self.n_neurons_per_ensemble = n_neurons
         self.n_ensembles = n_ensembles
         self.dimensions_per_ensemble = ens_dimensions
 
@@ -153,12 +153,14 @@ class EnsembleArray(nengo.Network):
                 attr='ea_ensembles[0].neuron_type', obj=self)
 
         self.neuron_input = nengo.Node(
-            size_in=self.n_neurons * self.n_ensembles, label="neuron_input")
+            size_in=self.n_neurons_per_ensemble * self.n_ensembles,
+            label="neuron_input")
 
         for i, ens in enumerate(self.ea_ensembles):
-            nengo.Connection(self.neuron_input[i * self.n_neurons:
-                                               (i + 1) * self.n_neurons],
-                             ens.neurons, synapse=None)
+            nengo.Connection(
+                self.neuron_input[i * self.n_neurons_per_ensemble:
+                                  (i + 1) * self.n_neurons_per_ensemble],
+                ens.neurons, synapse=None)
         return self.neuron_input
 
     @with_self
@@ -182,13 +184,15 @@ class EnsembleArray(nengo.Network):
                 attr='ea_ensembles[0].neuron_type', obj=self)
 
         self.neuron_output = nengo.Node(
-            size_in=self.n_neurons * self.n_ensembles, label="neuron_output")
+            size_in=self.n_neurons_per_ensemble * self.n_ensembles,
+            label="neuron_output")
 
         for i, ens in enumerate(self.ea_ensembles):
-            nengo.Connection(ens.neurons,
-                             self.neuron_output[i * self.n_neurons:
-                                                (i + 1) * self.n_neurons],
-                             synapse=None)
+            nengo.Connection(
+                ens.neurons,
+                self.neuron_output[i * self.n_neurons_per_ensemble:
+                                   (i + 1) * self.n_neurons_per_ensemble],
+                synapse=None)
         return self.neuron_output
 
     @with_self

--- a/nengo/tests/test_network.py
+++ b/nengo/tests/test_network.py
@@ -146,3 +146,13 @@ def test_raises_exception_on_incompatiple_type_arguments():
         nengo.Network(label=1)
     with pytest.raises(ValueError):
         nengo.Network(seed='label')
+
+
+def test_n_neurons():
+    with nengo.Network() as net:
+        nengo.Ensemble(10, 1)
+        assert net.n_neurons == 10
+        with nengo.Network() as subnet:
+            nengo.Ensemble(30, 1)
+            assert subnet.n_neurons == 30
+        assert net.n_neurons == 40


### PR DESCRIPTION
**Motivation and context:**
It's a pretty common thing to want to know how many neurons are in a particular network, as that's a metric people want to know when reviewing papers etc. I've given the one-liner to a few people over IM and it was asked for in #435, so might as well make it part of `Network`.

It should be noted that this PR also renames `EnsembleArray.n_neurons` to `EnsembleArray.n_neurons_per_ensemble`. Long, but we don't actually use it anywhere in tests or examples, so I think it won't matter much.

**How has this been tested?**
Added a short test for it (which passes).

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. (has a docstring, will show up in docs)
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
