### PR TITLE
Define pylint rules, fix pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,7 @@ extension-pkg-whitelist = numpy
 [MESSAGES CONTROL]
 
 #disable = all
-disable = broad-except, missing-docstring, no-self-use, protected-access, redefined-outer-name, redefined-variable-type, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-branches, too-many-locals, unused-argument
+disable = arguments-differ, broad-except, deprecated-method, missing-docstring, no-self-use, protected-access, redefined-builtin, redefined-outer-name, redefined-variable-type, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-branches, too-many-locals, unidiomatic-typecheck, unused-argument
 enable = W0231
 
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,7 @@ enable = W0231
 
 [REPORTS]
 
-reports = no
+reports = yes
 
 
 [BASIC]

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,7 @@ extension-pkg-whitelist = numpy
 [MESSAGES CONTROL]
 
 #disable = all
-disable = arguments-differ, broad-except, deprecated-method, missing-docstring, no-self-use, pointless-statement, protected-access, redefined-builtin, redefined-outer-name, redefined-variable-type, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-branches, too-many-locals, unidiomatic-typecheck, unused-argument
+disable = arguments-differ, broad-except, deprecated-method, missing-docstring, no-member, no-self-use, pointless-statement, protected-access, redefined-builtin, redefined-outer-name, redefined-variable-type, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-branches, too-many-locals, unidiomatic-typecheck, unused-argument
 enable = W0231
 
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -17,11 +17,13 @@ reports = yes
 [BASIC]
 good-names = E
 
-argument-rgx = ([A-Z]{1,2})|([a-z_][a-z0-9_]{0,30})$
-attr-rgx = [a-z_][a-z0-9_]{0,30}$
+argument-rgx = ([a-z_][a-z0-9_]{0,30})|([A-Z][a-zA-Z0-9]*(_[a-z0-9_]+)?)$
+attr-rgx = ([a-z_][a-z0-9_]{0,30})|([A-Z][a-zA-Z0-9]*(_[a-z0-9_]+)?)$
 class-attribute-rgx = ([A-Za-z_][A-Za-z0-9_]{0,30}|(__.*__))$
