### PR TITLE
Change circular convolution scaling.

### DIFF
--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -49,6 +49,7 @@ def transform_in(dims, align, invert):
             tr[i] = row.real if i % 4 == 0 or i % 4 == 3 else row.imag
 
     remove_imag_rows(tr)
+    tr /= np.sqrt(dims)
     return tr.reshape((-1, dims))
 
 
@@ -66,9 +67,6 @@ def transform_out(dims):
 
     tr = tr.reshape(4*dims2, dims)
     remove_imag_rows(tr)
-    # IDFT has a 1/D scaling factor
-    tr /= dims
-
     return tr.T
 
 
@@ -195,8 +193,9 @@ def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
     with net:
         net.A = nengo.Node(size_in=dimensions, label="A")
         net.B = nengo.Node(size_in=dimensions, label="B")
-        net.product = Product(n_neurons, tr_out.shape[1],
-                              input_magnitude=input_magnitude * 2)
+        net.product = Product(
+            n_neurons, tr_out.shape[1],
+            input_magnitude=input_magnitude * 2. / np.sqrt(dimensions))
         net.output = nengo.Node(size_in=dimensions, label="output")
 
         nengo.Connection(net.A, net.product.A, transform=tr_a, synapse=None)


### PR DESCRIPTION
**Motivation and context:**
The spaopt methods (which hopefully will be finally implemented as helper function for new-spa) require the scaling factor on the FFT transforms to be 1/sqrt(d) to preserve the distribution of vector lengths. This PR changes the scaling accordingly.

**How has this been tested?**
Tests still pass.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue) [not really a bug, but also not a new feature]

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
