### PR TITLE
Raise exception on invalid gains.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,11 @@ Release History
 
 **Changed**
 
+- We now raise an error when an ensemble is assigned a negative gain.
+  This can occur when solving for gains with intercepts greater than 1.
+  (`#1212 <https://github.com/nengo/nengo/issues/1212>`_,
+  `#1231 <https://github.com/nengo/nengo/issues/1231>`_,
+  `#1248 <https://github.com/nengo/nengo/pull/1248>`_)
 - We now raise an error when a ``Node`` or ``Direct`` ensemble
   produces a non-finite value.
   (`#1178 <https://github.com/nengo/nengo/issues/1178>`_,
@@ -53,6 +58,10 @@ Release History
   (`#691 <https://github.com/nengo/nengo/issues/691>`_,
   `#766 <https://github.com/nengo/nengo/issues/766>`_,
   `#1233 <https://github.com/nengo/nengo/pull/1233>`_)
+- The default refractory period (``tau_ref``) for the ``Sigmoid`` neuron type
+  has changed to 2.5 ms (from 2 ms) for better compatibility with the
+  default maximum firing rates of 200-400 Hz.
+  (`#1248 <https://github.com/nengo/nengo/pull/1248>`_)
 
 **Fixed**
 

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -193,20 +193,20 @@ class Sigmoid(NeuronType):
 
     tau_ref = NumberParam('tau_ref', low=0)
 
-    def __init__(self, tau_ref=0.002):
+    def __init__(self, tau_ref=0.0025):
         super(Sigmoid, self).__init__()
         self.tau_ref = tau_ref
 
     @property
     def _argreprs(self):
-        return [] if self.tau_ref == 0.002 else ["tau_ref=%s" % self.tau_ref]
+        return [] if self.tau_ref == 0.0025 else ["tau_ref=%s" % self.tau_ref]
 
     def gain_bias(self, max_rates, intercepts):
         """Analytically determine gain, bias."""
         lim = 1. / self.tau_ref
-        gain = (-2. / (intercepts - 1.0)) * np.log(
-            (2.0 * lim - max_rates) / (lim - max_rates))
-        bias = -np.log(lim / max_rates - 1) - gain
+        inverse = -np.log(lim / max_rates - 1.)
+        gain = inverse / (1. - intercepts)
+        bias = inverse - gain
         return gain, bias
 
     def step_math(self, dt, J, output):

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -39,7 +39,7 @@ def test_node_to_neurons(Simulator, nl_nodirect, plt, seed):
         inn = nengo.Node(output=np.sin)
         inh = nengo.Node(piecewise({0: 0, 0.5: 1}))
         nengo.Connection(inn, a)
-        nengo.Connection(inh, a.neurons, transform=[[-2.5]] * N)
+        nengo.Connection(inh, a.neurons, transform=[[-5]] * N)
 
         inn_p = nengo.Probe(inn, 'output')
         a_p = nengo.Probe(a, 'decoded_output', synapse=0.1)
@@ -72,7 +72,7 @@ def test_ensemble_to_neurons(Simulator, nl_nodirect, plt, seed):
         inh = nengo.Node(piecewise({0: 0, 0.5: 1}))
         nengo.Connection(inn, a)
         nengo.Connection(inh, b)
-        nengo.Connection(b, a.neurons, transform=[[-2.5]] * N)
+        nengo.Connection(b, a.neurons, transform=[[-10]] * N)
 
         inn_p = nengo.Probe(inn, 'output')
         a_p = nengo.Probe(a, 'decoded_output', synapse=0.1)

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -4,6 +4,7 @@ import pytest
 import nengo
 import nengo.utils.numpy as npext
 from nengo.dists import Choice, Gaussian, UniformHypersphere
+from nengo.exceptions import BuildError
 from nengo.processes import WhiteNoise, FilteredNoise
 from nengo.utils.testing import warns, allclose
 
@@ -397,3 +398,13 @@ def test_no_norm_encoders(Simulator):
 
     assert np.allclose(sim.data[norm].encoders, 1)
     assert np.allclose(sim.data[no_norm].encoders, enc_weight)
+
+
+@pytest.mark.parametrize('intercept', [1.0, 1.1])
+def test_raises_exception_for_invalid_intercepts(Simulator, intercept):
+    with nengo.Network() as model:
+        nengo.Ensemble(1, 1, intercepts=[intercept])
+
+    with pytest.raises(BuildError):
+        with nengo.Simulator(model):
+            pass

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -381,6 +381,7 @@ def test_voja_encoders(Simulator, nl_nodirect, rng, seed):
         u = nengo.Node(output=learned_vector)
         x = nengo.Ensemble(n, dimensions=len(learned_vector),
                            intercepts=intercepts, encoders=encoders,
+                           max_rates=nengo.dists.Uniform(300., 400.),
                            radius=2.0)  # to test encoder scaling
 
         conn = nengo.Connection(

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 import nengo
-from nengo.exceptions import SimulationError
+
+from nengo.exceptions import BuildError, SimulationError
 from nengo.neurons import Direct, NeuronTypeParam
 from nengo.processes import WhiteSignal
 from nengo.solvers import LstsqL2nz
@@ -282,6 +283,57 @@ def test_izhikevich(Simulator, plt, seed, rng):
     plot(fs, "Fast spiking", 4)
     plot(lts, "Low-threshold spiking", 5)
     plot(rz, "Resonator", 6)
+
+
+def test_sigmoid_response_curves(Simulator):
+    # Max rate > rate at inflection point => intercept has to be < 1
+    with nengo.Network() as m:
+        e = nengo.Ensemble(1, 1, neuron_type=nengo.Sigmoid(), max_rates=[300.])
+    with Simulator(m) as sim:
+        pass
+    x, y = nengo.utils.ensemble.response_curves(e, sim)
+    assert np.allclose(np.max(y), 300.)
+    assert np.all(y > 0.)
+    assert np.all(np.diff(y) > 0.)  # monotonically increasing
+
+    with nengo.Network() as m:
+        e = nengo.Ensemble(1, 1, neuron_type=nengo.Sigmoid(), max_rates=[300.],
+                           intercepts=[1.1])
+    with pytest.raises(BuildError):
+        with Simulator(m) as sim:
+            pass
+
+    with nengo.Network() as m:
+        e = nengo.Ensemble(1, 1, neuron_type=nengo.Sigmoid(), max_rates=[300.],
+                           intercepts=[1.0])
+    with pytest.raises(BuildError):
+        with Simulator(m) as sim:
+            pass
+
+    # Max rate < rate at inflection point => intercept has to be > 1
+    with nengo.Network() as m:
+        e = nengo.Ensemble(1, 1, neuron_type=nengo.Sigmoid(), max_rates=[100.],
+                           intercepts=[1.1])
+    with Simulator(m) as sim:
+        pass
+    x, y = nengo.utils.ensemble.response_curves(e, sim)
+    assert np.allclose(np.max(y), 100.)
+    assert np.all(y > 0.)
+    assert np.all(np.diff(y) > 0.)  # monotonically increasing
+
+    with nengo.Network() as m:
+        e = nengo.Ensemble(1, 1, neuron_type=nengo.Sigmoid(), max_rates=[100.],
+                           intercepts=[0.9])
+    with pytest.raises(BuildError):
+        with Simulator(m) as sim:
+            pass
+
+    with nengo.Network() as m:
+        e = nengo.Ensemble(1, 1, neuron_type=nengo.Sigmoid(), max_rates=[100.],
+                           intercepts=[1.0])
+    with pytest.raises(BuildError):
+        with Simulator(m) as sim:
+            pass
 
 
 def test_dt_dependence(Simulator, nl_nodirect, plt, seed, rng):


### PR DESCRIPTION
**Motivation and context:**
As noted in #1212 (and #1231) intercepts >= 1 give unexpected results for most neuron types. The matter is however a bit more complicated [as detailed in this comment](https://github.com/nengo/nengo/pull/1243#issuecomment-267787806). The correct generalization to all neuron types (in my opinion) is that non-positive gains give unexpected results. Thus, the core change of this PR is to check this and raise an exception when violated. There is a bunch of related changes, though:

* As detailed in the linked comment, the gain and bias calculation for the sigmoid neurons was incorrect giving flipped tuning curves for max. firing rates below the firing rate of the inflection point. This calculation was fixed. The new gain formula is based on the fact that the firing rate at the inflection point has to be 1/2 of 1/tau_ref.
* As also detailed in the linked comment, for max. firing rates below the firing rate of the inflection point, the intercept (i.e. inflection point) has to be > 1. The sigmoid inflection point was set to 250Hz while our default max_rates were 200 to 400Hz. Thus, depending on the sampled max_rates, the valid intercept range would switch. I propose with this PR to change sigmoid `tau_ref` to 0.0025 which brings the inflection point to 200Hz and the firing rate in the limit to 400Hz. This at least allows to use the sigmoid neuron type without an exception and changing any of the other ensemble defaults. But technically it is a breaking change! We could leave `tau_ref` at it's old value, but would likely need to adjust the max_rates in a lot of our tests.
* Changing the `tau_ref` changed the sigmoid tuning curves which required to fix a few other tests.

**Interactions with other PRs:**
This PR supersedes #1243.

**How has this been tested?**
Added some tests for the sigmoid neuron and a test checking that invalid intercepts raise an exception.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- [Without the `tau_ref` change: Bug fix (non-breaking change which fixes an issue)]
- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly. (Maybe some [this comment](https://github.com/nengo/nengo/pull/1243#issuecomment-267787806) should put somewhere in the documentation? Maybe we should add what intercepts are valid to the documentation of sigmoid neurons? In any case some feedback on the technical site of this PR would be nice before investing time in further documentation.)
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
