### PR TITLE
Make sim.model public again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,15 +46,6 @@ Release History
   (`#1076 <https://github.com/nengo/nengo/issues/1076>`_,
   `#1175 <https://github.com/nengo/nengo/pull/1175>`_)
 
-**Deprecated**
-
-- Access to ``nengo.Simulator.model`` is deprecated. To access static data
-  generated during the build use ``nengo.Simulator.data``. It provides access
-  to everything that ``nengo.Simulator.model.params`` used to provide access to
-  and is the canonical way to access this data across different backends.
-  (`#1145 <https://github.com/nengo/nengo/issues/1145>`_,
-  `#1173 <https://github.com/nengo/nengo/pull/1173>`_)
-
 2.2.0 (September 12, 2016)
 ==========================
 

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -83,7 +83,8 @@ def get_targets(conn, eval_points):
 
 def build_linear_system(model, conn, rng):
     eval_points = get_eval_points(model, conn, rng)
-    activities = get_activities(model.params, conn.pre_obj, eval_points)
+    ens = conn.pre_obj
+    activities = get_activities(model.params[ens], ens, eval_points)
     if np.count_nonzero(activities) == 0:
         raise BuildError(
             "Building %s: 'activites' matrix is all zero for %s. "

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -76,9 +76,9 @@ def gen_eval_points(ens, eval_points, rng, scale_eval_points=True):
     return eval_points
 
 
-def get_activities(params, ens, eval_points):
-    x = np.dot(eval_points, params[ens].encoders.T / ens.radius)
-    return ens.neuron_type.rates(x, params[ens].gain, params[ens].bias)
+def get_activities(built_ens, ens, eval_points):
+    x = np.dot(eval_points, built_ens.encoders.T / ens.radius)
+    return ens.neuron_type.rates(x, built_ens.gain, built_ens.bias)
 
 
 def get_gain_bias(ens, rng=np.random):

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -137,13 +137,6 @@ def test_entry_point(Simulator):
     assert Simulator in sims
 
 
-def test_model_attribute_is_deprecated(RefSimulator):
-    with warns(DeprecationWarning):
-        with RefSimulator(nengo.Network()) as sim:
-            pass
-        assert sim.model
-
-
 def test_signal_init_values(RefSimulator):
     """Tests that initial values are not overwritten."""
     zero = Signal([0])

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -101,8 +101,9 @@ def eval_point_decoding(conn, sim, eval_points=None):
     else:
         eval_points = np.asarray(eval_points)
 
+    ens = conn.pre_obj
     weights = sim.data[conn].weights
-    activities = get_activities(sim.data, conn.pre_obj, eval_points)
+    activities = get_activities(sim.data[ens], ens, eval_points)
     decoded = np.dot(activities, weights.T)
     targets = get_targets(conn, eval_points)
     return eval_points, targets, decoded

--- a/nengo/utils/ensemble.py
+++ b/nengo/utils/ensemble.py
@@ -54,7 +54,7 @@ def tuning_curves(ens, sim, inputs=None):
         inputs = np.asarray(inputs).T
 
     eval_points = inputs.reshape((-1, ens.dimensions))
-    activities = get_activities(sim.data, ens, eval_points)
+    activities = get_activities(sim.data[ens], ens, eval_points)
     return inputs, activities.reshape(inputs.shape[:-1] + (-1,))
 
 


### PR DESCRIPTION
**Motivation and context:**
This makes `sim.model` "public" again (that is, we no longer warn when accessing sim.model). This was discussed at the last dev meeting, and is the only issue blocking a Nengo and Nengo OCL release at the moment.

See #1198 for a summary of the issue, with links to the other places this was mentioned.

**How has this been tested?**
Existing tests are sufficient here.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [NA] I have updated the documentation accordingly.
- [NA] I have included a changelog entry.
- [NA] I have added tests to cover my changes.
- [x] All new and existing tests passed.

