### PR TITLE
Fix example tests.

### DIFF
--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -53,8 +53,8 @@ slow_examples.sort()
 fast_examples.sort()
 
 
-def assert_noexceptions(nb_file, tmpdir, plt):
-    plt.saveas = None  # plt used to ensure figures are closed, but don't save
+def assert_noexceptions(nb_file, tmpdir):
+    plt = pytest.importorskip('matplotlib.pyplot')
     pytest.importorskip("IPython", minversion="1.0")
     pytest.importorskip("jinja2")
     from nengo.utils.ipython import export_py, load_notebook
@@ -64,21 +64,22 @@ def assert_noexceptions(nb_file, tmpdir, plt):
         tmpdir.join(os.path.splitext(os.path.basename(nb_path))[0]))
     export_py(nb, pyfile)
     execfile(pyfile, {})
+    plt.close('all')
 
 
 @pytest.mark.example
 @pytest.mark.parametrize('nb_file', fast_examples)
-def test_fast_noexceptions(nb_file, tmpdir, plt):
+def test_fast_noexceptions(nb_file, tmpdir):
     """Ensure that no cells raise an exception."""
-    assert_noexceptions(nb_file, tmpdir, plt)
+    assert_noexceptions(nb_file, tmpdir)
 
 
 @pytest.mark.slow
 @pytest.mark.example
 @pytest.mark.parametrize('nb_file', slow_examples)
-def test_slow_noexceptions(nb_file, tmpdir, plt):
+def test_slow_noexceptions(nb_file, tmpdir):
     """Ensure that no cells raise an exception."""
-    assert_noexceptions(nb_file, tmpdir, plt)
+    assert_noexceptions(nb_file, tmpdir)
 
 
 @pytest.mark.example

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -39,9 +39,8 @@ all_examples, slow_examples, fast_examples = [], [], []
 for subdir, _, files in os.walk(examples_dir):
     if (os.path.sep + '.') in subdir:
         continue
-
-    examples = [os.path.join(subdir, os.path.splitext(f)[0]) for f in files
-                if f.endswith('.ipynb')]
+    files = [f for f in files if f.endswith('.ipynb')]
+    examples = [os.path.join(subdir, os.path.splitext(f)[0]) for f in files]
     all_examples.extend(examples)
     slow_examples.extend([e for e, f in zip(examples, files)
                           if os.path.splitext(f)[0] in too_slow])


### PR DESCRIPTION
**Motivation and context:**
Fixes for:
* #1203: Close figures created in examples properly to free some memory.
* #1204: Correctly ignore non-notebook files in example folder.

In case you are wondering why #1204 is a problem because we only have notebook files in those folders: I was editing some of those files in Vim for the new-spa branch (sometimes easier than opening the Jupyter notebook and making sure they are converted to the right format) and vim creates a temporary file `.filename.ipynb.swp` which then changed which tests were actually run.

**How has this been tested?**
Ran `py.test -s --strict -r w nengo/tests/test_examples.py` and got matplotlib's too many open figures warning, went away with these changes.

Create a file one of the folders containing slow example and observe which examples are run: `py.test -v nengo/tests/test_examples.py`. Without the fix slow and fast examples get messed up somewhere. For example creating a file `aaaa` in `examples/spa` will cause the `question_memory` example to run as fast test, though it should be in the slow example list.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [do we need one?] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
