### PR TITLE
Add standardized network inputs and outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,14 @@ Release History
   (`#1184 <https://github.com/nengo/nengo/issues/1184>`_,
   `#1185 <https://github.com/nengo/nengo/pull/1185>`_)
 
+**Deprecated**
+
+- The ``net`` argument to networks has been deprecated. This argument existed
+  so that network components could be added to an existing network instead of
+  constructing a new network. However, this feature is rarely used,
+  and makes the code more complicated for complex networks.
+  (`#1296 <https://github.com/nengo/nengo/pull/1296>`_)
+
 2.3.1 (February 18, 2017)
 =========================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,11 @@ Release History
   has changed to 2.5 ms (from 2 ms) for better compatibility with the
   default maximum firing rates of 200-400 Hz.
   (`#1248 <https://github.com/nengo/nengo/pull/1248>`_)
+- Inputs to the ``Product`` and ``CircularConvolution`` networks have been
+  renamed from ``A`` and ``B`` to ``input_a`` and ``input_b`` for consistency.
+  The old names are still available, but should be considered deprecated.
+  (`#887 <https://github.com/nengo/nengo/issues/887>`_,
+  `#1296 <https://github.com/nengo/nengo/pull/1296>`_)
 
 **Fixed**
 

--- a/examples/spa/convolution.ipynb
+++ b/examples/spa/convolution.ipynb
@@ -87,8 +87,8 @@
       "    cconv = nengo.networks.CircularConvolution(200, dimensions=dimensions)\n",
       "\n",
       "    # Connect the input nodes to the input slots `A` and `B` on the network\n",
-      "    nengo.Connection(a, cconv.A)\n",
-      "    nengo.Connection(b, cconv.B)\n",
+      "    nengo.Connection(a, cconv.input_a)\n",
+      "    nengo.Connection(b, cconv.input_b)\n",
       "\n",
       "    # Probe the output\n",
       "    out = nengo.Probe(cconv.output, synapse=0.03)"

--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 import nengo
@@ -89,7 +91,7 @@ def dft_half(n):
 
 
 def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
-                        input_magnitude=1.0, net=None):
+                        input_magnitude=1.0, net=None, **kwargs):
     r"""Compute the circular convolution of two vectors.
 
     The circular convolution :math:`c` of vectors :math:`a` and :math:`b`
@@ -122,10 +124,8 @@ def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
         The expected magnitude of the vectors to be convolved.
         This value is used to determine the radius of the ensembles
         computing the element-wise product.
-    net : Network, optional (Default: None)
-        A network in which the network components will be built.
-        This is typically used to provide a custom set of Nengo object
-        defaults through modifying ``net.config``.
+    kwargs
+        Keyword arguments passed through to ``nengo.Network``.
 
     Returns
     -------
@@ -186,7 +186,10 @@ def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
     is analytically zero.
     """
     if net is None:
-        net = nengo.Network("Circular Convolution")
+        kwargs.setdefault('label', "Circular Convolution")
+        net = nengo.Network(**kwargs)
+    else:
+        warnings.warn("The 'net' argument is deprecated.", DeprecationWarning)
 
     tr_a = transform_in(dimensions, 'A', invert_a)
     tr_b = transform_in(dimensions, 'B', invert_b)

--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -134,9 +134,9 @@ def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
 
     Attributes
     ----------
-    net.A : Node
+    net.input_a : Node
         The first vector to be convolved.
-    net.B : Node
+    net.input_b : Node
         The second vector to be convolved.
     net.product : Network
         Network created with `.Product` to do the element-wise product
@@ -154,8 +154,8 @@ def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
         B = EnsembleArray(50, n_ensembles=10)
         C = EnsembleArray(50, n_ensembles=10)
         cconv = nengo.networks.CircularConvolution(50, dimensions=10)
-        nengo.Connection(A.output, cconv.A)
-        nengo.Connection(B.output, cconv.B)
+        nengo.Connection(A.output, cconv.input_a)
+        nengo.Connection(B.output, cconv.input_b)
         nengo.Connection(cconv.output, C.input)
 
     Notes
@@ -193,15 +193,17 @@ def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
     tr_out = transform_out(dimensions)
 
     with net:
