### PR TITLE
Add the bias signal to `model.sig`

### DIFF
--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -165,8 +165,10 @@ def build_ensemble(model, ens):
             np.zeros(ens.n_neurons), name="%s.neuron_in" % ens)
         model.sig[ens.neurons]['out'] = Signal(
             np.zeros(ens.n_neurons), name="%s.neuron_out" % ens)
-        bias_sig = Signal(bias, name="%s.bias" % ens, readonly=True)
-        model.add_op(Copy(src=bias_sig, dst=model.sig[ens.neurons]['in']))
+        model.sig[ens.neurons]['bias'] = Signal(
+            bias, name="%s.bias" % ens, readonly=True)
+        model.add_op(Copy(src=model.sig[ens.neurons]['bias'],
+                          dst=model.sig[ens.neurons]['in']))
         # This adds the neuron's operator and sets other signals
         model.build(ens.neuron_type, ens.neurons)
 


### PR DESCRIPTION
**Motivation and context:**
I was making [these examples](https://github.com/nengo/nengo_examples/pull/9) of ablating neurons in an ensemble, and figured that the easiest way to do this is to set the encoder associated with the neuron to 0 (to eliminate decoded input) and setting the the bias to a large negative value (to eliminate direct input through `.neurons`). The encoder is already exposed through `model.sig[ens]['encoders']`, but bias was not. This PR exposes it through `model.sig[ens.neurons]['bias']`.

**How has this been tested?**
Existing unit tests should cover this.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [NA] I have updated the documentation accordingly.
- [NA] I have included a changelog entry.
- [NA] I have added tests to cover my changes.
- [x] All new and existing tests passed.