### PR TITLE
New spa fixes

### DIFF
--- a/nengo/spa/spa_ast.py
+++ b/nengo/spa/spa_ast.py
@@ -792,7 +792,7 @@ class DotProduct(BinaryNode):
         return 'dot({}, {})'.format(self.lhs, self.rhs)
 
 
-class Reinterpret(Node):
+class Reinterpret(Source):
     def __init__(self, source, vocab=None):
         source = ensure_node(source)
         super(Reinterpret, self).__init__(staticity=source.staticity)
@@ -833,7 +833,7 @@ class Reinterpret(Node):
         return 'reinterpret({})'.format(self.source)
 
 
-class Translate(Node):
+class Translate(Source):
     def __init__(self, source, vocab=None):
         source = ensure_node(source)
         super(Translate, self).__init__(staticity=source.staticity)

--- a/nengo/spa/tests/test_spa_ast.py
+++ b/nengo/spa/tests/test_spa_ast.py
@@ -241,3 +241,21 @@ def test_zero_vector():
     ast = Parser().parse_effect('state = 0')
     ast.infer_types(model, None)
     assert ast.source.type.vocab == model.state.vocabs[d]
+
+
+def test_vocab_transform_in_multiplication():
+    d = 16
+    with spa.Module() as model:
+        model.state = spa.State(d)
+
+    ast = Parser().parse_expr('2 * translate(state)')
+    assert str(ast) == '2 * translate(state)'
+
+    ast = Parser().parse_expr('translate(state) * 2')
+    assert str(ast) == 'translate(state) * 2'
+
+    ast = Parser().parse_expr('2 * reinterpret(state)')
+    assert str(ast) == '2 * reinterpret(state)'
+
+    ast = Parser().parse_expr('reinterpret(state) * 2')
+    assert str(ast) == 'reinterpret(state) * 2'


### PR DESCRIPTION
**Motivation and context:**
Changes to address #1201.

* Change the base class of `Translate` and `Reinterpret` to allow it to be used in other operations like products.
* Don't consider the parent context for type inference in dot products. It shouldn't matter as the dot product returns a scalar anyways.
* Be more specific about which binary operations allow to combine `TVocabulary` and `TScalar`.

The last two points lead to better, more specific error messages.

**How has this been tested?**
* Added a test for multiplictaion with `Translate` and `Reinterpret`
* Used the examples from #1201 to inspect the error messages.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@tcstewar, would you mind taking a look?