### PR TITLE
WIP: Implement RegularSpiking and PoissonSpiking

### DIFF
--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -21,8 +21,18 @@ from .config import Config
 from .connection import Connection
 from .ensemble import Ensemble
 from .node import Node
-from .neurons import (AdaptiveLIF, AdaptiveLIFRate, Direct, Izhikevich, LIF,
-                      LIFRate, RectifiedLinear, Sigmoid)
+from .neurons import (
+    AdaptiveLIF,
+    AdaptiveLIFRate,
+    Direct,
+    Izhikevich,
+    LIF,
+    LIFRate,
+    PoissonSpiking,
+    RectifiedLinear,
+    RegularSpiking,
+    Sigmoid
+)
 from .network import Network
 from .learning_rules import PES, BCM, Oja, Voja
 from .params import Default


### PR DESCRIPTION
**Motivation and context:**
See #579. The idea here is to generate spikes either at a regular rate, or with Poisson statistics, from a rate-based neuron type. So, if you do something like `nengo.RegularSpiking(nengo.LIFRate)`, you get something that is (very?) close to `nengo.LIF`.

This is still marked as a WIP because the `PoissonSpiking` implementation has poor accuracy and I'm not sure if that's a mistake in the implementation, or because they're bad. @tcstewar could you try out this branch and let me know what you think?

There are also some other things I want to look at in more detail. See the "Still to do" section below.

**How has this been tested?**
Real tests are TODO, but for now I've been playing with the new neuron types in the GUI to ensure that they build and run and look pretty normal. Right now, this looks right:

```python
import nengo

model = nengo.Network()
with model:
    stim = nengo.Node([0])
    a = nengo.Ensemble(n_neurons=50, 
                       dimensions=1, 
                       neuron_type=nengo.RegularSpiking(nengo.LIFRate()))
    nengo.Connection(stim, a)
```

But this looks strange / unstable:

```python
import nengo

model = nengo.Network()
with model:
    stim = nengo.Node([0])
    a = nengo.Ensemble(n_neurons=50, 
                       dimensions=1, 
                       neuron_type=nengo.PoissonSpiking(nengo.LIFRate()))
    nengo.Connection(stim, a)
```

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Types of changes:**

- New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Still to do:**

- [ ] Make sure the `PoissonSpiking` implementation is correct
- [ ] Use the Param system to store `base_type`
- [ ] Implement tests
- [ ] Add to `nl` / `nl_nodirect`

**Discussion points:**

One issue with testing this is that the neuron type requires a base neuron type to function (a neuron type from which to figure out the correct spike rate). That's fine for normal models, but currently the way our test suite works is to pass the neuron type to functions through a pytests fixture as a type, not as an instance. For each neuron type, we make an instance by just doing `nl()`, but that won't work for these composite types since they require something like `nl(some_other_nl())`. So there are two options.

1. Don't add it to `nl` / `nl_nodirect`; test them separately and specifically like we do for `AdaptiveLIF` and `Izhikevich`

2. Modify the testing infrastructure to take in instances rather than types. It used to be not possible to do this, since neuron types were mutable and that could cause annoying issues. But now neuron types are immutable, so we should be able to pass in instances. This, however, might be difficult to do through the command line, which is currently possible (but maybe could be done some other way?)