### PR TITLE
Make order of seed generation explicit.

### DIFF
--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -5,7 +5,11 @@ import numpy as np
 
 import nengo.utils.numpy as npext
 from nengo.builder import Builder
+from nengo.connection import Connection
+from nengo.ensemble import Ensemble
 from nengo.network import Network
+from nengo.node import Node
+from nengo.probe import Probe
 from nengo.utils.progress import ProgressTracker
 
 logger = logging.getLogger(__name__)
@@ -75,7 +79,9 @@ def build_network(model, network, progress_bar=False):
 
     # assign seeds to children
     rng = np.random.RandomState(model.seeds[network])
-    sorted_types = sorted(network.objects, key=lambda t: t.__name__)
+    # Put probes last so that they don't influence other seeds
+    sorted_types = (Connection, Ensemble, Network, Node, Probe)
+    assert all(tp in sorted_types for tp in network.objects)
     for obj_type in sorted_types:
         for obj in network.objects[obj_type]:
             model.seeded[obj] = (model.seeded[network] or


### PR DESCRIPTION
**Motivation and context:**

This makes it clear that Probe seeds should be generated last to not influence the model when adding probes for debugging. Also seed generation order will not randomly change when adding new types of Nengo objects (if that ever were to happen), but an explicit dicision has to be made.

There's an assert statement in there to make sure, we're not forgetting to set the seeds for any object.

Closes #1260.

**Interactions with other PRs:**
none

**How has this been tested?**
unit tests still pass

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- code style

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you stil plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
