### PR TITLE
Ignore failed move of cache index and warn.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ Release History
 - Fixed an issue in which SPA models could not be copied.
   (`#1266 <https://github.com/nengo/nengo/issues/1266>`_,
   `#1271 <https://github.com/nengo/nengo/pull/1271>`_)
+- Fixed an issue in which Nengo would crash if other programs
+  had locks on Nengo cache files in Windows.
+  (`#1200 <https://github.com/nengo/nengo/issues/1200>`_,
+  `#1235 <https://github.com/nengo/nengo/pull/1235>`_)
 
 **Changed**
 

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -7,12 +7,14 @@ import logging
 import os
 import shutil
 import struct
+from subprocess import CalledProcessError
 from uuid import uuid1
 import warnings
 
 import numpy as np
 
-from nengo.exceptions import CacheIOError, FingerprintError, TimeoutError
+from nengo.exceptions import (
+    CacheIOError, CacheIOWarning, FingerprintError, TimeoutError)
 from nengo.neurons import (AdaptiveLIF, AdaptiveLIFRate, Direct, Izhikevich,
                            LIF, LIFRate, RectifiedLinear, Sigmoid)
 from nengo.rc import rc
@@ -392,7 +394,26 @@ class WriteableCacheIndex(CacheIndex):
             # Use highest available protocol for index data for maximum
             # performance.
             pickle.dump(self._index, f, pickle.HIGHEST_PROTOCOL)
-        replace(self.index_path + '.part', self.index_path)
+        try:
+            replace(self.index_path + '.part', self.index_path)
+        except CalledProcessError:
+            # May happen with Python 2.7 on Windows where replace is
+            # implemented by a callout to the `move` command. It may fail when
+            # another program like a virus scanner is accessing the file to be
+            # moved. There is not a lot we could do about this. See
+            # <https://github.com/nengo/nengo/issues/1200> for more info.
+            warnings.warn(
+                "The cache index could not be updated because another program "
+                "blocked access to it. This is commonly caused by anti-virus "
+                "software. It is safe to ignore this warning. But if you see "
+                "it a lot, you might want to consider doing one of the "
+                "following for the best Nengo performance:\n"
+                "1. Try using Python 3 instead of Python 2.\n"
+                "2. Configure your anti-virus to ignore the Nengo cache "
+                "folder ('{cache_dir}').\n"
+                "3. Disable the cache.\n"
+                .format(cache_dir=self.cache_dir), category=CacheIOWarning)
+
         if os.path.exists(self.legacy_path):
             os.remove(self.legacy_path)
 

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -117,3 +117,7 @@ class NotAddedToNetworkWarning(NengoWarning):
             "use the copy method on the object instead of Python's copy "
             "module. When unpickling objects, they have to be added to "
             "networks manually.".format(obj=self.obj))
+
+
+class CacheIOWarning(NengoWarning):
+    """A non-critical issue in accessing files in the cache."""


### PR DESCRIPTION
**Motivation and context:**
The `replace` respectively `move` can fail on Windows due to some interaction with anti-virus software (see #1200 for details). This PR ignores the failure and produces a warning.

**Interactions with other PRs:**
I would like to include a link to some documentation on how to disable the cache in the warning, but I need #1130 to be merged for that.

**How has this been tested?**
I haven't tested this because testing stuff on Windows is always very time consuming and annoying for me. But maybe @arvoelke is so nice to give it a test run? 🙏 

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes. (Hard to do because the code in question is only used on very specific systems and the problem can be only reproduced under certain conditions.)
- [x] All new and existing tests passed.