-        net.A = nengo.Node(size_in=dimensions, label="A")
-        net.B = nengo.Node(size_in=dimensions, label="B")
+        net.input_a = net.A = nengo.Node(size_in=dimensions, label="input_a")
+        net.input_b = net.B = nengo.Node(size_in=dimensions, label="input_b")
         net.product = Product(n_neurons, tr_out.shape[1],
                               input_magnitude=input_magnitude * 2)
         net.output = nengo.Node(size_in=dimensions, label="output")
 
-        nengo.Connection(net.A, net.product.A, transform=tr_a, synapse=None)
-        nengo.Connection(net.B, net.product.B, transform=tr_b, synapse=None)
-        nengo.Connection(net.product.output, net.output,
-                         transform=tr_out, synapse=None)
+        nengo.Connection(
+            net.input_a, net.product.input_a, transform=tr_a, synapse=None)
+        nengo.Connection(
+            net.input_b, net.product.input_b, transform=tr_b, synapse=None)
+        nengo.Connection(
+            net.product.output, net.output, transform=tr_out, synapse=None)
 
     return net

--- a/nengo/networks/integrator.py
+++ b/nengo/networks/integrator.py
@@ -1,7 +1,9 @@
+import warnings
+
 import nengo
 
 
-def Integrator(recurrent_tau, n_neurons, dimensions, net=None):
+def Integrator(recurrent_tau, n_neurons, dimensions, net=None, **kwargs):
     """An ensemble that accumulates input and maintains state.
 
     This is accomplished through scaling the input signal and recurrently
@@ -15,11 +17,8 @@ def Integrator(recurrent_tau, n_neurons, dimensions, net=None):
         Number of neurons in the recurrently connected ensemble.
     dimensions : int
         Dimensionality of the input signal and ensemble.
-
-    net : Network, optional (Default: None)
-        A network in which the network components will be built.
-        This is typically used to provide a custom set of Nengo object
-        defaults through modifying ``net.config``.
+    kwargs
+        Keyword arguments passed through to ``nengo.Network``.
 
     Returns
     -------
@@ -34,7 +33,11 @@ def Integrator(recurrent_tau, n_neurons, dimensions, net=None):
         Provides the input signal.
     """
     if net is None:
-        net = nengo.Network(label="Integrator")
+        kwargs.setdefault('label', "Integrator")
+        net = nengo.Network(**kwargs)
+    else:
+        warnings.warn("The 'net' argument is deprecated.", DeprecationWarning)
+
     with net:
         net.input = nengo.Node(size_in=dimensions)
         net.ensemble = nengo.Ensemble(n_neurons, dimensions=dimensions)

--- a/nengo/networks/integrator.py
+++ b/nengo/networks/integrator.py
@@ -41,4 +41,5 @@ def Integrator(recurrent_tau, n_neurons, dimensions, net=None):
         nengo.Connection(net.ensemble, net.ensemble, synapse=recurrent_tau)
         nengo.Connection(net.input, net.ensemble,
                          transform=recurrent_tau, synapse=None)
+    net.output = net.ensemble
     return net

--- a/nengo/networks/oscillator.py
+++ b/nengo/networks/oscillator.py
@@ -1,7 +1,9 @@
+import warnings
+
 import nengo
 
 
-def Oscillator(recurrent_tau, frequency, n_neurons, net=None):
+def Oscillator(recurrent_tau, frequency, n_neurons, net=None, **kwargs):
     """A two-dimensional ensemble with interacting recurrent connections.
 
     The ensemble connects to itself in a manner similar to the integrator;
@@ -16,11 +18,8 @@ def Oscillator(recurrent_tau, frequency, n_neurons, net=None):
         Desired frequency, in Hz, of the cyclic oscillation.
     n_neurons : int
         Number of neurons in the recurrently connected ensemble.
-
-    net : Network, optional (Default: None)
-        A network in which the network components will be built.
-        This is typically used to provide a custom set of Nengo object
-        defaults through modifying ``net.config``.
+    kwargs
+        Keyword arguments passed through to ``nengo.Network``.
 
     Returns
     -------
@@ -35,7 +34,11 @@ def Oscillator(recurrent_tau, frequency, n_neurons, net=None):
         Provides the input signal.
     """
     if net is None:
