### PR TITLE
Document learning rate effect in BCM, Oja

### DIFF
--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -124,6 +124,16 @@ class BCM(LearningRuleType):
     and the difference between the postsynaptic activity and the average
     postsynaptic activity.
 
+    Notes
+    -----
+    The BCM rule is dependent on pre and post neural activities,
+    not decoded values, and so is not affected by changes in the
+    size of pre and post ensembles. However, if you are decoding from
+    the post ensemble, the BCM rule will have an increased effect on
+    larger post ensembles because more connection weights are changing.
+    In these cases, it may be advantageous to scale the learning rate
+    on the BCM rule by ``1 / post.n_neurons``.
+
     Parameters
     ----------
     theta_tau : float, optional (Default: 1.0)
@@ -184,6 +194,16 @@ class Oja(LearningRuleType):
     augments typicaly Hebbian coactivity with a "forgetting" term that is
     proportional to the weight of the connection and the square of the
     postsynaptic activity.
+
+    Notes
+    -----
+    The Oja rule is dependent on pre and post neural activities,
+    not decoded values, and so is not affected by changes in the
+    size of pre and post ensembles. However, if you are decoding from
+    the post ensemble, the Oja rule will have an increased effect on
+    larger post ensembles because more connection weights are changing.
+    In these cases, it may be advantageous to scale the learning rate
+    on the Oja rule by ``1 / post.n_neurons``.
 
     Parameters
     ----------


### PR DESCRIPTION
**Motivation and context:**
In #773 there was some discussion about changing the learning rate in the BCM rule. It's difficult to make that change in the general case; in specific cases (e.g. when decoding from `post`) it makes sense to scale the learning rate by `1 / post.n_neurons`. Rather than always do that, this PR adds some documentation to the BCM and Oja learning rules noting that scaling the learning rate makes sense sometimes.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [NA] I have included a changelog entry.
- [NA] I have added tests to cover my changes.
- [x] All new and existing tests passed.
