### PR TITLE
Use pylint to check for unused imports.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,6 +5,7 @@ enable = anomalous-backslash-in-string,
          bad-super-call,
          dangerous-default-value,
          super-init-not-called,
+         unused-import,
 
 
 [REPORTS]

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -97,6 +97,10 @@ else:
         assert isinstance(s, bytes)
         return s
 
+assert pickle
+assert configparser
+assert replace
+
 
 def is_integer(obj):
     return isinstance(obj, int_types + (np.integer,))

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -75,6 +75,7 @@ try:
 except ImportError:
     def get_ipython():
         return None
+assert get_ipython
 
 
 def has_ipynb_widgets():

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import numpy as np
-import mpl_toolkits.mplot3d  # noqa: F401
+import mpl_toolkits.mplot3d
 import pytest
 
 import nengo
@@ -13,6 +13,7 @@ def plot_tuning_curves(plt, eval_points, activities):
     if eval_points.ndim <= 2:
         plt.plot(eval_points, activities)
     elif eval_points.ndim == 3:
+        assert mpl_toolkits.mplot3d
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='3d')
         ax.plot_surface(eval_points.T[0], eval_points.T[1], activities.T[0])

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ ignore =
 
 [flake8]
 exclude = __init__.py, compat.py
-ignore = E123,E133,E226,E241,E242,E731,W503
+# F401 is checked by pylint
+ignore = E123,E133,E226,E241,E242,E731,F401,W503
 max-complexity = 10
 
 [upload_docs]


### PR DESCRIPTION
**Motivation and context:**
Instead of flake8 because flake8 misses some unused imports and
the by line disabling of the warning is less cryptic for pylint.
(Who knows what the error code F401 stands for from the top of their
head? Who knows the meaning of noqa? Apparently, it stands for “no
quality insurance”.)

**Interactions with other PRs:**
none

**How has this been tested?**
pylint produced not warnings, tests still pass

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