-        net = nengo.Network(label="Oscillator")
+        kwargs.setdefault('label', "Oscillator")
+        net = nengo.Network(**kwargs)
+    else:
+        warnings.warn("The 'net' argument is deprecated.", DeprecationWarning)
+
     with net:
         net.input = nengo.Node(label="In", size_in=2)
         net.ensemble = nengo.Ensemble(

--- a/nengo/networks/oscillator.py
+++ b/nengo/networks/oscillator.py
@@ -45,4 +45,5 @@ def Oscillator(recurrent_tau, frequency, n_neurons, net=None):
         nengo.Connection(net.ensemble, net.ensemble,
                          synapse=recurrent_tau, transform=tA)
         nengo.Connection(net.input, net.ensemble, synapse=None)
+    net.output = net.ensemble
     return net

--- a/nengo/networks/product.py
+++ b/nengo/networks/product.py
@@ -1,10 +1,12 @@
+import warnings
+
 import numpy as np
 
 import nengo
 from nengo.networks.ensemblearray import EnsembleArray
 
 
-def Product(n_neurons, dimensions, input_magnitude=1., net=None):
+def Product(n_neurons, dimensions, input_magnitude=1., net=None, **kwargs):
     """Computes the element-wise product of two equally sized vectors.
 
     The network used to calculate the product is described in
@@ -31,10 +33,8 @@ def Product(n_neurons, dimensions, input_magnitude=1., net=None):
         The expected magnitude of the vectors to be multiplied.
         This value is used to determine the radius of the ensembles
         computing the element-wise product.
-    net : Network, optional (Default: None)
-        A network in which the network components will be built.
-        This is typically used to provide a custom set of Nengo object
-        defaults through modifying ``net.config``.
+    kwargs
+        Keyword arguments passed through to ``nengo.Network``.
 
     Returns
     -------
@@ -55,7 +55,10 @@ def Product(n_neurons, dimensions, input_magnitude=1., net=None):
         Represents the second squared term. See `Gosmann, 2015`_ for details.
     """
     if net is None:
-        net = nengo.Network(label="Product")
+        kwargs.setdefault('label', "Product")
+        net = nengo.Network(**kwargs)
+    else:
+        warnings.warn("The 'net' argument is deprecated.", DeprecationWarning)
 
     with net:
         net.input_a = net.A = nengo.Node(size_in=dimensions, label="input_a")

--- a/nengo/networks/product.py
+++ b/nengo/networks/product.py
@@ -43,9 +43,9 @@ def Product(n_neurons, dimensions, input_magnitude=1., net=None):
 
     Attributes
     ----------
-    net.A : Node
+    net.input_a : Node
         The first vector to be multiplied.
-    net.B : Node
+    net.input_b : Node
         The second vector to be multiplied.
     net.output : Node
         The resulting product.
@@ -58,8 +58,8 @@ def Product(n_neurons, dimensions, input_magnitude=1., net=None):
         net = nengo.Network(label="Product")
 
     with net:
-        net.A = nengo.Node(size_in=dimensions, label="A")
-        net.B = nengo.Node(size_in=dimensions, label="B")
+        net.input_a = net.A = nengo.Node(size_in=dimensions, label="input_a")
+        net.input_b = net.B = nengo.Node(size_in=dimensions, label="input_b")
         net.output = nengo.Node(size_in=dimensions, label="output")
 
         net.sq1 = EnsembleArray(
@@ -70,10 +70,14 @@ def Product(n_neurons, dimensions, input_magnitude=1., net=None):
             radius=input_magnitude * np.sqrt(2))
 
         tr = 1. / np.sqrt(2.)
-        nengo.Connection(net.A, net.sq1.input, transform=tr, synapse=None)
-        nengo.Connection(net.B, net.sq1.input, transform=tr, synapse=None)
-        nengo.Connection(net.A, net.sq2.input, transform=tr, synapse=None)
-        nengo.Connection(net.B, net.sq2.input, transform=-tr, synapse=None)
+        nengo.Connection(
+            net.input_a, net.sq1.input, transform=tr, synapse=None)
+        nengo.Connection(
+            net.input_b, net.sq1.input, transform=tr, synapse=None)
+        nengo.Connection(
+            net.input_a, net.sq2.input, transform=tr, synapse=None)
+        nengo.Connection(
+            net.input_b, net.sq2.input, transform=-tr, synapse=None)
 
         sq1_out = net.sq1.add_output('square', np.square)
         nengo.Connection(sq1_out, net.output, transform=.5, synapse=None)

--- a/nengo/networks/tests/test_circularconv.py
+++ b/nengo/networks/tests/test_circularconv.py
@@ -40,19 +40,19 @@ def test_input_magnitude(Simulator, seed, rng, dims=16, magnitude=10):
     model = nengo.Network(label="circular conv", seed=seed)
     model.config[nengo.Ensemble].neuron_type = nengo.LIFRate()
     with model:
-        inputA = nengo.Node(a)
-        inputB = nengo.Node(b)
+        input_a = nengo.Node(a)
+        input_b = nengo.Node(b)
         cconv = nengo.networks.CircularConvolution(
             neurons_per_product, dimensions=dims,
             input_magnitude=magnitude)
-        nengo.Connection(inputA, cconv.A, synapse=None)
-        nengo.Connection(inputB, cconv.B, synapse=None)
+        nengo.Connection(input_a, cconv.input_a, synapse=None)
+        nengo.Connection(input_b, cconv.input_b, synapse=None)
         res_p = nengo.Probe(cconv.output)
         cconv_bad = nengo.networks.CircularConvolution(
             neurons_per_product, dimensions=dims,
             input_magnitude=1)  # incorrect magnitude
-        nengo.Connection(inputA, cconv_bad.A, synapse=None)
-        nengo.Connection(inputB, cconv_bad.B, synapse=None)
+        nengo.Connection(input_a, cconv_bad.input_a, synapse=None)
+        nengo.Connection(input_b, cconv_bad.input_b, synapse=None)
         res_p_bad = nengo.Probe(cconv_bad.output)
     with Simulator(model) as sim:
         sim.run(0.01)
@@ -73,12 +73,12 @@ def test_neural_accuracy(Simulator, seed, rng, dims, neurons_per_product=128):
     model = nengo.Network(label="circular conv", seed=seed)
     model.config[nengo.Ensemble].neuron_type = nengo.LIFRate()
     with model:
-        inputA = nengo.Node(a)
-        inputB = nengo.Node(b)
+        input_a = nengo.Node(a)
+        input_b = nengo.Node(b)
         cconv = nengo.networks.CircularConvolution(
             neurons_per_product, dimensions=dims)
-        nengo.Connection(inputA, cconv.A, synapse=None)
-        nengo.Connection(inputB, cconv.B, synapse=None)
+        nengo.Connection(input_a, cconv.input_a, synapse=None)
+        nengo.Connection(input_b, cconv.input_b, synapse=None)
         res_p = nengo.Probe(cconv.output)
     with Simulator(model) as sim:
         sim.run(0.01)

--- a/nengo/networks/tests/test_product.py
+++ b/nengo/networks/tests/test_product.py
@@ -13,31 +13,31 @@ def test_sine_waves(Simulator, plt, seed):
     product = nengo.networks.Product(
         200, dim, radius, net=nengo.Network(seed=seed))
 
-    func_A = lambda t: np.sqrt(radius)*np.sin(np.arange(1, dim+1)*2*np.pi*t)
-    func_B = lambda t: np.sqrt(radius)*np.sin(np.arange(dim, 0, -1)*2*np.pi*t)
+    func_a = lambda t: np.sqrt(radius)*np.sin(np.arange(1, dim+1)*2*np.pi*t)
+    func_b = lambda t: np.sqrt(radius)*np.sin(np.arange(dim, 0, -1)*2*np.pi*t)
     with product:
-        input_A = nengo.Node(func_A)
-        input_B = nengo.Node(func_B)
-        nengo.Connection(input_A, product.A)
-        nengo.Connection(input_B, product.B)
+        input_a = nengo.Node(func_a)
+        input_b = nengo.Node(func_b)
+        nengo.Connection(input_a, product.input_a)
+        nengo.Connection(input_b, product.input_b)
         p = nengo.Probe(product.output, synapse=0.005)
 
     with Simulator(product) as sim:
         sim.run(1.0)
 
     t = sim.trange()
-    AB = np.asarray(list(map(func_A, t))) * np.asarray(list(map(func_B, t)))
+    ideal = np.asarray(list(map(func_a, t))) * np.asarray(list(map(func_b, t)))
     delay = 0.013
     offset = np.where(t >= delay)[0]
 
     for i in range(dim):
         plt.subplot(dim+1, 1, i+1)
-        plt.plot(t + delay, AB[:, i])
+        plt.plot(t + delay, ideal[:, i])
         plt.plot(t, sim.data[p][:, i])
         plt.xlim(right=t[-1])
         plt.yticks((-2, 0, 2))
 
-    assert rmse(AB[:len(offset), :], sim.data[p][offset, :]) < 0.2
+    assert rmse(ideal[:len(offset), :], sim.data[p][offset, :]) < 0.2
 
 
 def test_direct_mode_with_single_neuron(Simulator, plt, seed):
@@ -50,31 +50,31 @@ def test_direct_mode_with_single_neuron(Simulator, plt, seed):
         product = nengo.networks.Product(
             1, dim, radius, net=nengo.Network(seed=seed))
 
-    func_A = lambda t: np.sqrt(radius)*np.sin(np.arange(1, dim+1)*2*np.pi*t)
-    func_B = lambda t: np.sqrt(radius)*np.sin(np.arange(dim, 0, -1)*2*np.pi*t)
+    func_a = lambda t: np.sqrt(radius)*np.sin(np.arange(1, dim+1)*2*np.pi*t)
+    func_b = lambda t: np.sqrt(radius)*np.sin(np.arange(dim, 0, -1)*2*np.pi*t)
     with product:
-        input_A = nengo.Node(func_A)
-        input_B = nengo.Node(func_B)
-        nengo.Connection(input_A, product.A)
-        nengo.Connection(input_B, product.B)
+        input_a = nengo.Node(func_a)
+        input_b = nengo.Node(func_b)
+        nengo.Connection(input_a, product.input_a)
+        nengo.Connection(input_b, product.input_b)
         p = nengo.Probe(product.output, synapse=0.005)
 
     with Simulator(product) as sim:
         sim.run(1.0)
 
     t = sim.trange()
-    AB = np.asarray(list(map(func_A, t))) * np.asarray(list(map(func_B, t)))
+    ideal = np.asarray(list(map(func_a, t))) * np.asarray(list(map(func_b, t)))
     delay = 0.013
     offset = np.where(t >= delay)[0]
 
     for i in range(dim):
         plt.subplot(dim+1, 1, i+1)
-        plt.plot(t + delay, AB[:, i])
+        plt.plot(t + delay, ideal[:, i])
         plt.plot(t, sim.data[p][:, i])
         plt.xlim(right=t[-1])
         plt.yticks((-2, 0, 2))
 
-    assert rmse(AB[:len(offset), :], sim.data[p][offset, :]) < 0.2
+    assert rmse(ideal[:len(offset), :], sim.data[p][offset, :]) < 0.2
 
 
 @pytest.mark.benchmark
@@ -101,8 +101,8 @@ def test_product_benchmark(Simulator, analytics, rng):
                 size_out=2)
 
             product_net = nengo.networks.Product(n_neurons, 1)
