### PR TITLE
Add Samples distribution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Release History
   ``Ensemble.normalize_encoders`` to ``False``.
   (`#1191 <https://github.com/nengo/nengo/issues/1191>`_,
   `#1267 <https://github.com/nengo/nengo/pull/1267>`_)
+- Added the ``Samples`` distribution to allow raw NumPy arrays
+  to be passed in situations where a distribution is required.
+  (`#1233 <https://github.com/nengo/nengo/pull/1233>`_)
 
 **Changed**
 
@@ -37,6 +40,11 @@ Release History
   be passed as the label.
   (`#1277 <https://github.com/nengo/nengo/pull/1277>`_,
   `#1275 <https://github.com/nengo/nengo/issues/1275>`_)
+- It is now possible to pass NumPy arrays in the ``ens_kwargs`` argument of
+  ``EnsembleArray``. Arrays are wrapped in a ``Samples`` distribution internally.
+  (`#691 <https://github.com/nengo/nengo/issues/691>`_,
+  `#766 <https://github.com/nengo/nengo/issues/766>`_,
+  `#1233 <https://github.com/nengo/nengo/pull/1233>`_)
 
 **Fixed**
 

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -41,6 +41,8 @@ Distributions
 
 .. autoclass:: nengo.dists.Choice
 
+.. autoclass:: nengo.dists.Samples
+
 .. autoclass:: nengo.dists.PDF
 
 .. autoclass:: nengo.dists.SqrtBeta

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -311,6 +311,55 @@ class Choice(Distribution):
         return self.options[i]
 
 
+class Samples(Distribution):
+    """A set of samples.
+
+    This class is a subclass of `.Distribution` so that it can be used in any
+    situation that calls for a  `.Distribution`. However, the call to `.sample`
+    must match the dimensions of the samples or a `.ValidationError`
+    will be raised.
+
+    Parameters
+    ----------
+    samples : (n, d) array_like
+        ``n`` and ``d`` must match what is eventually passed to `.sample`.
+    """
+
+    samples = NdarrayParam('samples', shape=('...',))
+
+    def __init__(self, samples):
+        super(Samples, self).__init__()
+        self.samples = samples
+
+    def __repr__(self):
+        return "Samples(samples=%r)" % (self.samples,)
+
+    def sample(self, n, d=None, rng=np.random):
+        samples = np.array(self.samples)
+        shape = (n,) if d is None else (n, d)
+
+        if d is None:
+            samples = samples.squeeze()
+
+        if d is not None and samples.ndim == 1:
+            samples = samples[..., np.newaxis]
+
+        if samples.shape[0] != shape[0]:
+            raise ValidationError("Wrong number of samples requested; got "
+                                  "%d, should be %d" % (n, samples.shape[0]),
+                                  attr='samples', obj=self)
+        elif d is None and len(samples.shape) != 1:
+            raise ValidationError("Wrong sample dimensionality requested; got "
+                                  "'None', should be %d" % (samples.shape[1],),
+                                  attr='samples', obj=self)
+        elif d is not None and samples.shape[1] != shape[1]:
+            raise ValidationError("Wrong sample dimensionality requested; got "
+                                  "%d, should be %d" % (d, samples.shape[1]),
+                                  attr='samples', obj=self)
+
+        return samples
+
+
 class SqrtBeta(Distribution):
     """Distribution of the square root of a Beta distributed random variable.
 

--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -89,6 +89,10 @@ class EnsembleArray(nengo.Network):
 
         super(EnsembleArray, self).__init__(label, seed, add_to_container)
 
+        for param in ens_kwargs:
+            if is_iterable(ens_kwargs[param]):
+                ens_kwargs[param] = nengo.dists.Samples(ens_kwargs[param])
+
         self.config[nengo.Ensemble].update(ens_kwargs)
 
         label_prefix = "" if label is None else label + "_"

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -116,6 +116,36 @@ def test_choice(weights, rng):
     assert np.allclose(p, p_empirical, atol=2 * sterr)
 
 
+@pytest.mark.parametrize("shape", [(12, 2), (7, 1), (7,), (1, 1)])
+def test_samples(shape, rng):
+    samples = rng.random_sample(size=shape)
+    d = dists.Samples(samples)
+    dims = None if len(shape) == 1 else shape[1]
+    assert np.allclose(d.sample(shape[0], dims), samples)
+
+
+@pytest.mark.parametrize("samples", [[1., 2., 3.], [[1, 2], [3, 4]]])
+def test_samples_list(samples):
+    d = dists.Samples(samples)
+    shape = np.array(samples).shape
+    dims = None if len(shape) == 1 else shape[1]
+    assert np.allclose(d.sample(shape[0], dims), samples)
+
+
+def test_samples_errors(rng):
+    samples = rng.random_sample(size=(12, 2))
+    with pytest.raises(ValidationError):
+        dists.Samples(samples).sample(11, 2)
+    with pytest.raises(ValidationError):
+        dists.Samples(samples).sample(12, 1)
+    with pytest.raises(ValidationError):
+        dists.Samples(samples).sample(12)
+
+    samples = rng.random_sample(size=12)
+    with pytest.raises(ValidationError):
+        dists.Samples(samples).sample(12, 2)
+
+
 @pytest.mark.parametrize("n,m", [(99, 1), (50, 50)])
 def test_sqrt_beta(n, m, rng):
     num_samples = 250


### PR DESCRIPTION
**Motivation and context:**
Look, people want to pass in NumPy arrays to `EnsembleArray`. They just do! See #691 and and #766 for proof, it's a thing. In #766 @arvoelke suggested a "no-op" distribution, which no one at the dev meeting disliked, so here it is.

Closes #691 and #766.

**How has this been tested?**
New `EnsembleArray` test included :+1:

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**

- [x] Discussion point: right now I make a copy of the array passed into `Samples`. Should we?
- [x] Add to docs
- [x] Add changelog entry
- [x] Are there other places `Samples` would simplify code?