### PR TITLE
Give better error for non-finite values from nodes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ Release History
 
 **Changed**
 
+- We now raise an error when a ``Node`` or ``Direct`` ensemble
+  produces a non-finite value.
+  (`#1178 <https://github.com/nengo/nengo/issues/1178>`_,
+  `#1280 <https://github.com/nengo/nengo/issues/1280>`_,
+  `#1286 <https://github.com/nengo/nengo/pull/1286>`_)
 - We now enforce that the ``label`` of a network must be a string or ``None``,
   and that the ``seed`` of a network must be an int or ``None``.
   This helps avoid situations where the seed would mistakenly

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -625,9 +625,11 @@ class SimPyFunc(Operator):
             args = (np.copy(x),) if x is not None else ()
             y = fn(t.item(), *args) if t is not None else fn(*args)
             if output is not None:
-                if y is None:  # required since Numpy turns None into NaN
+                # required since Numpy turns None into NaN
+                if y is None or not np.all(np.isfinite(y)):
                     raise SimulationError(
-                        "Function %r returned None" % function_name(self.fn))
+                        "Function %r returned non-finite value" %
+                        function_name(self.fn))
                 try:
                     output[...] = y
                 except ValueError:

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -44,6 +44,9 @@ class OutputParam(Parameter):
             output = npext.array(
                 output, min_dims=1, copy=False, dtype=np.float64)
             self.validate_ndarray(node, output)
+            if not np.all(np.isfinite(output)):
+                raise ValidationError("Output value must be finite.",
+                                      attr=self.name, obj=node)
             node.size_out = output.size
         else:
             raise ValidationError("Invalid node output type %r" %

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 import nengo
-from nengo.neurons import NeuronTypeParam
+from nengo.exceptions import SimulationError
+from nengo.neurons import Direct, NeuronTypeParam
 from nengo.processes import WhiteSignal
 from nengo.solvers import LstsqL2nz
 from nengo.utils.ensemble import tuning_curves
@@ -390,3 +391,14 @@ def test_frozen():
         a.tau_rc = 0.3
     with pytest.raises(ValueError):
         d.coupling = 8
+
+
+def test_direct_mode_nonfinite_value(Simulator):
+    with nengo.Network() as model:
+        e1 = nengo.Ensemble(10, 1, neuron_type=Direct())
+        e2 = nengo.Ensemble(10, 1)
+        nengo.Connection(e1, e2, function=lambda x: 1. / x)
+
+    with Simulator(model) as sim:
+        with pytest.raises(SimulationError):
+            sim.run(0.01)

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -379,3 +379,31 @@ def test_node_with_unusual_strided_view(Simulator, seed):
 
     with Simulator(model):
         pass
+
+
+def test_non_finite_values(Simulator):
+    with nengo.Network() as model:
+        with pytest.raises(ValidationError):
+            node = nengo.Node(np.inf)
+
+    with nengo.Network() as model:
+        with pytest.raises(ValidationError):
+            node = nengo.Node(np.nan)
+
+    with nengo.Network() as model:
+        node = nengo.Node(lambda t: np.inf)
+        ens = nengo.Ensemble(10, 1)
+        nengo.Connection(node, ens)
+
+    with Simulator(model) as sim:
+        with pytest.raises(SimulationError):
+            sim.run(0.01)
+
+    with nengo.Network() as model:
+        node = nengo.Node(lambda t: np.nan)
+        ens = nengo.Ensemble(10, 1)
+        nengo.Connection(node, ens)
+
+    with Simulator(model) as sim:
+        with pytest.raises(SimulationError):
+            sim.run(0.01)


### PR DESCRIPTION
**Motivation and context:**
This produces a slightly better error message when a node or direct mode ensemble produces non-finite values. By raising a `SimulationError` we make it clear that this is a problem that has to be solved on the user side and not some bug in the simulator (before one would get a FloatingPointError). The error message contains the name of the function (which might be `<lambda>` which is not that helpful, but definitely better than before if it is not a lambda).

I think for nodes it is correct to produce an error. In case of the direct mode ensemble with the function it would be nice if it would still run because it would run with non-direct mode ensembles. But to me it seems there is no logical value to set the result to and by not throwing an error it might seem like it works as intended, but does not. Like the Zen of Python says: “In the face of ambiguity, refuse the temptation to guess.”

I think we talked before about potentially implementing some sort of approximation of the neuron normalization in direct mode. This might solve this problem fully, but is also a much bigger jobs with some open questions.

Fixes #1280. Closes #1178.

**Interactions with other PRs:**
none

**How has this been tested?**
added tests

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.