### PR TITLE
Add a config system quirks notebook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release History
 2.3.1 (unreleased)
 ==================
 
+**Added**
+
+- Added documentation on config system quirks.
+  (`#1224 <https://github.com/nengo/nengo/pull/1224>`_)
+
 **Fixed**
 
 - The matrix multiplication example will now work with matrices of any size

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -43,3 +43,10 @@ Nengo includes preset configurations that can be
 dropped into your model to enable specific neural circuits.
 
 .. autofunction:: nengo.presets.ThresholdingEnsembles
+
+Quirks
+======
+
+.. toctree::
+
+   examples/config_quirks

--- a/docs/examples/config_quirks.rst
+++ b/docs/examples/config_quirks.rst
@@ -1,0 +1,5 @@
+********************
+Config system quirks
+********************
+
+.. notebook:: ../../examples/quirks/config.ipynb

--- a/examples/quirks/config.ipynb
+++ b/examples/quirks/config.ipynb
@@ -1,0 +1,209 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:0ebf5c3bc3199eb8063ee84cf921e8ddae0116438b8615395399705835eae42c"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# Context matters, membership doesn't\n",
+      "\n",
+      "When you create a Nengo object\n",
+      "and leave the parameters as their default values,\n",
+      "we determine the default values dynamically\n",
+      "based on `Config` objects.\n",
+      "Every `Network` has an associated `Config` object,\n",
+      "and you can make new `Config` objects for additional flexibility.\n",
+      "\n",
+      "Nengo keeps track of the current context.\n",
+      "The following example works based on the context."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import nengo"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with nengo.Network() as model:\n",
+      "    model.config[nengo.Ensemble].radius = 2.0\n",
+      "    subnet = nengo.Network()\n",
+      "\n",
+      "    with subnet:\n",
+      "        a = nengo.Ensemble(10, 1)\n",
+      "        print(a.radius)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "The radius of `a` is `2.0`\n",
+      "because the current context includes both\n",
+      "`subnet` and `model`.\n",
+      "`subnet` does not change the default value of the radius,\n",
+      "but `model` does, so it uses the `model` default of `2.0`.\n",
+      "\n",
+      "Here's a similar example."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with nengo.Network() as model:\n",
+      "    model.config[nengo.Ensemble].radius = 2.0\n",
+      "    subnet = nengo.Network()\n",
+      "\n",
+      "with subnet:\n",
+      "    a = nengo.Ensemble(10, 1)\n",
+      "    print(a.radius)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "While this example looks nearly identical,\n",
+      "the difference is that `a` is created\n",
+      "in the context of `subnet` only;\n",
+      "`model` is not part of the config context.\n",
+      "Because of that, when `a` is created,\n",
+      "Nengo sees that no default is set in `subnet`\n",
+      "and uses the global default value of `1.0`.\n",
+      "\n",
+      "This may seem counterintuitive\n",
+      "since `subnet` is a member of `model`;\n",
+      "it's stored as a sub-network of the `model` network.\n",
+      "However, Nengo objects are not aware of their parents.\n",
+      "This allows `subnet` to be used the same way\n",
+      "whether it's the top-level network\n",
+      "or whether it's nested twenty layers deep,\n",
+      "but it also means that we can't set defaults\n",
+      "based on network membership."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Context details\n",
+      "\n",
+      "The configuration context is stored in the\n",
+      "`nengo.Config` class as `nengo.Config.context`.\n",
+      "`context` is a thread-local list.\n",
+      "We add new contexts to the end of that list\n",
+      "at the start of `with` blocks,\n",
+      "and pop contexts off of that list\n",
+      "at the end of `with` blocks."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# No context\n",
+      "len(nengo.Config.context)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# Model context\n",
+      "with model:\n",
+      "    print(len(nengo.Config.context))\n",
+      "    print(nengo.Config.context[0] is model.config)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# Subnet, Model context\n",
+      "with model:\n",
+      "    with subnet:\n",
+      "        print(len(nengo.Config.context))\n",
+      "        print(nengo.Config.context[0] is model.config)\n",
+      "        print(nengo.Config.context[1] is subnet.config)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "If you are not sure what context you're in,\n",
+      "but you want to know what the defaults are\n",
+      "in the current context,\n",
+      "use `nengo.Config.all_defaults`.\n",
+      "You can optionally pass in the type that you're interested in."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with model:\n",
+      "    with subnet:\n",
+      "        print(nengo.Config.all_defaults(nengo.Ensemble))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with subnet:\n",
+      "    print(nengo.Config.all_defaults(nengo.Ensemble))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Note above that the radius changes\n",
+      "despite the fact that both situations occur\n",
+      "in the context of `subnet`!\n",
+      "Configuration outside matters if no default\n",
+      "has been set in the immediate context."
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
**Motivation and context:**
#615 noted an unexpected way in which the config system works: config context matters, network membership does not. This PR attempts to explain this through a notebook, which is rendered in the documentation.

**How has this been tested?**
I built the documentation locally and ensured that it rendered properly.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [NA] I have added tests to cover my changes.
- [x] All new and existing tests passed.