-            nengo.Connection(stimulus[0], product_net.A)
-            nengo.Connection(stimulus[1], product_net.B)
+            nengo.Connection(stimulus[0], product_net.input_a)
+            nengo.Connection(stimulus[1], product_net.input_b)
             probe_test = nengo.Probe(product_net.output)
 
             ens_direct = nengo.Ensemble(

--- a/nengo/networks/workingmemory.py
+++ b/nengo/networks/workingmemory.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 import nengo
@@ -6,7 +8,7 @@ from nengo.networks import EnsembleArray
 
 def InputGatedMemory(n_neurons, dimensions, feedback=1.0,
                      difference_gain=1.0, recurrent_synapse=0.1,
-                     difference_synapse=None, net=None):
+                     difference_synapse=None, net=None, **kwargs):
     """Stores a given vector in memory, with input controlled by a gate.
 
     Parameters
@@ -25,10 +27,8 @@ def InputGatedMemory(n_neurons, dimensions, feedback=1.0,
 
     difference_synapse : Synapse (Default: None)
         If None, ...
-    net : Network, optional (Default: None)
-        A network in which the network components will be built.
-        This is typically used to provide a custom set of Nengo object
-        defaults through modifying ``net.config``.
+    kwargs
+        Keyword arguments passed through to ``nengo.Network``.
 
     Returns
     -------
@@ -57,7 +57,10 @@ def InputGatedMemory(n_neurons, dimensions, feedback=1.0,
 
     """
     if net is None:
