### PR TITLE
Error if trying to learn on a direct ensemble

### DIFF
--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -3,6 +3,7 @@ import pytest
 
 import nengo
 from nengo.dists import UniformHypersphere
+from nengo.exceptions import ValidationError
 from nengo.learning_rules import LearningRuleTypeParam, PES, BCM, Oja, Voja
 from nengo.processes import WhiteSignal
 
@@ -469,3 +470,13 @@ def test_frozen():
 
     with pytest.raises((ValueError, RuntimeError)):
         a.learning_rate = 1e-1
+
+
+def test_pes_direct_errors():
+    """Test that applying a learning rule to a direct ensemble errors."""
+    with nengo.Network():
+        pre = nengo.Ensemble(10, 1, neuron_type=nengo.Direct())
+        post = nengo.Ensemble(10, 1)
+        conn = nengo.Connection(pre, post)
+        with pytest.raises(ValidationError):
+            conn.learning_rule_type = nengo.PES()


### PR DESCRIPTION
**Motivation and context:**
Currently we allow you to apply a PES learning rule to a connection from a direct mode ensemble. As shown in #554, this will fail at build time with a cryptic error. The error seems different now, but if anything worse, so this PR checks this at model construction time and raises a useful error.

**How has this been tested?**
Added a unit test to it. If you remove the `neuron_type=nengo.Direct()`, it will fail with `DID NOT RAISE`.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [NA] I have updated the documentation accordingly.
- [NA] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
