### PR TITLE
Raise exception when passing seed as label.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,15 @@ Release History
   (`#1191 <https://github.com/nengo/nengo/issues/1191>`_,
   `#1267 <https://github.com/nengo/nengo/pull/1267>`_)
 
+**Changed**
+
+- We now enforce that the ``label`` of a network must be a string or ``None``,
+  and that the ``seed`` of a network must be an int or ``None``.
+  This helps avoid situations where the seed would mistakenly
+  be passed as the label.
+  (`#1277 <https://github.com/nengo/nengo/pull/1277>`_,
+  `#1275 <https://github.com/nengo/nengo/issues/1275>`_)
+
 **Fixed**
 
 - Properly handle non C-contiguous node outputs.

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -7,6 +7,7 @@ from nengo.ensemble import Ensemble
 from nengo.exceptions import (
     ConfigError, NetworkContextError, NotAddedToNetworkWarning, ReadonlyError)
 from nengo.node import Node
+from nengo.params import IntParam, StringParam
 from nengo.probe import Probe
 from nengo.utils.compat import iteritems
 from nengo.utils.threading import ThreadLocalStack
@@ -77,6 +78,9 @@ class Network(object):
     """
 
     context = ThreadLocalStack(maxsize=100)  # static stack of Network objects
+
+    label = StringParam('label', optional=True, readonly=False)
+    seed = IntParam('seed', optional=True, readonly=False)
 
     def __init__(self, label=None, seed=None, add_to_container=None):
         self.label = label
@@ -202,6 +206,12 @@ class Network(object):
                 "to be '%s' but instead got '%s'." % (self, network))
 
         self._config.__exit__(dummy_exc_type, dummy_exc_value, dummy_tb)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['label'] = self.label
+        state['seed'] = self.seed
+        return state
 
     def __setstate__(self, state):
         for k, v in iteritems(state):

--- a/nengo/tests/test_network.py
+++ b/nengo/tests/test_network.py
@@ -139,3 +139,10 @@ def test_get_objects():
     assert Counter([subnet, subnet2]) == Counter(model.all_networks)
     # Make sure it works a second time
     assert Counter([ens1, ens2, ens3]) == Counter(model.all_ensembles)
+
+
+def test_raises_exception_on_incompatiple_type_arguments():
+    with pytest.raises(ValueError):
+        nengo.Network(label=1)
+    with pytest.raises(ValueError):
+        nengo.Network(seed='label')

--- a/nengo/tests/test_presets.py
+++ b/nengo/tests/test_presets.py
@@ -5,7 +5,7 @@ import nengo
 
 def test_thresholding_preset(Simulator, seed, plt):
     threshold = 0.3
-    with nengo.Network(seed) as model:
+    with nengo.Network(seed=seed) as model:
         with nengo.presets.ThresholdingEnsembles(threshold):
             ens = nengo.Ensemble(50, 1)
         stimulus = nengo.Node(lambda t: t)
@@ -31,7 +31,7 @@ def test_thresholding_preset(Simulator, seed, plt):
 def test_thresholding_preset_radius(Simulator, seed):
     threshold = 0.3
     radius = 0.5
-    with nengo.Network(seed) as model:
+    with nengo.Network(seed=seed) as model:
         with nengo.presets.ThresholdingEnsembles(threshold, radius=radius):
             ens = nengo.Ensemble(50, 1)
 


### PR DESCRIPTION
**Motivation and context:**
This helps issues like #1275 where one accidentally sets the label instead of the seed. @tcstewar mentioned that he made that mistake also twice in a weekend, so it seems to be not super uncommon and I don't see a good reason for not enforcing the proper types. If someone has an integer value and wants to set it as the label, it is still possible to manually convert it to a string which also makes the intend explicit.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Added a test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)


**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.