-        net = nengo.Network(label="Input Gated Memory")
+        kwargs.setdefault('label', "Input gated memory")
+        net = nengo.Network(**kwargs)
+    else:
+        warnings.warn("The 'net' argument is deprecated.", DeprecationWarning)
 
     if difference_synapse is None:
         difference_synapse = recurrent_synapse

--- a/nengo/spa/action_build.py
+++ b/nengo/spa/action_build.py
@@ -51,7 +51,8 @@ def convolution(module, target_name, effect, n_neurons_cconv, synapse):
             D = s1_vocab.dimensions
             t1 = np.dot(t1, np.eye(D)[-np.arange(D)])
 
-        nengo.Connection(s1_output, cconv.A, transform=t1, synapse=synapse)
+        nengo.Connection(
+            s1_output, cconv.input_a, transform=t1, synapse=synapse)
 
         t2 = s2_vocab.parse(source2.transform.symbol).get_convolution_matrix()
         if source2.inverted:
@@ -59,5 +60,6 @@ def convolution(module, target_name, effect, n_neurons_cconv, synapse):
             t2 = np.dot(t2, np.eye(D)[-np.arange(D)])
         if s1_vocab is not s2_vocab:
             t2 = np.dot(s2_vocab.transform_to(s1_vocab), t2)
