### PR TITLE
Add function to inhibit complete networks.

### DIFF
--- a/nengo/utils/network.py
+++ b/nengo/utils/network.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import nengo
 from .magic import decorator
 
@@ -61,3 +63,28 @@ def activate_direct_mode(network):
     for e in network.all_ensembles:
         if e not in requires_neurons:
             e.neuron_type = nengo.Direct()
+
+
+def inhibit_net(pre, post, strength=2., **kwargs):
+    """Makes an inhibitory connection to all ensembles of a network.
+
+    Parameters
+    ----------
+    pre : 1-d nengo.Node or nengo.Ensemble
+        Scalar source of the inhibition.
+    post : nengo.Network
+        Target of the inhibition.
+    strength : float
+        Strength of the inhibition.
+    kwargs : dict
+        Additional keyword arguments for the created connections.
+
+    Returns
+    -------
+    list
+        Created connections.
+    """
+
+    return [nengo.Connection(
+        pre, e.neurons, transform=-strength * np.ones((e.n_neurons, 1)),
+        **kwargs) for e in post.all_ensembles]

--- a/nengo/utils/network.py
+++ b/nengo/utils/network.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import numpy as np
 
 import nengo


### PR DESCRIPTION
**Motivation and context:**
I commonly want to inhibit complete networks (especially ensemble arrays and SPA states). This function simplifies that and give a more general solution to the `inhibt` option that was implemented for the associative memory networks, but is removed in PR #1253.

**Interactions with other PRs:**
Somewhat related to #1253 which removes the `inhibit` option from associative networks, but no real interaction.

**How has this been tested?**
Added a test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
