### PR TITLE
Rewrite associative memory.

### DIFF
--- a/examples/spa/associative_memory.ipynb
+++ b/examples/spa/associative_memory.ipynb
@@ -1,9 +1,9 @@
 {
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "nengodev",
    "language": "python",
-   "name": "python3"
+   "name": "nengodev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -15,9 +15,140 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.2"
+   "version": "3.5.2"
   },
-  "name": ""
+  "name": "",
+  "widgets": {
+   "state": {
+    "07b444dd387b42d5a56b2f11ad3cd510": {
+     "views": [
+      {
+       "cell_index": 28
+      }
+     ]
+    },
+    "234b57bb37924df1a391a9baf84cfbbf": {
+     "views": [
+      {
+       "cell_index": 28
+      }
+     ]
+    },
+    "28f8d3a35d634b06a69cd0efa33554b4": {
+     "views": [
+      {
+       "cell_index": 25
+      }
+     ]
+    },
+    "2d65401b231c49b2a945c5390a960041": {
+     "views": [
+      {
+       "cell_index": 25
+      }
+     ]
+    },
+    "32fe0cdbc753461aa451314424d2310d": {
+     "views": [
+      {
+       "cell_index": 28
+      }
+     ]
+    },
+    "430c1f2b56234a15b386955d6aaf9f2c": {
+     "views": [
+      {
+       "cell_index": 28
+      }
+     ]
+    },
+    "64f6d68d388c480681c621b06e870f96": {
+     "views": [
+      {
+       "cell_index": 5
+      }
+     ]
+    },
+    "72aba5ef3d7745d3b1ea10b079f64cdc": {
+     "views": [
+      {
+       "cell_index": 19
+      }
+     ]
+    },
+    "8f496f8318fa4842b8d3fd19fa411a95": {
+     "views": [
+      {
+       "cell_index": 19
+      }
+     ]
+    },
+    "94922a37e2fe442caad8fe8f10b1c3da": {
+     "views": [
+      {
+       "cell_index": 17
+      }
+     ]
+    },
+    "975fbc8a58464949bc29cd6d3b4ba80f": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "b054c5b4850a4bcd9841f483f0fa2363": {
+     "views": [
+      {
+       "cell_index": 28
+      }
+     ]
+    },
+    "b25c41a83df445cba1edef6cd8b5ddc0": {
+     "views": [
+      {
+       "cell_index": 17
+      }
+     ]
+    },
+    "c8d5e7f73c2349e2bb20e0fa23cf3032": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "d476a202888f44d5ad9472f9bc4cceac": {
+     "views": [
+      {
+       "cell_index": 5
+      }
+     ]
+    },
+    "d537743b0ef64c7c92748c1169fca90c": {
+     "views": [
+      {
+       "cell_index": 19
+      }
+     ]
+    },
+    "e47da4c39f8d497496395729b74a8e16": {
+     "views": [
+      {
+       "cell_index": 5
+      }
+     ]
+    },
+    "f4d6b5162a0e4d52a67cc0e368bc8991": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    }
+   },
+   "version": "1.2.0"
+  }
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -57,7 +188,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 1
     },
     {
      "cell_type": "markdown",
@@ -86,7 +218,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 2
     },
     {
      "cell_type": "markdown",
@@ -107,7 +240,7 @@
      "input": [
       "with spa.Module('AssociativeMemory', seed=1) as model_1:\n",
       "    # create the AM module\n",
-      "    model_1.assoc_mem = spa.AssociativeMemory(input_vocab=vocab)\n",
+      "    model_1.assoc_mem = spa.AssociativeMemory(threshold=0.3, input_vocab=vocab)\n",
       "\n",
       "    # present input to the AM\n",
       "    model_1.am_input = spa.Input()\n",
@@ -123,7 +256,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 3
     },
     {
      "cell_type": "markdown",
@@ -143,7 +277,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 4
     },
     {
      "cell_type": "markdown",
@@ -190,7 +325,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 5
     },
     {
      "cell_type": "code",
@@ -200,7 +336,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 6
     },
     {
      "cell_type": "markdown",
@@ -253,7 +390,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 7
     },
     {
      "cell_type": "markdown",
@@ -275,7 +413,7 @@
      "collapsed": false,
      "input": [
       "with spa.Module('Cleanup', seed=1) as model_2:\n",
-      "    model_2.assoc_mem = spa.AssociativeMemory(input_vocab=vocab)\n",
+      "    model_2.assoc_mem = spa.AssociativeMemory(threshold=0.3, input_vocab=vocab)\n",
       "    \n",
       "    # noisy input\n",
       "    input_expr = '0.9*APPLE + 0.85*CHERRY + 0.7*APRICOT'\n",
@@ -287,7 +425,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 8
     },
     {
      "cell_type": "code",
@@ -306,7 +445,8 @@
      "metadata": {
       "scrolled": true
      },
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 9
     },
     {
      "cell_type": "markdown",
@@ -321,7 +461,11 @@
      "collapsed": false,
      "input": [
       "with spa.Module('CleanupThreshold', seed=1) as model_3:\n",
-      "    model_3.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, wta_output=True, threshold_output=True)\n",
+      "    model_3.assoc_mem = spa.AssociativeMemory(\n",
+      "        threshold=0.3,\n",
+      "        input_vocab=vocab,\n",
+      "        selection_net=nengo.spa.selection.WTA,\n",
+      "        function=nengo.spa.selection.FilteredStepFunc())\n",
       "    \n",
       "    input_expr = '0.9*APPLE + 0.85*CHERRY + 0.7*APRICOT'\n",
       "    model_3.am_input = spa.Input()\n",
@@ -341,7 +485,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 12
     },
     {
      "cell_type": "markdown",
@@ -382,7 +527,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 13
     },
     {
      "cell_type": "markdown",
@@ -414,9 +560,12 @@
       "output_keys = ['TWO', 'THREE', 'FOUR', 'FIVE']\n",
       "    \n",
       "with spa.Module('Counting', seed=1) as model_4:\n",
-      "    model_4.assoc_mem = spa.AssociativeMemory(input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
-      "                                              input_keys=input_keys, output_keys=output_keys,\n",
-      "                                              wta_output=True)\n",
+      "    model_4.assoc_mem = spa.AssociativeMemory(\n",
+      "        threshold=0.3,\n",
+      "        input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
+      "        input_keys=input_keys, output_keys=output_keys,\n",
+      "        selection_net=nengo.spa.selection.WTA,\n",
+      "        function=nengo.spa.selection.FilteredStepFunc())\n",
       "\n",
       "    model_4.am_input = spa.Input()\n",
       "    model_4.am_input.assoc_mem = input_fun\n",
@@ -426,7 +575,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 14
     },
     {
      "cell_type": "code",
@@ -443,7 +593,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 15
     },
     {
      "cell_type": "markdown",
@@ -464,9 +615,12 @@
       "        return '0'\n",
       "\n",
       "with spa.Module('Counting', seed=1) as model_5:\n",
-      "    model_5.assoc_mem = spa.AssociativeMemory(input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
-      "                                              input_keys=input_keys, output_keys=output_keys,\n",
-      "                                              wta_output=True)\n",
+      "    model_5.assoc_mem = spa.AssociativeMemory(\n",
+      "        threshold=0.3,\n",
+      "        input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
+      "        input_keys=input_keys, output_keys=output_keys,\n",
+      "        selection_net=nengo.spa.selection.WTA,\n",
+      "        function=nengo.spa.selection.FilteredStepFunc())\n",
       "\n",
       "    model_5.am_input = spa.Input()\n",
       "    model_5.am_input.assoc_mem = input_fun\n",
@@ -479,7 +633,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 23
     },
     {
      "cell_type": "code",
@@ -496,7 +651,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [],
+     "prompt_number": 24
     },
     {
      "cell_type": "markdown",
@@ -510,3 +666,4 @@
   }
  ]
 }
+

--- a/examples/spa/associative_memory.ipynb
+++ b/examples/spa/associative_memory.ipynb
@@ -20,129 +20,101 @@
   "name": "",
   "widgets": {
    "state": {
-    "07b444dd387b42d5a56b2f11ad3cd510": {
+    "0445f22a76dc4f01a89dfddae80b7fad": {
      "views": [
       {
-       "cell_index": 28
+       "cell_index": 13
       }
      ]
     },
-    "234b57bb37924df1a391a9baf84cfbbf": {
-     "views": [
-      {
-       "cell_index": 28
-      }
-     ]
-    },
-    "28f8d3a35d634b06a69cd0efa33554b4": {
+    "18e86863f25c47c280d02ea531d09941": {
      "views": [
       {
        "cell_index": 25
       }
      ]
     },
-    "2d65401b231c49b2a945c5390a960041": {
+    "1a2e1dab5fe8460889da87c4cf350389": {
+     "views": [
+      {
+       "cell_index": 17
+      }
+     ]
+    },
+    "1affa42b48664a068a021b617c2e1499": {
+     "views": [
+      {
+       "cell_index": 5
+      }
+     ]
+    },
+    "1f0f87572aa64eb09489f9eea2a98418": {
+     "views": [
+      {
+       "cell_index": 28
+      }
+     ]
+    },
+    "32d52b08b92d4ab3865445b7a8b54e6f": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "424302a0262442e9abf630ceb7add409": {
+     "views": [
+      {
+       "cell_index": 19
+      }
+     ]
+    },
+    "6849532ef860432987ec57e610d2deff": {
+     "views": [
+      {
+       "cell_index": 19
+      }
+     ]
+    },
+    "79c84935d02342dea5a1a9fc4786f201": {
+     "views": [
+      {
+       "cell_index": 28
+      }
+     ]
+    },
+    "7c2fb781023d424b916ae13f64b5157c": {
+     "views": [
+      {
+       "cell_index": 19
+      }
+     ]
+    },
+    "87d635d2f8564f829f9eadac1a09a695": {
      "views": [
       {
        "cell_index": 25
       }
      ]
     },
-    "32fe0cdbc753461aa451314424d2310d": {
-     "views": [
-      {
-       "cell_index": 28
-      }
-     ]
-    },
-    "430c1f2b56234a15b386955d6aaf9f2c": {
-     "views": [
-      {
-       "cell_index": 28
-      }
-     ]
-    },
-    "64f6d68d388c480681c621b06e870f96": {
+    "a26b90f4704842308747cf689fa8ef0e": {
      "views": [
       {
        "cell_index": 5
       }
      ]
     },
-    "72aba5ef3d7745d3b1ea10b079f64cdc": {
+    "ac8f03b32aaf4dd78859f7e48063c3fb": {
      "views": [
       {
-       "cell_index": 19
+       "cell_index": 25
       }
      ]
     },
-    "8f496f8318fa4842b8d3fd19fa411a95": {
-     "views": [
-      {
-       "cell_index": 19
-      }
-     ]
-    },
-    "94922a37e2fe442caad8fe8f10b1c3da": {
+    "f68b8d4d9fed47ca804cfc10fbcbd60c": {
      "views": [
       {
        "cell_index": 17
-      }
-     ]
-    },
-    "975fbc8a58464949bc29cd6d3b4ba80f": {
-     "views": [
-      {
-       "cell_index": 13
-      }
-     ]
-    },
-    "b054c5b4850a4bcd9841f483f0fa2363": {
-     "views": [
-      {
-       "cell_index": 28
-      }
-     ]
-    },
-    "b25c41a83df445cba1edef6cd8b5ddc0": {
-     "views": [
-      {
-       "cell_index": 17
-      }
-     ]
-    },
-    "c8d5e7f73c2349e2bb20e0fa23cf3032": {
-     "views": [
-      {
-       "cell_index": 13
-      }
-     ]
-    },
-    "d476a202888f44d5ad9472f9bc4cceac": {
-     "views": [
-      {
-       "cell_index": 5
-      }
-     ]
-    },
-    "d537743b0ef64c7c92748c1169fca90c": {
-     "views": [
-      {
-       "cell_index": 19
-      }
-     ]
-    },
-    "e47da4c39f8d497496395729b74a8e16": {
-     "views": [
-      {
-       "cell_index": 5
-      }
-     ]
-    },
-    "f4d6b5162a0e4d52a67cc0e368bc8991": {
-     "views": [
-      {
-       "cell_index": 13
       }
      ]
     }
@@ -240,7 +212,7 @@
      "input": [
       "with spa.Module('AssociativeMemory', seed=1) as model_1:\n",
       "    # create the AM module\n",
-      "    model_1.assoc_mem = spa.AssociativeMemory(threshold=0.3, input_vocab=vocab)\n",
+      "    model_1.assoc_mem = spa.ThresholdingAssocMem(threshold=0.3, input_vocab=vocab)\n",
       "\n",
       "    # present input to the AM\n",
       "    model_1.am_input = spa.Input()\n",
@@ -370,7 +342,7 @@
      "collapsed": false,
      "input": [
       "with spa.Module('CleanupThreshold', seed=1) as model_3:\n",
-      "    model_3.assoc_mem = spa.AssociativeMemory(input_vocab=vocab, threshold=0.7)\n",
+      "    model_3.assoc_mem = spa.ThresholdingAssocMem(threshold=0.7, input_vocab=vocab)\n",
       "    \n",
       "    input_expr = '0.9*APPLE + 0.5*CHERRY + 0.4*APRICOT'\n",
       "    model_3.am_input = spa.Input()\n",
@@ -413,7 +385,7 @@
      "collapsed": false,
      "input": [
       "with spa.Module('Cleanup', seed=1) as model_2:\n",
-      "    model_2.assoc_mem = spa.AssociativeMemory(threshold=0.3, input_vocab=vocab)\n",
+      "    model_2.assoc_mem = spa.ThresholdingAssocMem(threshold=0.3, input_vocab=vocab)\n",
       "    \n",
       "    # noisy input\n",
       "    input_expr = '0.9*APPLE + 0.85*CHERRY + 0.7*APRICOT'\n",
@@ -461,11 +433,10 @@
      "collapsed": false,
      "input": [
       "with spa.Module('CleanupThreshold', seed=1) as model_3:\n",
-      "    model_3.assoc_mem = spa.AssociativeMemory(\n",
+      "    model_3.assoc_mem = spa.WtaAssocMem(\n",
       "        threshold=0.3,\n",
       "        input_vocab=vocab,\n",
-      "        selection_net=nengo.spa.selection.WTA,\n",
-      "        function=nengo.spa.selection.FilteredStepFunc())\n",
+      "        function=lambda x: x > 0.)\n",
       "    \n",
       "    input_expr = '0.9*APPLE + 0.85*CHERRY + 0.7*APRICOT'\n",
       "    model_3.am_input = spa.Input()\n",
@@ -486,7 +457,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 12
+     "prompt_number": 15
     },
     {
      "cell_type": "markdown",
@@ -528,7 +499,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 13
+     "prompt_number": 16
     },
     {
      "cell_type": "markdown",
@@ -560,12 +531,11 @@
       "output_keys = ['TWO', 'THREE', 'FOUR', 'FIVE']\n",
       "    \n",
       "with spa.Module('Counting', seed=1) as model_4:\n",
-      "    model_4.assoc_mem = spa.AssociativeMemory(\n",
+      "    model_4.assoc_mem = spa.WtaAssocMem(\n",
       "        threshold=0.3,\n",
       "        input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
       "        input_keys=input_keys, output_keys=output_keys,\n",
-      "        selection_net=nengo.spa.selection.WTA,\n",
-      "        function=nengo.spa.selection.FilteredStepFunc())\n",
+      "        function=lambda x: x > 0.)\n",
       "\n",
       "    model_4.am_input = spa.Input()\n",
       "    model_4.am_input.assoc_mem = input_fun\n",
@@ -576,7 +546,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 14
+     "prompt_number": 17
     },
     {
      "cell_type": "code",
@@ -594,7 +564,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 15
+     "prompt_number": 18
     },
     {
      "cell_type": "markdown",
@@ -615,12 +585,11 @@
       "        return '0'\n",
       "\n",
       "with spa.Module('Counting', seed=1) as model_5:\n",
-      "    model_5.assoc_mem = spa.AssociativeMemory(\n",
+      "    model_5.assoc_mem = spa.WtaAssocMem(\n",
       "        threshold=0.3,\n",
       "        input_vocab=vocab_numbers, output_vocab=vocab_numbers,\n",
       "        input_keys=input_keys, output_keys=output_keys,\n",
-      "        selection_net=nengo.spa.selection.WTA,\n",
-      "        function=nengo.spa.selection.FilteredStepFunc())\n",
+      "        function=lambda x: x > 0.)\n",
       "\n",
       "    model_5.am_input = spa.Input()\n",
       "    model_5.am_input.assoc_mem = input_fun\n",
@@ -634,7 +603,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 23
+     "prompt_number": 20
     },
     {
      "cell_type": "code",
@@ -652,7 +621,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 24
+     "prompt_number": 21
     },
     {
      "cell_type": "markdown",

--- a/nengo/spa/__init__.py
+++ b/nengo/spa/__init__.py
@@ -1,5 +1,5 @@
 from .actions import Actions
-from .assoc_mem import AssociativeMemory
+from .assoc_mem import AssociativeMemory, ThresholdingAssocMem, WtaAssocMem
 from .basalganglia import BasalGanglia
 from .bind import Bind
 from .compare import Compare

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -1,3 +1,8 @@
+"""Associative memory implementations.
+
+See :doc:`examples/associative_memory` for an introduction and examples.
+"""
+
 import nengo
 import numpy as np
 from nengo.spa.module import Module
@@ -7,6 +12,43 @@ from nengo.utils.network import with_self
 
 
 class AssociativeMemory(Module):
+    """General associative memory module.
+
+    This provides a low-level selection network with the necessary interface
+    to include it within the SPA system.
+
+    Parameters
+    ----------
+    selection_net : Network
+        The network that is used to select the response. It needs to accept
+        the arguments *n_neurons* (number of neurons to use to represent each
+        possible choice) and *n_ensembles* (number of choices). The returned
+        network needs to have an *input* attribute to which the utilities for
+        each choice are connected and an *output* attribute from which a
+        connection will be created to read the selected output(s).
+    input_vocab: list or Vocabulary
+        The vocabulary (or list of vectors) to match.
+    output_vocab: list or Vocabulary, optional (Default: None)
+        The vocabulary (or list of vectors) to be produced for each match. If
+        None, the associative memory will act like an autoassociative memory
+        (cleanup memory).
+    input_keys : list, optional (Default: None)
+        A list of strings that correspond to the input vectors.
+    output_keys : list, optional (Default: None)
+        A list of strings that correspond to the output vectors.
+    n_neurons : int
+        Number of neurons to represent each choice, passed on to the
+        *selection_net*.
+    label : str, optional (Default: None)
+        A name for the ensemble. Used for debugging and visualization.
+    seed : int, optional (Default: None)
+        The seed used for random number generation.
+    add_to_container : bool, optional (Default: None)
+        Determines if this Network will be added to the current container.
+        If None, will be true if currently with
+    vocabs : VocabularyMap, optional (Default: None)
+        Maps dimensionalities to the corresponding default vocabularies.
+    """
     input_vocab = VocabularyOrDimParam(
         'input_vocab', default=None, readonly=True)
     output_vocab = VocabularyOrDimParam(
@@ -58,6 +100,18 @@ class AssociativeMemory(Module):
 
     @with_self
     def add_default_output(self, key, min_activation_value, n_neurons=50):
+        """Adds a Semantic Pointer to output when no other pointer is active.
+
+        Parameters
+        ----------
+        key : str
+            Semantic Pointer to output.
+        min_activation_value : float
+            Minimum output of another Semantic Pointer to deactivate the
+            default output.
+        n_neurons : int, optional (Default: 50)
+            Number of neurons used to represent the default Semantic Pointer.
+        """
         assert not hasattr(self, 'default_ens'), \
             "Can add default output only once."
 
@@ -76,6 +130,10 @@ class AssociativeMemory(Module):
 
 
 class IaAssocMem(AssociativeMemory):
+    """Associative memory based on the `IA` network.
+
+    See `AssociativeMemory` and `IA` for more information.
+    """
     def __init__(
             self, input_vocab, output_vocab=None, input_keys=None,
             output_keys=None, n_neurons=50, label=None, seed=None,
@@ -92,6 +150,10 @@ class IaAssocMem(AssociativeMemory):
 
 
 class ThresholdingAssocMem(AssociativeMemory):
+    """Associative memory based on `ThresholdingArray`.
+
+    See `AssociativeMemory` and `ThresholdingArray` for more information.
+    """
     def __init__(
             self, threshold, input_vocab, output_vocab=None, input_keys=None,
             output_keys=None, n_neurons=50, label=None, seed=None,
@@ -107,6 +169,10 @@ class ThresholdingAssocMem(AssociativeMemory):
 
 
 class WtaAssocMem(AssociativeMemory):
+    """Associative memory based on the `WTA` network.
+
+    See `AssociativeMemory` and `WTA` for more information.
+    """
     def __init__(
             self, threshold, input_vocab, output_vocab=None, input_keys=None,
             output_keys=None, n_neurons=50, label=None, seed=None,

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -1,7 +1,7 @@
 import nengo
 import numpy as np
 from nengo.spa.module import Module
-from nengo.spa.selection import ThresholdingArray
+from nengo.spa.selection import ThresholdingArray, WTA
 from nengo.spa.vocab import VocabularyOrDimParam
 from nengo.utils.network import with_self
 
@@ -73,3 +73,33 @@ class AssociativeMemory(Module):
             self.selection.output, self.default_ens,
             transform=-np.ones(
                 (1, self.selection.output.size_out)) / min_activation_value)
+
+
+class ThresholdingAssocMem(AssociativeMemory):
+    def __init__(
+            self, threshold, input_vocab, output_vocab=None, input_keys=None,
+            output_keys=None, n_neurons=50, label=None, seed=None,
+            add_to_container=None, vocabs=None, **selection_net_args):
+        selection_net_args['threshold'] = threshold
+        super(ThresholdingAssocMem, self).__init__(
+            selection_net=ThresholdingArray,
+            input_vocab=input_vocab, output_vocab=output_vocab,
+            input_keys=input_keys, output_keys=output_keys,
+            n_neurons=n_neurons, label=label, seed=seed,
+            add_to_container=add_to_container, vocabs=vocabs,
+            **selection_net_args)
+
+
+class WtaAssocMem(AssociativeMemory):
+    def __init__(
+            self, threshold, input_vocab, output_vocab=None, input_keys=None,
+            output_keys=None, n_neurons=50, label=None, seed=None,
+            add_to_container=None, vocabs=None, **selection_net_args):
+        selection_net_args['threshold'] = threshold
+        super(WtaAssocMem, self).__init__(
+            selection_net=WTA,
+            input_vocab=input_vocab, output_vocab=output_vocab,
+            input_keys=input_keys, output_keys=output_keys,
+            n_neurons=n_neurons, label=label, seed=seed,
+            add_to_container=add_to_container, vocabs=vocabs,
+            **selection_net_args)

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -1,7 +1,7 @@
 import nengo
 import numpy as np
 from nengo.spa.module import Module
-from nengo.spa.selection import ThresholdingArray, WTA
+from nengo.spa.selection import IA, ThresholdingArray, WTA
 from nengo.spa.vocab import VocabularyOrDimParam
 from nengo.utils.network import with_self
 
@@ -73,6 +73,22 @@ class AssociativeMemory(Module):
             self.selection.output, self.default_ens,
             transform=-np.ones(
                 (1, self.selection.output.size_out)) / min_activation_value)
+
+
+class IaAssocMem(AssociativeMemory):
+    def __init__(
+            self, input_vocab, output_vocab=None, input_keys=None,
+            output_keys=None, n_neurons=50, label=None, seed=None,
+            add_to_container=None, vocabs=None, **selection_net_args):
+        super(IaAssocMem, self).__init__(
+            selection_net=IA,
+            input_vocab=input_vocab, output_vocab=output_vocab,
+            input_keys=input_keys, output_keys=output_keys,
+            n_neurons=n_neurons, label=label, seed=seed,
+            add_to_container=add_to_container, vocabs=vocabs,
+            **selection_net_args)
+        self.input_reset = self.selection.input_reset
+        self.inputs['reset'] = (self.input_reset, None)
 
 
 class ThresholdingAssocMem(AssociativeMemory):

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -1,110 +1,75 @@
-from nengo.networks.assoc_mem import AssociativeMemory as AssocMem
+import nengo
+import numpy as np
 from nengo.spa.module import Module
+from nengo.spa.selection import ThresholdingArray
+from nengo.spa.vocab import VocabularyOrDimParam
+from nengo.utils.network import with_self
 
 
 class AssociativeMemory(Module):
-    """Associative memory module.
+    input_vocab = VocabularyOrDimParam(
+        'input_vocab', default=None, readonly=True)
+    output_vocab = VocabularyOrDimParam(
+        'output_vocab', default=None, readonly=True)
 
-    See :doc:`examples/associative_memory` for an introduction and examples.
+    def __init__(
+            self, input_vocab, output_vocab=None, input_keys=None,
+            output_keys=None, selection_net=ThresholdingArray, n_neurons=50,
+            label=None, seed=None, add_to_container=None, vocabs=None,
+            **selection_net_args):
+        super(AssociativeMemory, self).__init__(
+            label=label, seed=seed, add_to_container=add_to_container,
+            vocabs=vocabs)
 
-    Parameters
-    ----------
-    input_vocab: list or Vocabulary
-        The vocabulary (or list of vectors) to match.
-    output_vocab: list or Vocabulary, optional (Default: None)
-        The vocabulary (or list of vectors) to be produced for each match. If
-        None, the associative memory will act like an autoassociative memory
-        (cleanup memory).
-    input_keys : list, optional (Default: None)
-        A list of strings that correspond to the input vectors.
-    output_keys : list, optional (Default: None)
-        A list of strings that correspond to the output vectors.
-    default_output_key: str, optional (Default: None)
-        The semantic pointer string to be produced if the input value matches
-        none of vectors in the input vector list.
-    threshold: float, optional (Default: 0.3)
-        The association activation threshold.
-    inhibitable: bool, optional (Default: False)
-        Flag to indicate if the entire associative memory module is
-        inhibitable (i.e., the entire module can be inhibited).
-    wta_output: bool, optional (Default: False)
-        Flag to indicate if output of the associative memory should contain
-        more than one vector. If True, only one vector's output will be
-        produced; i.e. produce a winner-take-all (WTA) output.
-        If False, combinations of vectors will be produced.
-    wta_inhibit_scale: float, optional (Default: 3.0)
-        Scaling factor on the winner-take-all (WTA) inhibitory connections.
-    wta_synapse: float, optional (Default: 0.005)
-        Synapse to use for the winner-take-all (wta) inhibitory connections.
-    threshold_output: bool, optional (Default: False)
-        Adds a threholded output if True.
-    label : str, optional (Default: None)
-        A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
-        The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
-        Determines if this Network will be added to the current container.
-        If None, will be true if currently within a Network.
-    """
-
-    def __init__(self, input_vocab, output_vocab=None,  # noqa: C901
-                 input_keys=None, output_keys=None,
-                 default_output_key=None, threshold=0.3,
-                 inhibitable=False, wta_output=False,
-                 wta_inhibit_scale=3.0, wta_synapse=0.005,
-                 threshold_output=False, label=None, seed=None,
-                 add_to_container=None):
-        super(AssociativeMemory, self).__init__(label, seed, add_to_container)
+        if output_vocab is None:
+            output_vocab = input_vocab
+        self.input_vocab = input_vocab
+        self.output_vocab = output_vocab
 
         if input_keys is None:
-            input_keys = input_vocab.keys
-            input_vectors = input_vocab.vectors
+            input_keys = self.input_vocab.keys()
+            input_vectors = self.input_vocab.vectors
         else:
             input_vectors = [input_vocab.parse(key).v for key in input_keys]
 
-        # If output vocabulary is not specified, use input vocabulary
-        # (i.e autoassociative memory)
-        if output_vocab is None:
-            output_vocab = input_vocab
-            output_vectors = input_vectors
-        else:
-            if output_keys is None:
-                output_keys = input_keys
+        if output_keys is None:
+            output_keys = input_keys
+        output_vectors = [output_vocab.parse(key).v for key in output_keys]
 
-            output_vectors = [output_vocab.parse(key).v for key in output_keys]
+        input_vectors = np.asarray(input_vectors)
+        output_vectors = np.asarray(output_vectors)
 
-        if default_output_key is None:
-            default_output_vector = None
-        else:
-            default_output_vector = output_vocab.parse(default_output_key).v
-
-        # Create nengo network
         with self:
-            self.am = AssocMem(input_vectors=input_vectors,
-                               output_vectors=output_vectors,
-                               threshold=threshold,
-                               inhibitable=inhibitable,
-                               label=label, seed=seed,
-                               add_to_container=add_to_container)
+            self.selection = selection_net(
+                n_neurons=n_neurons, n_ensembles=len(input_vectors),
+                label="selection", **selection_net_args)
+            self.input = nengo.Node(size_in=self.input_vocab.dimensions,
+                                    label="input")
+            self.output = nengo.Node(size_in=self.output_vocab.dimensions,
+                                     label="output")
 
-            if default_output_vector is not None:
-                self.am.add_default_output_vector(default_output_vector)
+            nengo.Connection(
+                self.input, self.selection.input, transform=input_vectors)
+            nengo.Connection(
+                self.selection.output, self.output, transform=output_vectors.T)
 
-            if wta_output:
-                self.am.add_wta_network(wta_inhibit_scale, wta_synapse)
+        self.inputs = dict(default=(self.input, self.input_vocab))
+        self.outputs = dict(default=(self.output, self.output_vocab))
 
-            if threshold_output:
-                self.am.add_threshold_to_outputs()
+    @with_self
+    def add_default_output(self, key, min_activation_value, n_neurons=50):
+        assert not hasattr(self, 'default_ens'), \
+            "Can add default output only once."
 
-            self.input = self.am.input
-            self.output = self.am.output
-
-            if inhibitable:
-                self.inhibit = self.am.inhibit
-
-            self.utilities = self.am.utilities
-            if threshold_output:
-                self.thresholded_utilities = self.am.thresholded_utilities
-
-        self.inputs = dict(default=(self.input, input_vocab))
-        self.outputs = dict(default=(self.output, output_vocab))
+        with nengo.presets.ThresholdingEnsembles(0.):
+            setattr(self, 'default_ens',
+                    nengo.Ensemble(n_neurons, 1, label="default"))
+        setattr(self, 'bias', nengo.Node(1., label="bias"))
+        nengo.Connection(self.bias, self.default_ens)
+        nengo.Connection(
+            self.default_ens, self.output,
+            transform=np.atleast_2d(self.output_vocab.parse(key).v).T)
+        nengo.Connection(
+            self.selection.output, self.default_ens,
+            transform=-np.ones(
+                (1, self.selection.output.size_out)) / min_activation_value)

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -13,8 +13,8 @@ class AssociativeMemory(Module):
         'output_vocab', default=None, readonly=True)
 
     def __init__(
-            self, input_vocab, output_vocab=None, input_keys=None,
-            output_keys=None, selection_net=ThresholdingArray, n_neurons=50,
+            self, selection_net, input_vocab, output_vocab=None,
+            input_keys=None, output_keys=None, n_neurons=50,
             label=None, seed=None, add_to_container=None, vocabs=None,
             **selection_net_args):
         super(AssociativeMemory, self).__init__(

--- a/nengo/spa/selection.py
+++ b/nengo/spa/selection.py
@@ -4,6 +4,48 @@ import nengo
 import numpy as np
 
 
+def IA(
+        n_neurons, n_ensembles, accum_threshold=0.8, accum_neuron_ratio=0.7,
+        accum_timescale=0.1, feedback_timescale=0.005,
+        accum_synapse=0.1, ff_synapse=0.005,
+        intercept_width=0.15, radius=1., **kwargs):
+    n_accum_neurons = int(accum_neuron_ratio * n_neurons)
+    n_thresholding_neurons = n_neurons - n_accum_neurons
+
+    bar_beta = 1. + radius * feedback_timescale / accum_timescale
+    feedback_tr = (
+        np.eye(n_ensembles) - bar_beta * (1. - np.eye(n_ensembles)) /
+        feedback_timescale)
+
+    with nengo.Network(**kwargs) as net:
+        net.accumulators = ThresholdingArray(
+            n_accum_neurons, n_ensembles, threshold=0., radius=radius)
+        net.thresholding = ThresholdingArray(
+            n_thresholding_neurons, n_ensembles, threshold=accum_threshold,
+            radius=radius, function=lambda x: x > accum_threshold)
+
+        nengo.Connection(
+            net.accumulators.output, net.accumulators.input,
+            synapse=accum_synapse)
+        nengo.Connection(
+            net.accumulators.output, net.thresholding.input,
+            synapse=ff_synapse)
+        nengo.Connection(
+            net.thresholding.output, net.accumulators.input,
+            synapse=accum_synapse, transform=accum_synapse * feedback_tr)
+
+        net.input_reset = nengo.Node(size_in=1)
+        nengo.Connection(
+            net.input_reset, net.accumulators.input, synapse=None,
+            transform=-radius * np.ones((n_ensembles, 1)) / accum_synapse)
+
+        net.input = nengo.Node(size_in=n_ensembles)
+        nengo.Connection(net.input, net.accumulators.input, synapse=None,
+                         transform=1. / accum_timescale)
+        net.output = net.thresholding.output
+    return net
+
+
 def ThresholdingArray(
         n_neurons, n_ensembles, threshold, intercept_width=0.15, function=None,
         radius=1., **kwargs):
@@ -21,9 +63,9 @@ def ThresholdingArray(
         net.thresholded = net.thresholding.output
 
         if function is None:
-            net.output = net.thresholding.output
-        else:
-            net.output = net.thresholding.add_output('function', function)
+            function = lambda x: x
+        function = lambda x, function=function: function(x + threshold)
+        net.output = net.thresholding.add_output('function', function)
     return net
 
 

--- a/nengo/spa/selection.py
+++ b/nengo/spa/selection.py
@@ -1,4 +1,4 @@
-"""Selection networks."""
+"""Selection networks that pick one or more options among multiple choices."""
 
 import nengo
 import numpy as np
@@ -9,6 +9,64 @@ def IA(
         accum_timescale=0.1, feedback_timescale=0.005,
         accum_synapse=0.1, ff_synapse=0.005,
         intercept_width=0.15, radius=1., **kwargs):
+    """Independent accumulator (IA) winner-take-all (WTA) network.
+
+    This is a two-layered network. The first layer consists of independent
+    accumulators (integrators), whereas the second layer does a thresholding.
+    Once the threshold is exceeded a feedback connection will stabilize the
+    current choice and inhibit all other choices. To switch the selection,
+    it is necessary to provide a transient input to *input_reset* to reset
+    the accumulator states.
+
+    This network is suited especially for accumulating evidence under noisy
+    conditions and keep a stable choice selection until the processing of the
+    choice has been finished.
+
+    Further details are to be found in "A Spiking Independent Accumulator Model
+    for Winner-Take-All Computation" (J Gosmann, AR Voelker, and C Eliasimth;
+    submitted to CogSci 2017).
+
+    Parameters
+    ----------
+    n_neurons : int
+        Number of neurons for each choice.
+    n_ensembles : int
+        Number of choices.
+    accum_threshold : float, optional (Default: 0.8)
+        Accumulation threshold that needs to be reached to produce an output.
+    accum_neuron_ratio: float, optional (Default: 0.7)
+        Portion of *n_neurons* that will be used for a layer 1 accumulator
+        ensemble. The remaining neurons will be used for a layer 2 thresholding
+        ensemble.
+    accum_timescale : float, optional (Default: 0.1)
+        Evidence accumulation timescale.
+    feedback_timescale : float, optional (Default: 0.005)
+        Timescale for the feedback connection from the thresholding layer to
+        the accumulation layer.
+    accum_synapse : Synapse or float, optional (Default: 0.1)
+        The synapse for connections to the accumulator ensembles.
+    ff_synapse : Synapse or float, optional (Default: 0.005)
+        Synapse for feed-forward connections.
+    intercept_width : float, optional (Default: 0.15)
+        The `presets.ThresholdingEnsembles` *intercept_width* parameter.
+    radius : float, optional (Default: 1.0)
+        The representational radius of the ensembles.
+    kwargs : dict
+        Passed on to `nengo.Network`.
+
+    Attributes
+    ----------
+    input : Node
+        The inputs to the network.
+    input_reset : Node
+        Input to reset the accumulators.
+    output : Node
+        The outputs of the network.
+    accumulators : ThresholdingArray
+        The layer 1 accumulators.
+    thresholding : ThresholdingArray
+        The layer 2 thresholding ensembles.
+    """
     n_accum_neurons = int(accum_neuron_ratio * n_neurons)
     n_thresholding_neurons = n_neurons - n_accum_neurons
 
@@ -49,6 +107,38 @@ def IA(
 def ThresholdingArray(
         n_neurons, n_ensembles, threshold, intercept_width=0.15, function=None,
         radius=1., **kwargs):
+    """Array of thresholding ensembles.
+
+    All inputs below the threshold will produce an output of 0, whereas inputs
+    above the threshold produce an output of equal value.
+
+    Parameters
+    ----------
+    n_neurons : int
+        Number of neurons for each ensemble.
+    n_ensembles : int
+        Number of ensembles.
+    threshold : float
+        The thresholding value.
+    intercept_width : float, optional (Default: 0.15)
+        The `presets.ThresholdingEnsembles` *intercept_width* parameter.
+    function : function, optional (Default: None)
+        Function to apply to the thresholded values.
+    radius : float, optional (Default: 1.0)
+        The representational radius of the ensembles.
+    kwargs : dict
+        Arguments passed on to `nengo.Network`.
+
+    Attributes
+    ----------
+    input : Node
+        The inputs to the network.
+    output : Node
+        The outputs of the network.
+    thresholded : Node
+        The raw thresholded value (before applying *function* or correcting
+        for the shift produced by the thresholding).
+    """
     with nengo.Network(**kwargs) as net:
         with nengo.presets.ThresholdingEnsembles(
                 0., intercept_width, radius=radius):
@@ -71,6 +161,31 @@ def ThresholdingArray(
 
 def WTA(n_neurons, n_ensembles, inhibit_scale=1.0, inhibit_synapse=0.005,
         **kwargs):
+    """Winner-take-all (WTA) network with lateral inhibition.
+
+    Parameters
+    ----------
+    n_neurons : int
+        Number of neurons for each ensemble.
+    n_ensembles : int
+        Number of ensembles.
+    inhibit_scale : float, optional (Default: 1.0)
+        Scaling of the lateral inhibition.
+    inhibit_synapse : Synapse or float, optional (Default: 0.005)
+        Synapse on the recurrent connection for lateral inhibition.
+    kwargs : dict
+        Arguments passed on to `ThresholdingArray`.
+
+    Attributes
+    ----------
+    input : Node
+        The inputs to the network.
+    output : Node
+        The outputs of the network.
+    thresholded : Node
+        The raw thresholded value (before applying *function* or correcting
+        for the shift produced by the thresholding).
+    """
     net = ThresholdingArray(n_neurons, n_ensembles, **kwargs)
     with net:
         nengo.Connection(

--- a/nengo/spa/selection.py
+++ b/nengo/spa/selection.py
@@ -5,45 +5,9 @@ import numpy as np
 from nengo.utils.compat import is_iterable
 
 
-def LinearFunc():
-    """Returns a linear mapping function.
-
-    Returns a linear mapping function for ease of use when creating output
-    mappings. The returned function takes in a non-optional 'x' parameter.
-    """
-    return lambda x: x
-
-
-def FilteredStepFunc(x_scale=15.0):
-    """Returns a filtered step mapping function.
-
-    Returns a filtered step mapping function for ease of use when creating
-    output mappings. The returned function takes in a non-optional 'x'.
-
-    Parameters
-    ----------
-    x_scale: float, optional
-        Scaling factor to be applied to the 'x' input. Affects the
-        sharpness of the filtered step edge. Larger values produce a
-        sharper edge. Set to a negative value to flip the mapping
-        function about the 'y' axis at x == 0.
-    """
-    return lambda x: np.maximum(1. - np.exp(-x_scale * x), 0)
-
-
-def StepFunc():
-    """Returns a step mapping function.
-
-    Returns a step mapping function for ease of use when creating
-    output mappings. The returned function takes in a non-optional 'x'
-    parameter.
-    """
-    return lambda x: float(x > 0.)
-
-
 def ThresholdingArray(
-        n_neurons, n_ensembles, threshold, intercept_width=0.15,
-        function=LinearFunc(), radius=1., **kwargs):
+        n_neurons, n_ensembles, threshold, intercept_width=0.15, function=None,
+        radius=1., **kwargs):
     if not is_iterable(threshold):
         threshold = threshold * np.ones((n_ensembles, 1))
     else:
@@ -61,7 +25,10 @@ def ThresholdingArray(
 
         net.input = net.thresholding.input
         net.thresholded = net.thresholding.output
-        net.output = net.thresholding.add_output('function', function)
+        if function is None:
+            net.output = net.thresholding.output
+        else:
+            net.output = net.thresholding.add_output('function', function)
     return net
 
 

--- a/nengo/spa/selection.py
+++ b/nengo/spa/selection.py
@@ -2,17 +2,11 @@
 
 import nengo
 import numpy as np
-from nengo.utils.compat import is_iterable
 
 
 def ThresholdingArray(
         n_neurons, n_ensembles, threshold, intercept_width=0.15, function=None,
         radius=1., **kwargs):
-    if not is_iterable(threshold):
-        threshold = threshold * np.ones((n_ensembles, 1))
-    else:
-        threshold = np.atleast_2d(threshold)
-
     with nengo.Network(**kwargs) as net:
         with nengo.presets.ThresholdingEnsembles(
                 0., intercept_width, radius=radius):
@@ -21,10 +15,11 @@ def ThresholdingArray(
 
         net.bias = nengo.Node(1.)
         nengo.Connection(net.bias, net.thresholding.input,
-                         transform=-threshold)
+                         transform=-threshold * np.ones((n_ensembles, 1)))
 
         net.input = net.thresholding.input
         net.thresholded = net.thresholding.output
+
         if function is None:
             net.output = net.thresholding.output
         else:

--- a/nengo/spa/selection.py
+++ b/nengo/spa/selection.py
@@ -1,0 +1,76 @@
+"""Selection networks."""
+
+import nengo
+import numpy as np
+from nengo.utils.compat import is_iterable
+
+
+def LinearFunc():
+    """Returns a linear mapping function.
+
+    Returns a linear mapping function for ease of use when creating output
+    mappings. The returned function takes in a non-optional 'x' parameter.
+    """
+    return lambda x: x
+
+
+def FilteredStepFunc(x_scale=15.0):
+    """Returns a filtered step mapping function.
+
+    Returns a filtered step mapping function for ease of use when creating
+    output mappings. The returned function takes in a non-optional 'x'.
+
+    Parameters
+    ----------
+    x_scale: float, optional
+        Scaling factor to be applied to the 'x' input. Affects the
+        sharpness of the filtered step edge. Larger values produce a
+        sharper edge. Set to a negative value to flip the mapping
+        function about the 'y' axis at x == 0.
+    """
+    return lambda x: np.maximum(1. - np.exp(-x_scale * x), 0)
+
+
+def StepFunc():
+    """Returns a step mapping function.
+
+    Returns a step mapping function for ease of use when creating
+    output mappings. The returned function takes in a non-optional 'x'
+    parameter.
+    """
+    return lambda x: float(x > 0.)
+
+
+def ThresholdingArray(
+        n_neurons, n_ensembles, threshold, intercept_width=0.15,
+        function=LinearFunc(), radius=1., **kwargs):
+    if not is_iterable(threshold):
+        threshold = threshold * np.ones((n_ensembles, 1))
+    else:
+        threshold = np.atleast_2d(threshold)
+
+    with nengo.Network(**kwargs) as net:
+        with nengo.presets.ThresholdingEnsembles(
+                0., intercept_width, radius=radius):
+            net.thresholding = nengo.networks.EnsembleArray(
+                n_neurons, n_ensembles)
+
+        net.bias = nengo.Node(1.)
+        nengo.Connection(net.bias, net.thresholding.input,
+                         transform=-threshold)
+
+        net.input = net.thresholding.input
+        net.thresholded = net.thresholding.output
+        net.output = net.thresholding.add_output('function', function)
+    return net
+
+
+def WTA(n_neurons, n_ensembles, inhibit_scale=1.0, inhibit_synapse=0.005,
+        **kwargs):
+    net = ThresholdingArray(n_neurons, n_ensembles, **kwargs)
+    with net:
+        nengo.Connection(
+            net.thresholded, net.input,
+            transform=inhibit_scale * (np.eye(n_ensembles) - 1.),
+            synapse=inhibit_synapse)
+    return net

--- a/nengo/spa/tests/test_assoc_mem.py
+++ b/nengo/spa/tests/test_assoc_mem.py
@@ -2,8 +2,8 @@ import nengo
 import numpy as np
 from nengo import spa
 from nengo.spa import Vocabulary
-from nengo.spa.assoc_mem import AssociativeMemory
-from nengo.spa.selection import FilteredStepFunc, WTA
+from nengo.spa.assoc_mem import ThresholdingAssocMem, WtaAssocMem
+from nengo.spa.selection import FilteredStepFunc
 from nengo.spa.utils import similarity
 
 
@@ -15,8 +15,8 @@ def test_am_basic(Simulator, plt, seed, rng):
     vocab.populate('A; B; C; D')
 
     with spa.Module('model', seed=seed) as m:
-        m.am = AssociativeMemory(vocab, threshold=0.3,
-                                 function=FilteredStepFunc())
+        m.am = ThresholdingAssocMem(threshold=0.3, input_vocab=vocab,
+                                    function=FilteredStepFunc())
         m.stimulus = spa.Input()
         m.stimulus.am = 'A'
 
@@ -55,8 +55,9 @@ def test_am_threshold(Simulator, plt, seed, rng):
         return '0.49 * A' if t < 0.1 else '0.8 * B'
 
     with spa.Module('model', seed=seed) as m:
-        m.am = AssociativeMemory(vocab, vocab2, threshold=0.5,
-                                 function=FilteredStepFunc())
+        m.am = ThresholdingAssocMem(
+            threshold=0.5, input_vocab=vocab, output_vocab=vocab2,
+            function=FilteredStepFunc())
         m.stimulus = spa.Input()
         m.stimulus.am = input_func
 
@@ -98,9 +99,8 @@ def test_am_wta(Simulator, plt, seed, rng):
             return '0.8 * A + B'
 
     with spa.Module('model', seed=seed) as m:
-        m.am = AssociativeMemory(
-            vocab, selection_net=WTA, threshold=0.3,
-            function=FilteredStepFunc())
+        m.am = WtaAssocMem(
+            threshold=0.3, input_vocab=vocab, function=FilteredStepFunc())
         m.stimulus = spa.Input()
         m.stimulus.am = input_func
 
@@ -138,8 +138,8 @@ def test_am_default_output(Simulator, plt, seed, rng):
         return '0.2 * A' if t < 0.25 else 'A'
 
     with spa.Module('model', seed=seed) as m:
-        m.am = AssociativeMemory(vocab, threshold=0.5,
-                                 function=FilteredStepFunc())
+        m.am = ThresholdingAssocMem(threshold=0.5, input_vocab=vocab,
+                                    function=FilteredStepFunc())
         m.am.add_default_output('D', 0.5)
         m.stimulus = spa.Input()
         m.stimulus.am = input_func
@@ -182,10 +182,9 @@ def test_am_spa_keys_as_expressions(Simulator, plt, seed, rng):
     out_keys = ['C*D', 'C+D']
 
     with nengo.spa.Module(seed=seed) as model:
-        model.am = AssociativeMemory(input_vocab=vocab_in,
-                                     output_vocab=vocab_out,
-                                     input_keys=in_keys,
-                                     output_keys=out_keys, threshold=0.3)
+        model.am = ThresholdingAssocMem(
+            threshold=0.3, input_vocab=vocab_in, output_vocab=vocab_out,
+            input_keys=in_keys, output_keys=out_keys)
 
         model.inp = spa.Input()
         model.inp.am = lambda t: 'A' if t < 0.1 else 'A*B'

--- a/nengo/spa/tests/test_assoc_mem.py
+++ b/nengo/spa/tests/test_assoc_mem.py
@@ -3,8 +3,10 @@ import numpy as np
 from nengo import spa
 from nengo.spa import Vocabulary
 from nengo.spa.assoc_mem import ThresholdingAssocMem, WtaAssocMem
-from nengo.spa.selection import FilteredStepFunc
 from nengo.spa.utils import similarity
+
+
+filtered_step_fn = lambda x: np.maximum(1. - np.exp(-15. * x), 0.)
 
 
 def test_am_basic(Simulator, plt, seed, rng):
@@ -16,7 +18,7 @@ def test_am_basic(Simulator, plt, seed, rng):
 
     with spa.Module('model', seed=seed) as m:
         m.am = ThresholdingAssocMem(threshold=0.3, input_vocab=vocab,
-                                    function=FilteredStepFunc())
+                                    function=filtered_step_fn)
         m.stimulus = spa.Input()
         m.stimulus.am = 'A'
 
@@ -57,7 +59,7 @@ def test_am_threshold(Simulator, plt, seed, rng):
     with spa.Module('model', seed=seed) as m:
         m.am = ThresholdingAssocMem(
             threshold=0.5, input_vocab=vocab, output_vocab=vocab2,
-            function=FilteredStepFunc())
+            function=filtered_step_fn)
         m.stimulus = spa.Input()
         m.stimulus.am = input_func
 
@@ -100,7 +102,7 @@ def test_am_wta(Simulator, plt, seed, rng):
 
     with spa.Module('model', seed=seed) as m:
         m.am = WtaAssocMem(
-            threshold=0.3, input_vocab=vocab, function=FilteredStepFunc())
+            threshold=0.3, input_vocab=vocab, function=filtered_step_fn)
         m.stimulus = spa.Input()
         m.stimulus.am = input_func
 
@@ -139,7 +141,7 @@ def test_am_default_output(Simulator, plt, seed, rng):
 
     with spa.Module('model', seed=seed) as m:
         m.am = ThresholdingAssocMem(threshold=0.5, input_vocab=vocab,
-                                    function=FilteredStepFunc())
+                                    function=filtered_step_fn)
         m.am.add_default_output('D', 0.5)
         m.stimulus = spa.Input()
         m.stimulus.am = input_func

--- a/nengo/spa/tests/test_selection.py
+++ b/nengo/spa/tests/test_selection.py
@@ -5,7 +5,7 @@ import nengo
 from nengo.spa.selection import ThresholdingArray, WTA
 
 
-def test_thresholding_array(Simulator, plt, seed, rng):
+def test_thresholding_array(Simulator, plt, seed):
     with nengo.Network(seed=seed) as m:
         thresholding = ThresholdingArray(50, 4, 0.2, function=lambda x: x > 0.)
         in_node = nengo.Node([0.8, 0.5, 0.2, -0.1], label='input')
@@ -39,7 +39,28 @@ def test_thresholding_array(Simulator, plt, seed, rng):
     assert np.all(sim.data[thresholded_p][t > 0.15, 2:] < 0.001)
 
 
-def test_wta(Simulator, plt, seed, rng):
+def test_thresholding_array_output_shift(Simulator, plt, seed):
+    with nengo.Network(seed=seed) as m:
+        thresholding = ThresholdingArray(50, 2, 0.5)
+        in_node = nengo.Node([0.7, 0.4])
+        nengo.Connection(in_node, thresholding.input)
+        p = nengo.Probe(thresholding.output, synapse=0.03)
+
+    with Simulator(m) as sim:
+        sim.run(0.2)
+    t = sim.trange()
+
+    plt.plot(t, sim.data[p])
+    plt.axhline(y=0.7)
+    plt.ylim(0., 1.)
+    plt.xlabel("Time")
+    plt.ylabel("Output")
+
+    assert_allclose(sim.data[p][t > 0.15, 0], 0.7, atol=0.05)
+    assert_allclose(sim.data[p][:, 1], 0.)
+
+
+def test_wta(Simulator, plt, seed):
     def input_func(t):
         if t < 0.2:
             return np.array([1.0, 0.8, 0.0, 0.0])

--- a/nengo/spa/tests/test_selection.py
+++ b/nengo/spa/tests/test_selection.py
@@ -1,0 +1,92 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+import nengo
+from nengo.spa.selection import StepFunc, ThresholdingArray, WTA
+
+
+def test_thresholding_array(Simulator, plt, seed, rng):
+    with nengo.Network(seed=seed) as m:
+        thresholding = ThresholdingArray(50, 4, 0.2, function=StepFunc())
+        in_node = nengo.Node([0.8, 0.5, 0.2, -0.1], label='input')
+        nengo.Connection(in_node, thresholding.input)
+
+        in_p = nengo.Probe(in_node)
+        out_p = nengo.Probe(thresholding.output, synapse=0.03)
+        thresholded_p = nengo.Probe(thresholding.thresholded, synapse=0.03)
+
+    with Simulator(m) as sim:
+        sim.run(0.2)
+    t = sim.trange()
+
+    plt.subplot(3, 1, 1)
+    plt.plot(t, sim.data[in_p])
+    plt.ylabel("Input")
+    plt.subplot(3, 1, 2)
+    plt.plot(t, sim.data[out_p])
+    plt.plot(t[t > 0.15], 0.9 * np.ones(t.shape)[t > 0.15], c='k', lw=2)
+    plt.ylabel("Output")
+    plt.subplot(3, 1, 3)
+    plt.plot(t, sim.data[thresholded_p])
+    plt.plot(t[t > 0.15], 0.6 * np.ones(t.shape)[t > 0.15], c='k', lw=2)
+    plt.plot(t[t > 0.15], 0.3 * np.ones(t.shape)[t > 0.15], c='k', lw=2)
+    plt.ylabel("Utilities")
+
+    assert np.all(sim.data[out_p][t > 0.15, :2] > 0.9)
+    assert np.all(sim.data[out_p][t > 0.15, 2:] < 0.001)
+    assert_allclose(sim.data[thresholded_p][t > 0.15, 0], 0.6, atol=0.05)
+    assert_allclose(sim.data[thresholded_p][t > 0.15, 1], 0.3, atol=0.05)
+    assert np.all(sim.data[thresholded_p][t > 0.15, 2:] < 0.001)
+
+
+def test_wta(Simulator, plt, seed, rng):
+    def input_func(t):
+        if t < 0.2:
+            return np.array([1.0, 0.8, 0.0, 0.0])
+        elif t < 0.3:
+            return np.zeros(4)
+        else:
+            return np.array([0.8, 1.0, 0.0, 0.0])
+
+    with nengo.Network(seed=seed) as m:
+        wta = WTA(50, 4, threshold=0.3, function=StepFunc())
+
+        in_node = nengo.Node(output=input_func, label='input')
+        nengo.Connection(in_node, wta.input)
+
+        in_p = nengo.Probe(in_node)
+        out_p = nengo.Probe(wta.output, synapse=0.03)
+        thresholded_p = nengo.Probe(wta.thresholded, synapse=0.03)
+
+    with Simulator(m) as sim:
+        sim.run(0.5)
+    t = sim.trange()
+    more_a = (t > 0.15) & (t < 0.2)
+    more_b = t > 0.45
+
+    plt.subplot(3, 1, 1)
+    plt.plot(t, sim.data[in_p])
+    plt.ylabel("Input")
+    plt.ylim(0., 1.1)
+    plt.subplot(3, 1, 2)
+    plt.plot(t, sim.data[out_p])
+    plt.plot(t[more_a], np.ones(t.shape)[more_a] * 0.9, c='g', lw=2)
+    plt.plot(t[more_b], np.ones(t.shape)[more_b] * 0.9, c='g', lw=2)
+    plt.ylabel("Output")
+    plt.ylim(0., 1.1)
+    plt.subplot(3, 1, 3)
+    plt.plot(t, sim.data[thresholded_p])
+    plt.plot(t[more_a], np.ones(t.shape)[more_a] * 0.6, c='g', lw=2)
+    plt.plot(t[more_b], np.ones(t.shape)[more_b] * 0.6, c='g', lw=2)
+    plt.ylabel("Thresholded")
+    plt.ylim(0., 1.1)
+
+    assert np.all(sim.data[out_p][more_a, 0] > 0.9)
+    assert np.all(sim.data[out_p][more_a, 1] < 0.1)
+    assert np.all(sim.data[out_p][more_b, 1] > 0.9)
+    assert np.all(sim.data[out_p][more_b, 0] < 0.1)
+    assert np.all(sim.data[thresholded_p][more_a, 0] > 0.6)
+    assert np.all(sim.data[thresholded_p][more_a, 1:] < 0.001)
+    assert np.all(sim.data[thresholded_p][more_b, 1] > 0.6)
+    assert np.all(sim.data[thresholded_p][more_b, 0] < 0.001)
+    assert np.all(sim.data[thresholded_p][more_b, 2:] < 0.001)

--- a/nengo/spa/tests/test_selection.py
+++ b/nengo/spa/tests/test_selection.py
@@ -2,12 +2,12 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import nengo
-from nengo.spa.selection import StepFunc, ThresholdingArray, WTA
+from nengo.spa.selection import ThresholdingArray, WTA
 
 
 def test_thresholding_array(Simulator, plt, seed, rng):
     with nengo.Network(seed=seed) as m:
-        thresholding = ThresholdingArray(50, 4, 0.2, function=StepFunc())
+        thresholding = ThresholdingArray(50, 4, 0.2, function=lambda x: x > 0.)
         in_node = nengo.Node([0.8, 0.5, 0.2, -0.1], label='input')
         nengo.Connection(in_node, thresholding.input)
 
@@ -49,7 +49,7 @@ def test_wta(Simulator, plt, seed, rng):
             return np.array([0.8, 1.0, 0.0, 0.0])
 
     with nengo.Network(seed=seed) as m:
-        wta = WTA(50, 4, threshold=0.3, function=StepFunc())
+        wta = WTA(50, 4, threshold=0.3, function=lambda x: x > 0.)
 
         in_node = nengo.Node(output=input_func, label='input')
         nengo.Connection(in_node, wta.input)


### PR DESCRIPTION
**Motivation and context:**
This PR introduces a rewritten associative memory for the `new-spa`.

Compared to previous implementations where the `AssociativeMemory` implemented all possible variants, I split up different possible implementations.

The core networks that can be used to implement something like an associative memory are found in `selection.py`. These are a simple array of thresholding ensembles (`ThresholdingArray`), a basic WTA (`WTA`) with lateral inhibition, and the independent accumulator (`IA`) network submitted to CogSci. All these core networks are standard Nengo networks because they don't operate on semantic pointers, but each dimension represents a potential choice. (I also wanted to repeatedly use such networks in situations where I didn't have semantic pointers.) This also leads to the question: **Do we want those networks potentially in core Nengo? Or do we keep them in nengo_spa?**

The `AssociativeMemory` is basically a wrapper around such a core network that adds the projections from and to the Semantic Pointer space and allows to use the network with other SPA modules. We pass only the class of the core network + kwargs to the AssociativeMemory to avoid the user to have to pass `add_to_container=False`. Also, for better usability for the end-user there are classes `ThresholdingAssocMem`, `WtaAssocMem`, and `IaAssocMem`.

Further comments:
* I am not setting a default value for the threshold. To me it seems better to explicitly force the user to specify the threshold.
* By default the identity function is applied to the outputs of `ThresholdingArray` and `WTA`. A step function might be more appropriate in some cases, but is easily added by providing the `function=lambda x: x > threshold` argument.
* I haven't implemented an `inhibitable` flag. One still has the option to create inhibitory connections to the core network and other SPA modules don't provide this option either (actually I would find it more useful on `spa.State` then on the `AssociativeMemory`). I plan to make a PR to core Nengo with a function that inhbits all ensembles in a network. It's a functionality I commonly need, even outside of SPA. That function could than also be used for all SPA modules.
* I haven't implemented the cleanup with double inhibition. It never made it into the Nengo master (but exists in @xchoo's `assoc_mem_v3` branch). I'm not sure whether we want to include it. It reduces the noise on the output in certain circumstances, but I haven't missed the functionality and it could always be added later.
* There is no non-SPA associative memory that uses vectors anymore. If you need that, you can use one of the core networks and set the transforms on the input and output connection yourself. It doesn't seem necessary to have just a network for that and chances are high if someone is using vectors, the SPA associative memory with a proper vocab can be used.

**Interactions with other PRs:**

This PR supersedes #991.

**How has this been tested?**
Updated and adapted existing tests.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Lengthy (more than 150 lines changed or changes are complicated)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly. [The associative_memory example probably needs to be updated, but all the SPA examples need to be updated at some point which will be a separete effort.]
- [n/a] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
- [x] documentation
- [x] drift diffusion network
- ~~cleanup with double inhibition?~~