+class-rgx = [A-Z_][a-zA-Z0-9]*$
 const-rgx = (([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
-function-rgx = [a-zA-Z_][a-zA-Z0-9_]{2,30}$
+function-rgx = ([a-zA-Z_][a-zA-Z0-9_]{0,30})|(test_[a-z0-9_]+)$
+method-rgx = ([a-z_][a-z0-9_]{0,30})|(test_[a-z0-9_]+)$
 variable-rgx = ([A-Z]{1,2})|([a-z_][a-z0-9_]{0,30})|([a-z][A-Z])$
 
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,7 @@ extension-pkg-whitelist = numpy
 [MESSAGES CONTROL]
 
 #disable = all
-disable = broad-except, missing-docstring, protected-access, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-locals
+disable = broad-except, missing-docstring, no-self-use, protected-access, redefined-outer-name, redefined-variable-type, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-branches, too-many-locals, unused-argument
 enable = W0231
 
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -39,4 +39,5 @@ ignored-modules = matplotlib.cm, matplotlib.pyplot, numpy, numpy.random, numpy.l
 
 
 [FORMAT]
+max-line-length = 79
 ignore-long-lines = ^\s*(# (noqa )?)?<?https?://\S+>?(\s+ # noqa)?$

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,7 @@ extension-pkg-whitelist = numpy
 [MESSAGES CONTROL]
 
 #disable = all
-disable = arguments-differ, broad-except, deprecated-method, missing-docstring, no-self-use, protected-access, redefined-builtin, redefined-outer-name, redefined-variable-type, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-branches, too-many-locals, unidiomatic-typecheck, unused-argument
+disable = arguments-differ, broad-except, deprecated-method, missing-docstring, no-self-use, pointless-statement, protected-access, redefined-builtin, redefined-outer-name, redefined-variable-type, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-branches, too-many-locals, unidiomatic-typecheck, unused-argument
 enable = W0231
 
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,9 +1,40 @@
+[MASTER]
+extension-pkg-whitelist = numpy
+
+
 [MESSAGES CONTROL]
 
-disable = all
+#disable = all
+disable = broad-except, missing-docstring, protected-access, redundant-keyword-arg, too-few-public-methods, too-many-ancestors, too-many-arguments, too-many-instance-attributes, too-many-locals
 enable = W0231
 
 
 [REPORTS]
 
 reports = no
+
+
+[BASIC]
+good-names = E
+
+argument-rgx = ([A-Z]{1,2})|([a-z_][a-z0-9_]{0,30})$
+attr-rgx = [a-z_][a-z0-9_]{0,30}$
+class-attribute-rgx = ([A-Za-z_][A-Za-z0-9_]{0,30}|(__.*__))$
+const-rgx = (([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
+function-rgx = [a-zA-Z_][a-zA-Z0-9_]{2,30}$
+variable-rgx = ([A-Z]{1,2})|([a-z_][a-z0-9_]{0,30})|([a-z][A-Z])$
+
+
+[VARIABLES]
+redefining-builtins-modules = nengo.utils.compat
+dummy-variables-rgx = (_+[a-zA-Z0-9]*?$)|dummy|request
+
+
+[TYPECHECK]
+ignored-classes = nengo.params.DefaultType, tuple
+ignored-modules = matplotlib.cm, matplotlib.pyplot, numpy, numpy.random, numpy.linalg, scipy.special
+#ignored-modules = numpy.random, scipy.special
+
+
+[FORMAT]
+ignore-long-lines = ^\s*(# (noqa )?)?<?https?://\S+>?(\s+ # noqa)?$

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -11,9 +11,10 @@ in the `examples` directory of the source code repository.
 
 __copyright__ = "2013-2014, Applied Brain Research"
 __license__ = "Free for non-commercial use; see LICENSE.rst"
-from .version import version as __version__
 
 import logging
+
+from .version import version as __version__
 
 # Nengo namespace (API)
 from .base import Process

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -35,6 +35,7 @@ class NetworkMember(type):
         inst.__init__(*args, **kwargs)
         if add_to_container:
             nengo.Network.add(inst)
+        # pylint: disable=attribute-defined-outside-init
         inst._initialized = True  # value doesn't matter, just existance
         return inst
 
@@ -93,6 +94,7 @@ class NengoObject(with_metaclass(NetworkMember, SupportDefaultsMixin)):
         for k, v in iteritems(state):
             setattr(self, k, v)
 
+        # pylint: disable=attribute-defined-outside-init
         self._initialized = True
         if len(nengo.Network.context) > 0:
             warnings.warn(NotAddedToNetworkWarning(self))

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -206,6 +206,7 @@ class Builder(object):
             warnings.warn("Object %s has already been built." % obj)
             return None
 
+        obj_cls = object
         for obj_cls in type(obj).__mro__:
             if obj_cls in cls.builders:
                 break

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -11,17 +11,17 @@ from nengo.synapses import Lowpass
 
 
 class SimBCM(Operator):
-    """Calculate connection weight change according to the BCM rule.
+    r"""Calculate connection weight change according to the BCM rule.
 
     Implements the Bienenstock-Cooper-Munroe learning rule of the form
 
-    .. math:: \Delta \omega_{ij} = \kappa a_j (a_j - \\theta_j) a_i
+    .. math:: \Delta \omega_{ij} = \kappa a_j (a_j - \theta_j) a_i
 
     where
 
     * :math:`\kappa` is a scalar learning rate,
     * :math:`a_j` is the activity of a postsynaptic neuron,
-    * :math:`\\theta_j` is an estimate of the average :math:`a_j`, and
+    * :math:`\theta_j` is an estimate of the average :math:`a_j`, and
     * :math:`a_i` is the activity of a presynaptic neuron.
 
     Parameters
@@ -31,7 +31,7 @@ class SimBCM(Operator):
     post_filtered : Signal
         The postsynaptic activity, :math:`a_j`.
     theta : Signal
-        The modification threshold, :math:`\\theta_j`.
+        The modification threshold, :math:`\theta_j`.
     delta : Signal
         The synaptic weight change to be applied, :math:`\Delta \omega_{ij}`.
     learning_rate : float
@@ -52,7 +52,7 @@ class SimBCM(Operator):
     tag : str or None
         A label associated with the operator, for debugging purposes.
     theta : Signal
-        The modification threshold, :math:`\\theta_j`.
+        The modification threshold, :math:`\theta_j`.
 
     Notes
     -----
@@ -94,18 +94,18 @@ class SimBCM(Operator):
 
 
 class SimOja(Operator):
-    """Calculate connection weight change according to the Oja rule.
+    r"""Calculate connection weight change according to the Oja rule.
 
     Implements the Oja learning rule of the form
 
-    .. math:: \Delta \omega_{ij} = \kappa (a_i a_j - \\beta a_j^2 \omega_{ij})
+    .. math:: \Delta \omega_{ij} = \kappa (a_i a_j - \beta a_j^2 \omega_{ij})
 
     where
 
     * :math:`\kappa` is a scalar learning rate,
     * :math:`a_i` is the activity of a presynaptic neuron,
     * :math:`a_j` is the activity of a postsynaptic neuron,
-    * :math:`\\beta` is a scalar forgetting rate, and
+    * :math:`\beta` is a scalar forgetting rate, and
     * :math:`\omega_{ij}` is the connection weight between the two neurons.
 
     Parameters
@@ -121,14 +121,14 @@ class SimOja(Operator):
     learning_rate : float
         The scalar learning rate, :math:`\kappa`.
     beta : float
-        The scalar forgetting rate, :math:`\\beta`.
+        The scalar forgetting rate, :math:`\beta`.
     tag : str, optional (Default: None)
         A label associated with the operator, for debugging purposes.
 
     Attributes
     ----------
     beta : float
-        The scalar forgetting rate, :math:`\\beta`.
+        The scalar forgetting rate, :math:`\beta`.
     delta : Signal
         The synaptic weight change to be applied, :math:`\Delta \omega_{ij}`.
     learning_rate : float
@@ -189,7 +189,7 @@ class SimOja(Operator):
 
 
 class SimVoja(Operator):
-    """Simulates a simplified version of Oja's rule in the vector space.
+    r"""Simulates a simplified version of Oja's rule in the vector space.
 
     See :doc:`examples/learn_associations` for details.
 

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -80,6 +80,11 @@ class Operator(object):
     def __init__(self, tag=None):
         self.tag = tag
 
+        self._sets = []
+        self._incs = []
+        self._reads = []
+        self._updates = []
+
     def __repr__(self):
         return "<%s%s at 0x%x>" % (
             type(self).__name__, self._tagstr(), id(self))

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -97,6 +97,7 @@ def build_probe(model, probe):
     """
 
     # find the right parent class in `objtypes`, using `isinstance`
+    probeables = {}
     for nengotype, probeables in iteritems(probemap):
         if isinstance(probe.obj, nengotype):
             break

--- a/nengo/builder/tests/test_signal.py
+++ b/nengo/builder/tests/test_signal.py
@@ -133,7 +133,7 @@ def test_signal_slicing(rng):
     a = Signal(x.copy())
     b = Signal(y.copy())
 
-    for i in range(100):
+    for _ in range(100):
         si0, si1 = rng.randint(0, len(slices), size=2)
         s0, s1 = slices[si0], slices[si1]
         assert np.array_equiv(a[s0].initial_value, x[s0])

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -666,7 +666,7 @@ class DecoderCache(object):
                 with open(path, 'rb') as f:
                     f.seek(start)
                     solver_info, decoders = nco.read(f)
-            except (KeyError, IOError, OSError):
+            except Exception:
                 logger.debug("Cache miss [%s].", key)
                 decoders, solver_info = solver_fn(
                     solver, neuron_type, gain, bias, x, targets, rng=rng, E=E)

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -472,7 +472,6 @@ class DecoderCache(object):
 
     _CACHE_EXT = '.nco'
 
-    # pylint: disable=redefined-variable-type
     def __init__(self, readonly=False, cache_dir=None):
         self.readonly = readonly
         if cache_dir is None:
@@ -721,7 +720,6 @@ class DecoderCache(object):
         return os.path.join(directory, suffix + self._CACHE_EXT)
 
 
-# pylint: disable=no-self-use
 class NoDecoderCache(object):
     """Provides the same interface as `.DecoderCache` without caching."""
 
@@ -747,7 +745,6 @@ class NoDecoderCache(object):
         pass
 
 
-# pylint: disable=redefined-variable-type
 def get_default_decoder_cache():
     if rc.getboolean('decoder_cache', 'enabled'):
         decoder_cache = DecoderCache(

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -234,13 +234,11 @@ class InstanceParams(object):
                 lines.append("  %s: %s" % (attr, getattr(self, attr)))
         return "\n".join(lines)
 
-    # pylint: disable=unused-argument
     def get_param(self, key):
         raise ConfigError("Cannot get parameters on an instance; use "
                           "'config[%s].get_param' instead."
                           % type(self._configures).__name__)
 
-    # pylint: disable=unused-argument
     def set_param(self, key, value):
         raise ConfigError("Cannot set parameters on an instance; use "
                           "'config[%s].set_param' instead."

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -234,11 +234,13 @@ class InstanceParams(object):
                 lines.append("  %s: %s" % (attr, getattr(self, attr)))
         return "\n".join(lines)
 
+    # pylint: disable=unused-argument
     def get_param(self, key):
         raise ConfigError("Cannot get parameters on an instance; use "
                           "'config[%s].get_param' instead."
                           % type(self._configures).__name__)
 
+    # pylint: disable=unused-argument
     def set_param(self, key, value):
         raise ConfigError("Cannot set parameters on an instance; use "
                           "'config[%s].set_param' instead."

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -15,7 +15,8 @@ class Distribution(FrozenObject):
     accept the same arguments for the sample function.
     """
 
-    def _sample_shape(self, n, d=None):
+    @classmethod
+    def _sample_shape(cls, n, d=None):
         """Returns output shape for sample method."""
         return (n,) if d is None else (n, d)
 
@@ -234,7 +235,7 @@ class UniformHypersphere(Distribution):
         return "UniformHypersphere(%s)" % (
             "surface=True" if self.surface else "")
 
-    def sample(self, n, d, rng=np.random):
+    def sample(self, n, d=None, rng=np.random):
         if d is None or d < 1:  # check this, since other dists allow d = None
             raise ValidationError("Dimensions must be a positive integer", 'd')
 

--- a/nengo/ipynb.py
+++ b/nengo/ipynb.py
@@ -14,6 +14,7 @@ try:
     from html import escape
 except ImportError:
     from cgi import escape as cgi_escape
+    # pylint: disable=deprecated-method
     escape = lambda s, quote=True: cgi_escape(s, quote=quote)
 import warnings
 
@@ -25,12 +26,14 @@ from nengo.utils.progress import ProgressBar, timestamp2timedelta
 
 if has_ipynb_widgets():
     if IPython.version_info[0] <= 3:
+        # pylint: disable=no-name-in-module,import-error,ungrouped-imports
         from IPython.html.widgets import DOMWidget
         import IPython.utils.traitlets as traitlets
     else:
         import ipywidgets
         from ipywidgets import DOMWidget
         import traitlets
+    # pylint: disable=ungrouped-imports
     from IPython.display import display
 else:
     raise ImportError(

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -307,7 +307,7 @@ class Voja(LearningRuleType):
 class LearningRuleTypeParam(Parameter):
     def validate(self, instance, rule):
         if is_iterable(rule):
-            for r in (itervalues(rule) if isinstance(rule, dict) else rule):
+            for r in itervalues(rule) if isinstance(rule, dict) else rule:
                 self.validate_rule(instance, r)
         elif rule is not None:
             self.validate_rule(instance, rule)

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -137,6 +137,10 @@ class AssociativeMemory(nengo.Network):
                 # am_ensembles have [1] encoders
             else:
                 self.inhibit = None
+
+            self.thresh_bias = None
+            self.thresholded_utilities = None
+
         self.add_input_mapping("input", input_vectors, input_scales)
         self.add_output_mapping("output", output_vectors)
 

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -3,9 +3,9 @@ import warnings
 import numpy as np
 
 import nengo
-from .ensemblearray import EnsembleArray
 from nengo.dists import Choice, Exponential, Uniform
 from nengo.exceptions import ValidationError
+from nengo.networks.ensemblearray import EnsembleArray
 from nengo.utils.compat import is_iterable, range
 from nengo.utils.network import with_self
 

--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -90,7 +90,7 @@ def dft_half(n):
 
 def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
                         input_magnitude=1.0, net=None):
-    """Compute the circular convolution of two vectors.
+    r"""Compute the circular convolution of two vectors.
 
     The circular convolution :math:`c` of vectors :math:`a` and :math:`b`
     is given by

--- a/nengo/networks/tests/test_oscillator.py
+++ b/nengo/networks/tests/test_oscillator.py
@@ -11,7 +11,7 @@ def test_oscillator(Simulator, plt, seed):
 
         tau = 0.1
         freq = 5
-        T = nengo.networks.Oscillator(tau, freq,  n_neurons=100)
+        T = nengo.networks.Oscillator(tau, freq, n_neurons=100)
         nengo.Connection(input, T.input)
 
         A = nengo.Ensemble(100, dimensions=2)

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -405,9 +405,9 @@ class NdarrayParam(Parameter):
             shape = self.shape
 
         if ndarray.ndim != len(shape):
-                raise ValidationError("ndarray must be %dD (got %dD)"
-                                      % (len(shape), ndarray.ndim),
-                                      attr=self.name, obj=instance)
+            raise ValidationError("ndarray must be %dD (got %dD)"
+                                  % (len(shape), ndarray.ndim),
+                                  attr=self.name, obj=instance)
 
         for i, attr in enumerate(shape):
             assert is_integer(attr) or is_string(attr), (
@@ -454,6 +454,7 @@ class FunctionParam(Parameter):
                                   attr=self.name, obj=instance)
         return np.asarray(value).size
 
+    # pylint: disable=no-self-use,unused-argument
     def function_args(self, instance, function):
         return (np.zeros(1),)
 
@@ -488,6 +489,7 @@ class FrozenObject(object):
     def __eq__(self, other):
         if self is other:  # quick check for speed
             return True
+        # pylint: disable=unidiomatic-typecheck
         return type(self) == type(other) and all(
             p.equal(self, other) for p in self._params)
 

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -454,7 +454,6 @@ class FunctionParam(Parameter):
                                   attr=self.name, obj=instance)
         return np.asarray(value).size
 
-    # pylint: disable=no-self-use,unused-argument
     def function_args(self, instance, function):
         return (np.zeros(1),)
 

--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -79,11 +79,11 @@ class _RC(configparser.SafeConfigParser):
                 filename = fp.name
             else:
                 filename = '<???>'
-        logger.info('Reading configuration from {}'.format(filename))
+        logger.info('Reading configuration from %s.', filename)
         return configparser.SafeConfigParser.readfp(self, fp, filename)
 
     def read(self, filenames):
-        logger.info('Reading configuration files {}'.format(filenames))
+        logger.info('Reading configuration files %s.', filenames)
         return configparser.SafeConfigParser.read(self, filenames)
 
     def reload_rc(self, filenames=None):

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -132,6 +132,8 @@ class Simulator(object):
             self, network, dt=0.001, seed=None, model=None, progress_bar=True):
         self.closed = False
         self.progress_bar = progress_bar
+        self._n_steps = None
+        self._time = None
 
         if model is None:
             self.model = Model(dt=float(dt),
@@ -293,7 +295,7 @@ class Simulator(object):
         if progress_bar is None:
             progress_bar = self.progress_bar
         with ProgressTracker(steps, progress_bar, "Simulating") as progress:
-            for i in range(steps):
+            for _ in range(steps):
                 self.step()
                 progress.step()
 

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -127,6 +127,7 @@ class Lstsq(Solver):
                    'time': t}
 
 
+# pylint: disable=abstract-method
 class _LstsqNoiseSolver(Solver):
     """Base class for least-squares solvers with noise."""
 
@@ -350,7 +351,7 @@ class LstsqDrop(Solver):
 
     def __call__(self, A, Y, rng=None, E=None):
         tstart = time.time()
-        Y, m, n, _, matrix_in = format_system(A, Y)
+        Y, _, _, _, matrix_in = format_system(A, Y)
 
         # solve for coefficients using standard solver
         X, info0 = self.solver1(A, Y, rng=rng)
@@ -408,7 +409,7 @@ class Nnls(Solver):
         import scipy.optimize
 
         tstart = time.time()
-        Y, m, n, _, matrix_in = format_system(A, Y)
+        Y, _, n, _, matrix_in = format_system(A, Y)
         Y = self.mul_encoders(Y, E, copy=True)
         d = Y.shape[1]
 
@@ -456,11 +457,11 @@ class NnlsL2(Nnls):
         super(NnlsL2, self).__init__(weights=weights)
         self.reg = reg
 
-    def _solve(self, A, Y, rng, E, sigma=0.):
+    def _solve(self, A, Y, E, sigma=0.):
         import scipy.optimize
 
         tstart = time.time()
-        Y, m, n, _, matrix_in = format_system(A, Y)
+        Y, _, n, _, matrix_in = format_system(A, Y)
         Y = self.mul_encoders(Y, E, copy=True)
         d = Y.shape[1]
 
@@ -480,7 +481,7 @@ class NnlsL2(Nnls):
         return X if matrix_in or X.shape[1] > 1 else X.ravel(), info
 
     def __call__(self, A, Y, rng=None, E=None):
-        return self._solve(A, Y, rng, E, sigma=self.reg * A.max())
+        return self._solve(A, Y, E, sigma=self.reg * A.max())
 
 
 class NnlsL2nz(NnlsL2):

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -457,7 +457,7 @@ class NnlsL2(Nnls):
         super(NnlsL2, self).__init__(weights=weights)
         self.reg = reg
 
-    def _solve(self, A, Y, E, sigma=0.):
+    def _solve(self, A, Y, rng, E, sigma=0.):
         import scipy.optimize
 
         tstart = time.time()
@@ -481,7 +481,7 @@ class NnlsL2(Nnls):
         return X if matrix_in or X.shape[1] > 1 else X.ravel(), info
 
     def __call__(self, A, Y, rng=None, E=None):
-        return self._solve(A, Y, E, sigma=self.reg * A.max())
+        return self._solve(A, Y, rng, E, sigma=self.reg * A.max())
 
 
 class NnlsL2nz(NnlsL2):

--- a/nengo/spa/actions.py
+++ b/nengo/spa/actions.py
@@ -38,6 +38,7 @@ class Expression(object):
         self.validate_string(expression)
         sanitized_exp = ' '.join(expression.split('\n'))
         try:
+            # pylint: disable=eval-used
             self.expression = eval(sanitized_exp, {}, self)
         except NameError as e:
             raise SpaParseError("Unknown module in expression '%s': %s" %

--- a/nengo/spa/basalganglia.py
+++ b/nengo/spa/basalganglia.py
@@ -65,7 +65,8 @@ class BasalGanglia(Module):
             for c in cond.items:
                 if isinstance(c, DotProduct):
                     if ((isinstance(c.item1, Source) and c.item1.inverted) or
-                       (isinstance(c.item2, Source) and c.item2.inverted)):
+                            (isinstance(c.item2, Source)
+                             and c.item2.inverted)):
                         raise NotImplementedError(
                             "Inversion in subexpression '%s' from action '%s' "
                             "is not supported by the Basal Ganglia." %

--- a/nengo/spa/basalganglia.py
+++ b/nengo/spa/basalganglia.py
@@ -30,6 +30,7 @@ class BasalGanglia(Module):
                  label=None, seed=None, add_to_container=None):
         self.actions = actions
         self.input_synapse = input_synapse
+        self.spa = None
         self._bias = None
         Module.__init__(self, label, seed, add_to_container)
         nengo.networks.BasalGanglia(dimensions=self.actions.count, net=self)

--- a/nengo/spa/basalganglia.py
+++ b/nengo/spa/basalganglia.py
@@ -176,6 +176,7 @@ class BasalGanglia(Module):
                 "Only 1-dimensional sources can be scalar inputs")
 
         try:
+            # pylint: disable=eval-used
             scale = float(eval(source.transform.symbol))
         except ValueError:
             raise ValidationError("Transform must be scalar; got '%s'"

--- a/nengo/spa/bind.py
+++ b/nengo/spa/bind.py
@@ -54,6 +54,7 @@ class Bind(Module):
             self.cc = nengo.networks.CircularConvolution(
                 n_neurons, dimensions, invert_a, invert_b,
                 input_magnitude=input_magnitude)
+            # pylint: disable=invalid-name
             self.A = self.cc.A
             self.B = self.cc.B
             self.output = self.cc.output

--- a/nengo/spa/compare.py
+++ b/nengo/spa/compare.py
@@ -42,6 +42,7 @@ class Compare(Module):
                 neurons_per_multiply, dimensions,
                 input_magnitude=input_magnitude)
 
+            # pylint: disable=invalid-name
             self.inputA = nengo.Node(size_in=dimensions, label='inputA')
             self.inputB = nengo.Node(size_in=dimensions, label='inputB')
             self.output = nengo.Node(size_in=1, label='output')

--- a/nengo/spa/cortical.py
+++ b/nengo/spa/cortical.py
@@ -33,6 +33,7 @@ class Cortical(Module):
         self.actions = actions
         self.synapse = synapse
         self.neurons_cconv = neurons_cconv
+        self.spa = None
 
     def on_add(self, spa):
         Module.on_add(self, spa)

--- a/nengo/spa/tests/test_action_objects.py
+++ b/nengo/spa/tests/test_action_objects.py
@@ -102,6 +102,7 @@ def test_dotproduct():
     assert str(0.5 * (0.5*DotProduct(x, y))) == '0.25 * dot(x, y)'
     assert str(DotProduct(B, y)*2) == '2 * dot(B, y)'
 
+    # pylint: disable=expression-not-assigned
     with pytest.raises(TypeError):
         A * DotProduct(x, y)
     with pytest.raises(TypeError):

--- a/nengo/spa/tests/test_action_objects.py
+++ b/nengo/spa/tests/test_action_objects.py
@@ -40,7 +40,7 @@ def test_symbol():
     assert str(~(~A)) == 'A'
 
     assert str(-A) == '-A'
-    assert str(-(-A)) == 'A'
+    assert str(-(-A)) == 'A'  # pylint: disable=nonexistent-operator
 
     assert str(A*B+(B*~A)*0.5-A) == '(((A * B) + ((B * ~A) * 0.5)) - A)'
 
@@ -65,7 +65,7 @@ def test_source():
     assert str(A * s_q) == '(Q * A) * s'
 
     assert str(-s) == '-1 * s'
-    assert str(-(-s)) == 's'
+    assert str(-(-s)) == 's'  # pylint: disable=nonexistent-operator
     assert str(-s_q) == '-Q * s'
 
     assert str(s + s_q) == 's + Q * s'
@@ -121,7 +121,7 @@ def test_dotproduct():
     assert str(B + DotProduct(x, y)) == 'dot(x, y) + B'
 
     assert str(-DotProduct(x, y)) == '-dot(x, y)'
-    assert str(-(-DotProduct(x, y))) == 'dot(x, y)'
+    assert str(-(-DotProduct(x, y))) == 'dot(x, y)'  # pylint: disable=nonexistent-operator
 
     assert str(DotProduct(x, y) - 1) == 'dot(x, y) + -1'
     assert str(1 - DotProduct(x, y)) == '-dot(x, y) + 1'
@@ -238,4 +238,4 @@ def test_vector_list():
         '' - xy
 
     assert str(-xy) == '-1 * x + -1 * y'
-    assert str(-(-xy)) == 'x + y'
+    assert str(-(-xy)) == 'x + y'  # pylint: disable=nonexistent-operator

--- a/nengo/spa/tests/test_action_objects.py
+++ b/nengo/spa/tests/test_action_objects.py
@@ -121,7 +121,7 @@ def test_dotproduct():
     assert str(B + DotProduct(x, y)) == 'dot(x, y) + B'
 
     assert str(-DotProduct(x, y)) == '-dot(x, y)'
-    assert str(-(-DotProduct(x, y))) == 'dot(x, y)'  # pylint: disable=nonexistent-operator
+    assert str(-(-DotProduct(x, y))) == 'dot(x, y)'  # noqa, pylint: disable=nonexistent-operator
 
     assert str(DotProduct(x, y) - 1) == 'dot(x, y) + -1'
     assert str(1 - DotProduct(x, y)) == '-dot(x, y) + 1'

--- a/nengo/spa/tests/test_compare.py
+++ b/nengo/spa/tests/test_compare.py
@@ -32,7 +32,7 @@ def test_run(Simulator, seed):
 
         model.input = spa.Input(compare_A=inputA, compare_B='A')
 
-    compare, vocab = model.get_module_output('compare')
+    compare, _ = model.get_module_output('compare')
 
     with model:
         p = nengo.Probe(compare, 'output', synapse=0.03)

--- a/nengo/spa/tests/test_input.py
+++ b/nengo/spa/tests/test_input.py
@@ -9,8 +9,8 @@ def test_fixed():
         model.buffer2 = spa.Buffer(dimensions=8, subdimensions=2)
         model.input = spa.Input(buffer1='A', buffer2='B')
 
-    input1, vocab1 = model.get_module_input('buffer1')
-    input2, vocab2 = model.get_module_input('buffer2')
+    _, vocab1 = model.get_module_input('buffer1')
+    _, vocab2 = model.get_module_input('buffer2')
 
     assert np.allclose(model.input.input_nodes['buffer1'].output,
                        vocab1.parse('A').v)

--- a/nengo/spa/tests/test_spa.py
+++ b/nengo/spa/tests/test_spa.py
@@ -16,6 +16,7 @@ def test_spa_verification(seed):
         model.buf = spa.Buffer(d)
         model.input_node = spa.Input(buf='B')
         # make sure errors aren't fired for non-spa modules
+        # pylint: disable=unused-variable
         prod = nengo.networks.Product(10, 2)  # noqa: F841
         model.int_val = 1
 

--- a/nengo/spa/tests/test_thalamus.py
+++ b/nengo/spa/tests/test_thalamus.py
@@ -97,8 +97,7 @@ def test_routing(Simulator, seed, plt):
 
         actions = spa.Actions('dot(ctrl, A) --> buff3=buff1',
                               'dot(ctrl, B) --> buff3=buff2',
-                              'dot(ctrl, C) --> buff3=buff1*buff2',
-                              )
+                              'dot(ctrl, C) --> buff3=buff1*buff2',)
         model.bg = spa.BasalGanglia(actions)
         model.thal = spa.Thalamus(model.bg)
 
@@ -169,8 +168,7 @@ def test_nondefault_routing(Simulator, seed):
 
         actions = spa.Actions('dot(ctrl, A) --> cmp_A=buff1, cmp_B=buff1',
                               'dot(ctrl, B) --> cmp_A=buff1, cmp_B=buff2',
-                              'dot(ctrl, C) --> cmp_A=buff2, cmp_B=buff2',
-                              )
+                              'dot(ctrl, C) --> cmp_A=buff2, cmp_B=buff2',)
         model.bg = spa.BasalGanglia(actions)
         model.thal = spa.Thalamus(model.bg)
 

--- a/nengo/spa/thalamus.py
+++ b/nengo/spa/thalamus.py
@@ -78,6 +78,7 @@ class Thalamus(Module):
         self.threshold_gate = threshold_gate
         self.synapse_to_gate = synapse_to_gate
         self.synapse_bg = synapse_bg
+        self.spa = None
 
         self.gates = {}     # gating ensembles per action (created as needed)
         self.channels = {}  # channels to pass transformed data between modules

--- a/nengo/spa/vocab.py
+++ b/nengo/spa/vocab.py
@@ -222,6 +222,7 @@ class Vocabulary(object):
         # implementation, this will automatically create new semantic
         # pointers as needed.
         try:
+            # pylint: disable=eval-used
             value = eval(text, {}, self)
         except NameError:
             raise SpaParseError(

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -224,7 +224,7 @@ def test_signal_slicing(rng):
     a = Signal(x.copy())
     b = Signal(y.copy())
 
-    for i in range(100):
+    for _ in range(100):
         si0, si1 = rng.randint(0, len(slices), size=2)
         s0, s1 = slices[si0], slices[si1]
         assert np.array_equiv(a[s0].initial_value, x[s0])

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -83,7 +83,7 @@ def test_decoder_cache(tmpdir):
 
         solver_args = get_solver_test_args()
         solver_args['gain'] *= 2
-        decoders3, solver_info3 = cache.wrap_solver(solver_mock)(**solver_args)
+        decoders3, _ = cache.wrap_solver(solver_mock)(**solver_args)
         assert SolverMock.n_calls[solver_mock] == 2
         assert np.any(decoders1 != decoders3)
 

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -308,7 +308,7 @@ def test_cache_works(tmpdir, RefSimulator, seed):
 
     assert len(os.listdir(cache_dir)) == 0
     with RefSimulator(model, model=nengo.builder.Model(
-            dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
+        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
         assert len(os.listdir(cache_dir)) == 2  # index, and *.nco
 
 
@@ -321,7 +321,7 @@ def test_cache_not_used_without_seed(tmpdir, RefSimulator):
 
     assert len(os.listdir(cache_dir)) == 0
     with RefSimulator(model, model=nengo.builder.Model(
-            dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
+        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
         assert len(os.listdir(cache_dir)) == 1  # index
 
 
@@ -331,7 +331,7 @@ def build_many_ensembles(cache_dir, RefSimulator):
             nengo.Connection(nengo.Ensemble(10, 1), nengo.Ensemble(10, 1))
 
     with RefSimulator(model, model=nengo.builder.Model(
-            dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
+        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
         pass
 
 

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -307,8 +307,9 @@ def test_cache_works(tmpdir, RefSimulator, seed):
         nengo.Connection(nengo.Ensemble(10, 1), nengo.Ensemble(10, 1))
 
     assert len(os.listdir(cache_dir)) == 0
-    with RefSimulator(model, model=nengo.builder.Model(
-        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
+    sim_model = nengo.builder.Model(
+        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))
+    with RefSimulator(model, model=sim_model):
         assert len(os.listdir(cache_dir)) == 2  # index, and *.nco
 
 
@@ -320,8 +321,9 @@ def test_cache_not_used_without_seed(tmpdir, RefSimulator):
         nengo.Connection(nengo.Ensemble(10, 1), nengo.Ensemble(10, 1))
 
     assert len(os.listdir(cache_dir)) == 0
-    with RefSimulator(model, model=nengo.builder.Model(
-        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
+    sim_model = nengo.builder.Model(
+        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))
+    with RefSimulator(model, model=sim_model):
         assert len(os.listdir(cache_dir)) == 1  # index
 
 
@@ -330,8 +332,9 @@ def build_many_ensembles(cache_dir, RefSimulator):
         for _ in range(100):
             nengo.Connection(nengo.Ensemble(10, 1), nengo.Ensemble(10, 1))
 
-    with RefSimulator(model, model=nengo.builder.Model(
-        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))):
+    sim_model = nengo.builder.Model(
+        dt=0.001, decoder_cache=DecoderCache(cache_dir=cache_dir))
+    with RefSimulator(model, model=sim_model):
         pass
 
 

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -109,7 +109,7 @@ def test_choice(weights, rng):
 
     # check that frequency of choices matches weights
     inds = [tchoices.index(s) for s in tsample]
-    hist, bins = np.histogram(inds, bins=np.linspace(-0.5, N - 0.5, N + 1))
+    hist, _ = np.histogram(inds, bins=np.linspace(-0.5, N - 0.5, N + 1))
     p_empirical = hist / float(hist.sum())
     p = np.ones(N) / N if dist.p is None else dist.p
     sterr = 1. / np.sqrt(n)  # expected maximum standard error

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -37,7 +37,7 @@ too_slow = ['inhibitory_gating',
 all_examples, slow_examples, fast_examples = [], [], []
 
 for subdir, _, files in os.walk(examples_dir):
-    if (os.path.sep + '.') in subdir:
+    if os.path.sep + '.' in subdir:
         continue
     files = [f for f in files if f.endswith('.ipynb')]
     examples = [os.path.join(subdir, os.path.splitext(f)[0]) for f in files]

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -338,7 +338,7 @@ def test_learningrule_attr(seed):
         assert rule.connection is conn and rule.learning_rule_type is rule_type
 
     with nengo.Network(seed=seed):
-        a, b, e = [nengo.Ensemble(10, 2) for i in range(3)]
+        a, b, _ = [nengo.Ensemble(10, 2) for i in range(3)]
         T = np.ones((10, 10))
 
         r1 = PES()

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -304,6 +304,7 @@ def test_dt_dependence(Simulator, nl_nodirect, plt, seed, rng):
     out_data = []
     dts = (0.0001, 0.001)
     colors = ('b', 'g', 'r')
+    dt = None
     for c, dt in zip(colors, dts):
         with Simulator(m, dt=dt, seed=seed+1) as sim:
             sim.run(0.1)

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -28,7 +28,7 @@ def test_lif_builtin(rng):
     reftime = np.zeros_like(J)
 
     spikes = np.zeros((int(t_final / dt),) + J.shape)
-    for i, spikes_i in enumerate(spikes):
+    for spikes_i in spikes:
         lif.step_math(dt, J, spikes_i, voltage, reftime)
 
     math_rates = lif.rates(x, gain, bias)

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -22,7 +22,7 @@ def test_time(Simulator):
 def test_simple(Simulator, plt, seed):
     m = nengo.Network(seed=seed)
     with m:
-        input = nengo.Node(output=lambda t: np.sin(t))
+        input = nengo.Node(output=np.sin)
         p = nengo.Probe(input, 'output')
 
     with Simulator(m) as sim:
@@ -39,7 +39,7 @@ def test_simple(Simulator, plt, seed):
 def test_connected(Simulator, plt, seed):
     m = nengo.Network(seed=seed)
     with m:
-        input = nengo.Node(output=lambda t: np.sin(t), label='input')
+        input = nengo.Node(output=np.sin, label='input')
         output = nengo.Node(output=lambda t, x: np.square(x),
                             size_in=1,
                             label='output')
@@ -67,7 +67,7 @@ def test_connected(Simulator, plt, seed):
 def test_passthrough(Simulator, plt, seed):
     m = nengo.Network(seed=seed)
     with m:
-        in1 = nengo.Node(output=lambda t: np.sin(t))
+        in1 = nengo.Node(output=np.sin)
         in2 = nengo.Node(output=lambda t: t)
         passthrough = nengo.Node(size_in=1)
         out = nengo.Node(output=lambda t, x: x, size_in=1)

--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -33,7 +33,7 @@ def test_multirun(Simulator, rng):
 def test_dts(Simulator, seed, rng):
     """Test probes with different dts and runtimes"""
 
-    for i in range(100):
+    for _ in range(100):
         dt = rng.uniform(0.001, 0.1)  # simulator dt
         dt2 = rng.uniform(dt, 0.15)   # probe dt
         tend = rng.uniform(0.2, 0.3)  # simulator runtime

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -405,7 +405,7 @@ def test_eval_points_static(plt, rng):
 
     rmses_norm1 = rmses - rmses.mean(0, keepdims=True)
     rmses_norm2 = (rmses - rmses.mean(0, keepdims=True)
-                   ) / rmses.std(0, keepdims=True)
+                  ) / rmses.std(0, keepdims=True)
 
     def make_plot(rmses):
         mean = rmses.mean(1)

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -134,7 +134,7 @@ def test_subsolvers(Solver, seed, rng, tol=1e-2):
 
     subsolvers = [lstsq.Conjgrad, lstsq.BlockConjgrad]
     for subsolver in subsolvers:
-        x, info = Solver(solver=subsolver(tol=tol))(A, b, rng=get_rng())
+        x, _ = Solver(solver=subsolver(tol=tol))(A, b, rng=get_rng())
         rel_rmse = rms(x - x0) / rms(x0)
         assert rel_rmse < 4 * tol
         # the above 4 * tol is just a heuristic; the main purpose of this

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -32,7 +32,7 @@ class Factory(object):
     def __str__(self):
         try:
             inst = self()
-        except:
+        except Exception:
             inst = "%s(args=%s, kwargs=%s)" % (
                 self.klass, self.args, self.kwargs)
         return str(inst)
@@ -40,7 +40,7 @@ class Factory(object):
     def __repr__(self):
         try:
             inst = self()
-        except:
+        except Exception:
             inst = "<%r instance>" % (self.klass.__name__)
         return repr(inst)
 

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -86,7 +86,7 @@ def test_linearfilter(Simulator, plt, seed):
     # generated with `scipy.signal.butter(4, 0.2, analog=False)`
     num = np.array(
         [0.00482434, 0.01929737, 0.02894606, 0.01929737, 0.00482434])
-    den = np.array([1., -2.36951301,  2.31398841, -1.05466541,  0.18737949])
+    den = np.array([1., -2.36951301, 2.31398841, -1.05466541, 0.18737949])
 
     synapse = LinearFilter(num, den, analog=False)
     t, x, yhat = run_synapse(Simulator, seed, synapse, dt=dt)

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -1,3 +1,5 @@
+# pylint: disable=unused-import
+
 from __future__ import absolute_import
 
 import collections

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -27,6 +27,7 @@ if PY2:
     itervalues = lambda d: d.itervalues()
 
     # We have to put this in an exec call because it's a syntax error in Py3+
+    # pylint: disable=exec-used
     exec('def reraise(tp, value, tb):\n raise tp, value, tb')
 
     def ensure_bytes(s):

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -1,4 +1,5 @@
-# pylint: disable=unused-import
+# pylint: disable=import-error,unused-import,undefined-variable
+# pylint: disable=ungrouped-imports
 
 from __future__ import absolute_import
 

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -81,7 +81,7 @@ else:
     TextIO = StringIO
     string_types = (str,)
     int_types = (int,)
-    range = range
+    range = range  # pylint: disable=invalid-name
     ResourceWarning = ResourceWarning
 
     # No iterkeys; use ``for key in dict:`` instead
@@ -138,7 +138,7 @@ def with_metaclass(meta, *bases):
     Code snippet from Armin Ronacher:
     http://lucumr.pocoo.org/2013/5/21/porting-to-python-3-redux/
     """
-    class metaclass(meta):
+    class Metaclass(meta):
         __call__ = type.__call__
         __init__ = type.__init__
 
@@ -146,4 +146,4 @@ def with_metaclass(meta, *bases):
             if this_bases is None:
                 return type.__new__(cls, name, (), d)
             return meta(name, bases, d)
-    return metaclass('temporary_class', None, {})
+    return Metaclass('temporary_class', None, {})

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -4,8 +4,8 @@ import warnings
 
 import numpy as np
 
-from . import numpy as npext
-from ..exceptions import ValidationError
+from nengo.utils import numpy as npext
+from nengo.exceptions import ValidationError
 
 
 def target_function(eval_points, targets):

--- a/nengo/utils/docutils.py
+++ b/nengo/utils/docutils.py
@@ -120,7 +120,7 @@ class NotebookDirective(Directive):
         self.state_machine.insert_input([link_rst], rst_file)
 
         # Create notebook node
-        nb_node = notebook_node(
+        nb_node = NotebookNode(
             '', evaluated_html, format='html', source=nb_path)
         nb_node.source, nb_node.line = (
             self.state_machine.get_source_and_line(self.lineno))
@@ -157,7 +157,7 @@ def formatted_link(path, text=None):
     return "`%s <%s>`__" % (text, path)
 
 
-class notebook_node(nodes.raw):
+class NotebookNode(nodes.raw):
     """An evaluated IPython notebook"""
 
 
@@ -178,6 +178,6 @@ def setup(app):
     setup.app = app
     setup.config = app.config
     setup.confdir = app.confdir
-    app.add_node(notebook_node,
+    app.add_node(NotebookNode,
                  html=(visit_notebook_node, depart_notebook_node))
     app.add_directive('notebook', NotebookDirective)

--- a/nengo/utils/ensemble.py
+++ b/nengo/utils/ensemble.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 import numpy as np
 
-from . import numpy as npext
-from .compat import range
+from nengo.utils import numpy as npext
+from nengo.utils.compat import range
 
 
 def tuning_curves(ens, sim, inputs=None):
@@ -50,7 +50,7 @@ def tuning_curves(ens, sim, inputs=None):
         if ens.dimensions > 1:
             inputs = npext.meshgrid_nd(*(ens.dimensions * [inputs]))
         else:
-            inputs = [inputs]
+            inputs = (inputs,)
         inputs = np.asarray(inputs).T
 
     eval_points = inputs.reshape((-1, ens.dimensions))
@@ -185,7 +185,7 @@ def sorted_neurons(ensemble, sim, iterations=100, seed=None):
     indices = np.arange(N)
     rng = np.random.RandomState(seed)
 
-    for k in range(iterations):
+    for _ in range(iterations):
         target = rng.randint(0, N, N)  # pick random swap targets
         for i in range(N):
             j = target[i]

--- a/nengo/utils/filter_design.py
+++ b/nengo/utils/filter_design.py
@@ -43,8 +43,8 @@ import numpy as np
 from numpy import (product, zeros, array, dot, r_, eye,
                    atleast_1d, atleast_2d, poly, roots, asarray, allclose)
 
-from .compat import range
-from .numpy import expm
+from nengo.utils.compat import range
+from nengo.utils.numpy import expm
 
 
 class BadCoefficients(UserWarning):
@@ -265,7 +265,7 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     """
     A, B, C, D = map(_atleast_2d_or_none, (A, B, C, D))
 
-    MA, NA = _shape_or_none(A)
+    MA, _ = _shape_or_none(A)
     MB, NB = _shape_or_none(B)
     MC, NC = _shape_or_none(C)
     MD, ND = _shape_or_none(D)

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -41,7 +41,7 @@ import numpy as np
 
 try:
     import IPython
-    from IPython import get_ipython
+    from IPython import get_ipython  # pylint: disable=unused-import
     from IPython.display import HTML
 
     if IPython.version_info[0] <= 3:
@@ -53,6 +53,7 @@ try:
 
     # nbformat.current deprecated in IPython 3.0
     if IPython.version_info[0] <= 2:
+        # pylint: disable=ungrouped-imports
         from IPython.nbformat import current
         from IPython.nbformat.current import write as write_nb
         from IPython.nbformat.current import NotebookNode
@@ -174,7 +175,7 @@ def export_py(nb, dest_path=None):
     Optionally saves script to dest_path.
     """
     exporter = PythonExporter()
-    body, resources = exporter.from_notebook_node(nb)
+    body, _ = exporter.from_notebook_node(nb)
     # We'll remove %matplotlib inline magic, but leave the rest
     body = body.replace(u"get_ipython().magic(u'matplotlib inline')\n", u"")
     body = body.replace(u"get_ipython().magic('matplotlib inline')\n", u"")
@@ -391,7 +392,7 @@ class NotebookRunner(object):
         for i, cell in enumerate(self.iter_code_cells()):
             try:
                 self.run_cell(cell)
-            except:
+            except Exception:
                 if not skip_exceptions:
                     raise
             if progress_callback is not None:

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -173,6 +173,7 @@ class Conjgrad(LeastSquaresSolver):
         p = r.copy()
         rsold = np.dot(r, r)
 
+        i = -1
         for i in range(maxiters):
             Ap = calcAx(p)
             alpha = rsold / np.dot(p, Ap)
@@ -228,6 +229,7 @@ class BlockConjgrad(LeastSquaresSolver):
         Rsold = np.dot(R.T, R)
         AP = np.zeros((n, d))
 
+        i = -1
         maxiters = int(n / d)
         for i in range(maxiters):
             AP = G(P)

--- a/nengo/utils/magic.py
+++ b/nengo/utils/magic.py
@@ -279,7 +279,7 @@ def callable_decorator(callable_wrapper):
     return wrapper
 
 
-@callable_decorator
+@callable_decorator  # pylint: disable=invalid-name
 class memoize(object):
     """Memoizes a function based on the given arguments."""
 

--- a/nengo/utils/magic.py
+++ b/nengo/utils/magic.py
@@ -83,9 +83,9 @@ class ObjectProxyMeta(type):
     implementation for them in all derived classes.
     """
 
-    def __new__(cls, name, bases, dictionary):
+    def __new__(mcs, name, bases, dictionary):
         dictionary.update(vars(ObjectProxyMethods))
-        return type.__new__(cls, name, bases, dictionary)
+        return type.__new__(mcs, name, bases, dictionary)
 
 
 class ObjectProxy(with_metaclass(ObjectProxyMeta)):
@@ -305,7 +305,7 @@ class DocstringInheritor(type):
     a variation on Paul McGuire's code at
     http://groups.google.com/group/comp.lang.python/msg/26f7b4fcb4d66c95
     '''
-    def __new__(meta, name, bases, clsdict):
+    def __new__(mcs, name, bases, clsdict):
         if not('__doc__' in clsdict and clsdict['__doc__']):
             for mro_cls in (
                     mro_cls for base in bases for mro_cls in base.mro()):
@@ -322,4 +322,4 @@ class DocstringInheritor(type):
                     if doc:
                         attribute.__doc__ = doc
                         break
-        return type.__new__(meta, name, bases, clsdict)
+        return type.__new__(mcs, name, bases, clsdict)

--- a/nengo/utils/neurons.py
+++ b/nengo/utils/neurons.py
@@ -3,8 +3,8 @@ import logging
 
 import numpy as np
 
-from . import numpy as npext
-from ..exceptions import ValidationError
+from nengo.utils import numpy as npext
+from nengo.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,6 @@ def rates_kernel(t, spikes, kind='gauss', tau=0.04):
         raise ValidationError("Last dimension of 'spikes' must equal 'len(t)'",
                               attr='spikes')
 
-    n, nt = spikes.shape
     dt = t[1] - t[0]
 
     tau_i = tau / dt

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -196,7 +196,7 @@ class TerminalProgressBar(ProgressBar):
             self.task, int(100 * progress.progress))
         try:
             width, _ = get_terminal_size()
-        except:
+        except Exception:
             width = 80
         progress_width = max(0, width - len(line))
         progress_str = (
@@ -214,7 +214,7 @@ class TerminalProgressBar(ProgressBar):
     def _get_finished_line(self, progress):
         try:
             width, _ = get_terminal_size()
-        except:
+        except Exception:
             width = 80
         line = "{} finished in {}.".format(
             self.task,
@@ -514,4 +514,4 @@ def wrap_with_progressupdater(task, progress_bar=True):
     else:
         raise ValidationError(
             "must be a boolean or instance of ProgressBar or ProgressUpdater "
-            "(got %r)" % type(progress_bar).__name__,  attr='progress_bar')
+            "(got %r)" % type(progress_bar).__name__, attr='progress_bar')

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -198,7 +198,7 @@ def groupby(objects, key, hashable=None, force_list=True):
 if hasattr(os, 'terminal_size'):
     terminal_size = os.terminal_size
 else:
-    terminal_size = collections.namedtuple(
+    terminal_size = collections.namedtuple(  # pylint: disable=invalid-name
         'terminal_size', ['columns', 'lines'])
 
 

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -115,7 +115,7 @@ def checked_call(func, *args, **kwargs):
     """
     try:
         return CheckedCall(func(*args, **kwargs), True)
-    except:
+    except Exception:
         tb = inspect.trace()
         if not len(tb) or tb[-1][0] is not inspect.currentframe():
             raise  # exception occurred inside func
@@ -210,11 +210,11 @@ else:
         w, h = fallback
         try:
             w = int(os.environ['COLUMNS'])
-        except:
+        except (KeyError, ValueError):
             pass
         try:
             h = int(os.environ['LINES'])
-        except:
+        except (KeyError, ValueError):
             pass
         return terminal_size(w, h)
 

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -141,7 +141,7 @@ def execfile(path, globals, locals=None):
         source = fp.read()
 
     code = compile(source, path, "exec")
-    exec(code, globals, locals)
+    exec(code, globals, locals)  # pylint: disable=exec-used
 
 
 def groupby(objects, key, hashable=None, force_list=True):

--- a/nengo/utils/tests/test_builder.py
+++ b/nengo/utils/tests/test_builder.py
@@ -52,40 +52,40 @@ def test_full_transform():
         conn = nengo.Connection(neurons3[1:], neurons3[::2], transform=-1)
         assert np.all(conn.transform == np.array(-1))
         assert np.all(full_transform(conn) == np.array([[0, -1, 0],
-                                                       [0, 0, 0],
-                                                       [0, 0, -1]]))
+                                                        [0, 0, 0],
+                                                        [0, 0, -1]]))
 
         # Both slices with 2x2 transform -> 3x3 transform
         conn = nengo.Connection(node3[[0, 2]], neurons3[1:],
                                 transform=[[1, 2], [3, 4]])
         assert np.all(conn.transform == np.array([[1, 2], [3, 4]]))
         assert np.all(full_transform(conn) == np.array([[0, 0, 0],
-                                                       [1, 0, 2],
-                                                       [3, 0, 4]]))
+                                                        [1, 0, 2],
+                                                        [3, 0, 4]]))
 
         # Both slices with 2x3 transform -> 3x3 transform... IN REVERSE!
         conn = nengo.Connection(neurons3[::-1], neurons3[[2, 0]],
                                 transform=[[1, 2, 3], [4, 5, 6]])
         assert np.all(conn.transform == np.array([[1, 2, 3], [4, 5, 6]]))
         assert np.all(full_transform(conn) == np.array([[6, 5, 4],
-                                                       [0, 0, 0],
-                                                       [3, 2, 1]]))
+                                                        [0, 0, 0],
+                                                        [3, 2, 1]]))
 
         # Both slices using lists
         conn = nengo.Connection(neurons3[[1, 0, 2]], neurons3[[2, 1]],
                                 transform=[[1, 2, 3], [4, 5, 6]])
         assert np.all(conn.transform == np.array([[1, 2, 3], [4, 5, 6]]))
         assert np.all(full_transform(conn) == np.array([[0, 0, 0],
-                                                       [5, 4, 6],
-                                                       [2, 1, 3]]))
+                                                        [5, 4, 6],
+                                                        [2, 1, 3]]))
 
         # using vector
         conn = nengo.Connection(ens3[[1, 0, 2]], ens3[[2, 0, 1]],
                                 transform=[1, 2, 3])
         assert np.all(conn.transform == np.array([1, 2, 3]))
         assert np.all(full_transform(conn) == np.array([[2, 0, 0],
-                                                       [0, 0, 3],
-                                                       [0, 1, 0]]))
+                                                        [0, 0, 3],
+                                                        [0, 1, 0]]))
 
         # using vector 1D
         conn = nengo.Connection(ens1, ens1, transform=[5])
@@ -97,10 +97,10 @@ def test_full_transform():
                                 transform=[1, 2, 3])
         assert np.all(conn.transform == np.array([1, 2, 3]))
         assert np.all(full_transform(conn) == np.array([[2, 0, 0],
-                                                       [0, 0, 3],
-                                                       [0, 1, 0]]))
+                                                        [0, 0, 3],
+                                                        [0, 1, 0]]))
 
         # using multi-index lists
         conn = nengo.Connection(ens3, ens2[[0, 1, 0]])
         assert np.all(full_transform(conn) == np.array([[1, 0, 1],
-                                                       [0, 1, 0]]))
+                                                        [0, 1, 0]]))

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import numpy as np
-import mpl_toolkits.mplot3d  # noqa: F401
+import mpl_toolkits.mplot3d  # noqa: F401, pylint: disable=unused-import
 import pytest
 
 import nengo

--- a/nengo/utils/tests/test_magic.py
+++ b/nengo/utils/tests/test_magic.py
@@ -183,22 +183,22 @@ def test_class():
         return inst
 
     @test_decorator
-    class f(object):
+    class F(object):
         """Return 1."""
         def __init__(self, a, b):
             self.a = a
             self.b = b
 
-    _test_decorated(f)
-    inst = f('a', 'b')
+    _test_decorated(F)
+    inst = F('a', 'b')
     assert inst.a == 'a' and inst.b == 'b'
     assert inst.ran
-    assert type(inst) == f.__wrapped__
-    assert type(inst) == f.__wrapped__
+    assert type(inst) == F.__wrapped__
+    assert type(inst) == F.__wrapped__
 
     # Make sure introspection works
     # Note: for classes, the decorator isn't part of the source. Weird!
-    assert inspect.getsource(f) == ('    class f(object):\n'
+    assert inspect.getsource(F) == ('    class f(object):\n'
                                     '        """Return 1."""\n'
                                     '        def __init__(self, a, b):\n'
                                     '            self.a = a\n'

--- a/nengo/utils/tests/test_magic.py
+++ b/nengo/utils/tests/test_magic.py
@@ -16,7 +16,7 @@ def _test_decorated(obj):
     state = 'not run'
 
     # Make sure decorated function looks like non-decorated
-    assert obj.__name__ == 'f'
+    assert obj.__name__.lower() == 'f'
     assert obj.__doc__ == "Return 1."
 
 
@@ -199,7 +199,7 @@ def test_class():
 
     # Make sure introspection works
     # Note: for classes, the decorator isn't part of the source. Weird!
-    assert inspect.getsource(F) == ('    class f(object):\n'
+    assert inspect.getsource(F) == ('    class F(object):\n'
                                     '        """Return 1."""\n'
                                     '        def __init__(self, a, b):\n'
                                     '            self.a = a\n'

--- a/nengo/utils/tests/test_magic.py
+++ b/nengo/utils/tests/test_magic.py
@@ -2,6 +2,7 @@ import inspect
 
 from nengo.utils.magic import decorator, memoize
 
+# pylint: disable=global-statement
 state = None  # Used to make sure decorators are running
 
 

--- a/nengo/utils/tests/test_probe.py
+++ b/nengo/utils/tests/test_probe.py
@@ -23,21 +23,21 @@ def test_probe_all_recursive(recursive):
     # test top level probing
     total_number_probes1 = len(
         ens1.probeable) + len(node1.probeable) + len(conn.probeable)
-    assert(len(model.probes) == total_number_probes1)
+    assert len(model.probes) == total_number_probes1
 
     # test dictionary
-    assert(len(probes[ens1]) == len(ens1.probeable))
-    assert(len(probes[node1]) == len(node1.probeable))
-    assert(len(probes[conn]) == len(conn.probeable))
+    assert len(probes[ens1]) == len(ens1.probeable)
+    assert len(probes[node1]) == len(node1.probeable)
+    assert len(probes[conn]) == len(conn.probeable)
 
     # test recursive probing
     if recursive:
         total_number_probes2 = len(ens2.probeable) + len(node2.probeable)
-        assert(len(subnet.probes) == total_number_probes2)
-        assert(len(probes[ens2]) == len(ens2.probeable))
-        assert(len(probes[node2]) == len(node2.probeable))
+        assert len(subnet.probes) == total_number_probes2
+        assert len(probes[ens2]) == len(ens2.probeable)
+        assert len(probes[node2]) == len(node2.probeable)
     else:
-        assert(len(subnet.probes) == 0)
+        assert len(subnet.probes) == 0
         assert ens2 not in probes
 
 
@@ -57,8 +57,8 @@ def test_probe_all_options():
         nengo.Ensemble: ['decoded_output']})
 
     # only probes spikes and decoded output of the ensembles
-    assert(len(model.probes) == 1)
-    assert(len(subnet.probes) == 1)
+    assert len(model.probes) == 1
+    assert len(subnet.probes) == 1
 
 
 def test_probe_all_kwargs():

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -39,7 +39,7 @@ class TestProgress(object):
         try:
             with Progress(10) as p2:
                 raise Exception()
-        except:
+        except Exception:
             pass
         assert not p2.success
 

--- a/nengo/utils/tests/test_stdlib.py
+++ b/nengo/utils/tests/test_stdlib.py
@@ -222,4 +222,4 @@ def test_weakkeydict_frees_values():
     assert sys.getrefcount(weak_v()) > 1  # function argument might make it > 1
     del k
     v = weak_v()
-    assert v is None,  "Value in WeakKeyIDDictionary not garbage collected."
+    assert v is None, "Value in WeakKeyIDDictionary not garbage collected."

--- a/nengo/utils/tests/test_stdlib.py
+++ b/nengo/utils/tests/test_stdlib.py
@@ -105,7 +105,7 @@ def test_groupby(hashable, force_list, rng):
 
 def test_timer():
     with Timer() as timer:
-        for i in range(1000):
+        for _ in range(1000):
             2 + 2
     assert timer.duration > 0.0
     assert timer.duration < 1.0  # Pretty bad worst case


### PR DESCRIPTION
**Motivation and context:**
`pylint` can provide a number of useful warnings about problems in Python code. We already use it to check for missed super-constructor calls, but we should use it to check other things to. However, it also has a number of less useful warnings or disagrees with some of our code style, so it requires some configuration to be useful.

In this PR, I first enabled all warnings and then selectively disable warnings, locally disable warnings or fix the issue in the code. With some warnings it is not obvious if we want to keep them or not, so we can discuss this here.

List of questions (more might follow):
1. `unused-argument`: Do we want a warning about unused function arguments? There are bugs where one forgets to actually use a function argument, but a lot of times it is correctly unused (e.g. in interface classes) which requires to add disable comments to the affected functions. I have a slight tendency towards disabling the check.
2. `redefined-outer-name`: Sometimes we use variable names in functions (or function argument names) that are the same as a global name. This is somewhat bad practice as it makes the global name unaccessible and might cause confusion what is referred to. But sometimes this requires to change one of the the two variable names to something which is less intuitive or awkward to type and might not clear up the confusion. I have a slight tendencey towards disabling this check.
3. `no-self-use`: pylint warns when a instance method does not use `self` and could be written as `@classmethod` or `@staticmethod`. But for interfaces etc. this warning is sometimes wrong because the method is intended to be overwritten. I have a slight tendency to leave this check enabled and use comments to disable it locally where appropriate.
4. `redefined-variable-type` warns about when the type of a variable changes. This seems to me like a really good warning to have, but unfortunately all instances of it that I checked where false positives. pylint seems to get really easily confused if different classes from the same inheritance hierarchy are used in different branches of if-statements (supposedly a fixed issue, but apparently it is not). Because of that, I would vote for disabling the warning.
5. `too-many-branches` is a warning about the complexity of functions. I'm undecided on this one. It is good to provide some push for keeping functions simple enough, but sometimes nothing is won by splitting it up to get rid of such a warning. Maybe this decision when a function gets to complex is better left to the author and reviewers of the code.
6. `unused-imports` and maximum line length are checked by both pylint and pep8. Should both tools check it or just one? If both check it, incorrect warnings for individual lines have to be disabled for both tools, so I would vote for only one tool. I prefer pylint, because the line based disabling is more human readable (`pylint: disable=unused-import` vs. `noqa: F401`) and pylint supports a regex for lines that are allowed to exceed the maximum length (then long URL do not need to be prefixed with noqa).
7. `unexpected-keyword-arg`: Has some false positives in some tests because the `add_to_container` argument gets handled in the `__new__` of a metaclass. I'm leaning towards locally disabling the warning for these false positives.
8. `undefined-loop-variable` seems useful because it prevents usage of a loop variable that might be unitialized because no iterations of the loop where executed, but there is a number of false positives in our code where the code path after the for is only executed when an iteration has been executed or the number of iterations is known in advance. The warning is easily fixed by assigning a default value before the loop and in some cases this is the right thing to do, but in others it's just a bit of added noise and does not make the code any more correct.

Please comment if you have any opinions on those points.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
todo

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

todo
- Quick (less than 40 lines changed or changes are straightforward)
- Average (neither quick nor lengthy)
- Lengthy (more than 150 lines changed or changes are complicated)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->
todo

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

todo
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that causes existing functionality to change)
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you stil plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

#### Discuss

- [ ] `redefined-builtin`

#### Separate PRs

- [x] `bad-super-call`
- [x] `dangerous-default-value`
- [x] `cyclic-import`
- [x] `deprecated-method`
- [x] `function-redefined`
- [ ] `unidiomatic-typecheck`
- [ ] `arguments-differ`
- [x] `cell-var-from-loop`
- [x] `signature-differs`
- [ ] `too-many-return-statements`
- [ ] `locally-disabled`
- [ ] `too-many-statements`
- [ ] `fixme`
- [ ] `duplicate-code`

#### Separate PRs cherry-picked from this PR
- [x] `anomalous-backslash-in-string`
- [x] `unused-import`
- [x] `bare-except`
- [x] `ungrouped-imports`
- [x] `import-error`
- [x] `reimported`
- [x] `wrong-import-order`
- [x] `bad-mcs-classmethod-argument`
- [x] `unnecessary-lambda`
- [x] `bad-whitespace`

#### This PR

- [x] `expression-not-assigned`
- [x] `nonexistent-operator`
- [x] `global-statement`
- [x] `undefined-loop-variable`
- [x] `undefined-variable`
- [x] `attribute-defined-outside-init`
- [x] `superfluous-parens`
- [x] `unused-variable`
- [x] `bad-continuation`
- [x] `no-member`
- [x] `pointless-statement`
- [x] `invalid-name`
- [ ] Get the number of pylint warnings to 0.

#### Single warning false positives
- [ ] `invalid-sequence-index`
- [ ] `not-callable`

#### Disable list
- [x] `eval-used`
- [x] `exec-used`
- [ ] `unused-argument`
- [ ] `redefined-outer-name`
- [ ] `no-self-use`
- [ ] `redefined-variable-type`
- [ ] `unexpected-keyword-arg`
- [ ] `undefined-loop-variable`
  