### PR TITLE
Change DotInc to ElementwiseInc in PES rule

### DIFF
--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -540,7 +540,7 @@ def build_pes(model, pes, rule):
                  else conn.pre_obj.size_in)
     lr_sig = Signal(-pes.learning_rate * model.dt / n_neurons,
                     name="PES:learning_rate")
-    model.add_op(DotInc(lr_sig, error, correction, tag="PES:correct"))
+    model.add_op(ElementwiseInc(lr_sig, error, correction, tag="PES:correct"))
 
     if not conn.is_decoded:
         post = get_post_ens(conn)


### PR DESCRIPTION
**Motivation and context:**
As defined, the arguments to `DotInc` should be a matrix and a vector.  In this case it was being called with a scalar and a vector as input, which would more appropriately be an `ElementwiseInc`.  

The swap works fine in the reference backend, because `dot(scalar, vector) == scalar*vector` in numpy.  But in other backends, such as `nengo_ocl` or `nengo_dl`, there may be specialized implementations for `DotInc` that are optimized under the assumption that it will be called with a matrix.  Since there's no downside to switching this operation to an `ElementwiseInc` for the reference backend, we might as well in order to be consistent.

**Interactions with other PRs:**
I've based this on #1245, the only new commit is f1c52e8431560ce3a2b0a4cbed6b7210937cce3e.  Technically it's independent, but it's in the same vein (I created a new PR for this one because #1245 has already been reviewed).

**How has this been tested?**
All unit tests continue to pass with the change.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [N/A] I have included a changelog entry.
- [N/A] I have added tests to cover my changes.
- [x] All new and existing tests passed.