-        nengo.Connection(s2_output, cconv.B, transform=t2, synapse=synapse)
+        nengo.Connection(
+            s2_output, cconv.input_b, transform=t2, synapse=synapse)
     return cconv

--- a/nengo/spa/bind.py
+++ b/nengo/spa/bind.py
@@ -54,8 +54,8 @@ class Bind(Module):
             self.cc = nengo.networks.CircularConvolution(
                 n_neurons, dimensions, invert_a, invert_b,
                 input_magnitude=input_magnitude)
-            self.A = self.cc.A
-            self.B = self.cc.B
+            self.A = self.cc.input_a
+            self.B = self.cc.input_b
             self.output = self.cc.output
 
         self.inputs = dict(A=(self.A, vocab), B=(self.B, vocab))

--- a/nengo/spa/compare.py
+++ b/nengo/spa/compare.py
@@ -50,7 +50,7 @@ class Compare(Module):
         self.outputs = dict(default=(self.output, None))
 
         with self:
-            nengo.Connection(self.inputA, self.product.A, synapse=None)
-            nengo.Connection(self.inputB, self.product.B, synapse=None)
+            nengo.Connection(self.inputA, self.product.input_a, synapse=None)
+            nengo.Connection(self.inputB, self.product.input_b, synapse=None)
             nengo.Connection(self.product.output, self.output,
                              transform=np.ones((1, dimensions)))


### PR DESCRIPTION
**Motivation and context:**
This makes the product and circular convolution network adhere to the newly defined standard for network inputs (#887) which should be named input_*. The old inputs are still available to keep backwards compatibility. They will not produce a deprecation warning as this is not possible in a backwards compatible way. Furthermore, this PR deprecates the `net` argument. As discussed before this argument was rarely used and in almost all uses cases the new `**kwargs` passed to `nengo.Network` provide the same functionality. This is required to allow for a deprecation on the old inputs in the future.

For consistency I made the `net` argument also obsolete on other network creation functions. In some other networks I also introduced in `output` node to provide a common interface.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
new-spa/nengo_spa uses the new input names.
This is a non-breaking version of #1179 for the inclusion in one of the next minor releases. #1179 is for the inclusion in the next major release.

**How has this been tested?**
Unit tests still pass.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
