### PR TITLE
Fix bare excepts reported by pylint.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,8 +1,9 @@
 [MESSAGES CONTROL]
 
-disable = all
+disable = all, broad-except
 enable = anomalous-backslash-in-string,
          bad-super-call,
+         bare-except,
          dangerous-default-value,
          super-init-not-called,
          unused-import,

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -300,7 +300,9 @@ class CacheIndex(object):
             with open(self.legacy_path, 'r') as lf:
                 text = lf.read()
             return tuple(int(x.strip()) for x in text.split('.'))
-        except:
+        except Exception:
+            logger.exception(
+                "Decoder cache version information could not be read.")
             return (-1, -1)
 
 
@@ -355,7 +357,9 @@ class WriteableCacheIndex(CacheIndex):
         with self._lock:
             try:
                 self._load_index_file()
-            except:
+            except Exception:
+                logger.exception(
+                    "Decoder cache index corrupted. Reinitializing cache.")
                 # If we can't load the index file, the cache is corrupted,
                 # so we invalidate it (delete all files in the cache)
                 self._reinit()
@@ -675,8 +679,11 @@ class DecoderCache(object):
                 with open(path, 'rb') as f:
                     f.seek(start)
                     info, decoders = nco.read(f)
-            except:
-                logger.debug("Cache miss [%s].", key)
+            except Exception as err:
+                if isinstance(err, KeyError):
+                    logger.debug("Cache miss [%s].", key)
+                else:
+                    logger.exception("Corrupted cache entry [%s].", key)
                 decoders, info = solver_fn(conn, gain, bias, x, targets,
                                            rng=rng, E=E, **uncached_kwargs)
                 if not self.readonly:

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -32,7 +32,7 @@ class Factory(object):
     def __str__(self):
         try:
             inst = self()
-        except:
+        except Exception:
             inst = "%s(args=%s, kwargs=%s)" % (
                 self.klass, self.args, self.kwargs)
         return str(inst)
@@ -40,7 +40,7 @@ class Factory(object):
     def __repr__(self):
         try:
             inst = self()
-        except:
+        except Exception:
             inst = "<%r instance>" % (self.klass.__name__)
         return repr(inst)
 

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -396,7 +396,7 @@ class NotebookRunner(object):
         for i, cell in enumerate(self.iter_code_cells()):
             try:
                 self.run_cell(cell)
-            except:
+            except Exception:
                 if not skip_exceptions:
                     raise
             if progress_callback is not None:

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -194,10 +194,7 @@ class TerminalProgressBar(ProgressBar):
             eta=timestamp2timedelta(progress.eta()))
         percent_str = " {}... {}% ".format(
             self.task, int(100 * progress.progress))
-        try:
-            width, _ = get_terminal_size()
-        except:
-            width = 80
+        width, _ = get_terminal_size()
         progress_width = max(0, width - len(line))
         progress_str = (
             int(progress_width * progress.progress) * "#").ljust(
@@ -212,10 +209,7 @@ class TerminalProgressBar(ProgressBar):
         return '\r' + line.format(progress_str)
 
     def _get_finished_line(self, progress):
-        try:
-            width, _ = get_terminal_size()
-        except:
-            width = 80
+        width, _ = get_terminal_size()
         line = "{} finished in {}.".format(
             self.task,
             timestamp2timedelta(progress.elapsed_seconds())).ljust(width)

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -171,7 +171,7 @@ def checked_call(func, *args, **kwargs):
     """
     try:
         return CheckedCall(func(*args, **kwargs), True)
-    except:
+    except Exception:
         tb = inspect.trace()
         if not len(tb) or tb[-1][0] is not inspect.currentframe():
             raise  # exception occurred inside func
@@ -260,17 +260,21 @@ else:
 
 # get_terminal_size was introduced in Python 3.3
 if hasattr(shutil, 'get_terminal_size'):
-    get_terminal_size = shutil.get_terminal_size
+    def get_terminal_size(fallback=(80, 24)):
+        try:
+            return shutil.get_terminal_size(fallback)
+        except Exception:
+            return terminal_size(fallback)
 else:
     def get_terminal_size(fallback=(80, 24)):
         w, h = fallback
         try:
             w = int(os.environ['COLUMNS'])
-        except:
+        except (KeyError, ValueError):
             pass
         try:
             h = int(os.environ['LINES'])
-        except:
+        except (KeyError, ValueError):
             pass
         return terminal_size(w, h)
 

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -472,7 +472,7 @@ class ThreadedAssertion(object):
             try:
                 self.parent.assert_thread(self)
                 self.assertion_result = True
-            except:
+            except Exception:
                 self.assertion_result = False
                 self.exc_info = sys.exc_info()
             finally:

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -39,7 +39,7 @@ class TestProgress(object):
         try:
             with Progress(10) as p2:
                 raise Exception()
-        except:
+        except Exception:
             pass
         assert not p2.success
 


### PR DESCRIPTION
**Motivation and context:**
A bare except also catches exceptions like SystemExit and KeyboardInterrupt
that should only handled in the outer most exception handler if at all.
Otherwise Ctrl-C might not work to exit a Python program as expected if it
happened to be pressed while in a bare exception handler. In most places,
I changed it to catch Exception which is pretty general, but seems to be ok
to me in those cases where an exception should never lead to Nengo exiting.
Within the cache I added logging statements to provide a bit more debugging
information because those exception can indicate problems, but are not
a failure we cannot recover from (and we should recover from it).

I explicitly disabled the broad-except warning because we have quite a number
where it seems acceptable to catch broadly. I hope that disallowing broad
excepts and thus forcing to specify exception types, everyone will think about
whether `Exception` is appropriate or a more narrow scope would be better.

**Interactions with other PRs:**
none

**How has this been tested?**
tests still pass

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
