### PR TITLE
Fix float indexing in learn_associations

### DIFF
--- a/examples/learning/learn_associations.ipynb
+++ b/examples/learning/learn_associations.ipynb
@@ -135,7 +135,7 @@
       "        raise ValueError(\"dt (%s) does not divide period (%s)\" % (dt, period))\n",
       "    def f(t):\n",
       "        i = int(round((t - dt)/dt))  # t starts at dt\n",
-      "        return x[(i/i_every)%len(x)]\n",
+      "        return x[int(i/i_every)%len(x)]\n",
       "    return f"
      ],
      "language": "python",


### PR DESCRIPTION
**Motivation and context:**

Our [appveyor builds are failing on Python 3 64-bit](https://ci.appveyor.com/project/nengo/nengo/build/1.0.1039) :( I was able to reproduce the error locally; I'm not sure if the issue is a new version of NumPy or Python, but for whatever reason, dividing an int by and int somehow gets promoted to a float now, which is causing the error. This casts it to int _again_ to fix the error.

**How has this been tested?**
Fixes the broken test locally. We should wait for AppVeyor to finish before merging.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] All new and existing tests passed.