### PR TITLE
Change ElementwiseInc to copy in learning rules

### DIFF
--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from nengo.builder import Builder, Operator, Signal
-from nengo.builder.operator import DotInc, ElementwiseInc, Reset
+from nengo.builder.operator import DotInc, ElementwiseInc, Copy, Reset
 from nengo.connection import LearningRule
 from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError
@@ -381,8 +381,7 @@ def build_learning_rule(model, rule):
 
     delta = Signal(np.zeros(target.shape), name='Delta')
 
-    model.add_op(
-        ElementwiseInc(model.sig['common'][1], delta, target, tag=tag))
+    model.add_op(Copy(delta, target, inc=True, tag=tag))
     model.sig[rule]['delta'] = delta
 
     model.params[rule] = None  # by default, no build-time info to return


### PR DESCRIPTION
**Motivation and context:**
With the PreserveValue changes in #1245, it is no longer necessary to use an `inc` instead of a `set`.  So instead of doing an unnecessary elementwise multiplication by one, we can just directly add the learning rule delta to the target signal.

**Interactions with other PRs:**
Based on #1245

Breaks `nengo_ocl`, which relies on all `SlicedCopy` ops being applied to vectors (whereas `delta` can be a matrix).

**How has this been tested?**
Tested by existing unit tests.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
