### PR TITLE
Fix typo in `operator_dependency_graph`

### DIFF
--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -15,7 +15,7 @@ from nengo.exceptions import ReadonlyError, SimulatorClosed
 from nengo.utils.compat import range, ResourceWarning
 from nengo.utils.graphs import toposort
 from nengo.utils.progress import ProgressTracker
-from nengo.utils.simulator import operator_depencency_graph
+from nengo.utils.simulator import operator_dependency_graph
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ class Simulator(object):
             self.model.build(network, progress_bar=self.progress_bar)
 
         # Order the steps (they are made in `Simulator.reset`)
-        self.dg = operator_depencency_graph(self.model.operators)
+        self.dg = operator_dependency_graph(self.model.operators)
 
         if optimize:
             opmerge_optimize(self.model, self.dg)

--- a/nengo/utils/simulator.py
+++ b/nengo/utils/simulator.py
@@ -6,7 +6,7 @@ from .graphs import add_edges
 from .stdlib import groupby
 
 
-def operator_depencency_graph(operators):  # noqa: C901
+def operator_dependency_graph(operators):  # noqa: C901
     # -- all views of a base object in a particular dictionary
     by_base_sets = defaultdict(set)
     by_base_writes = defaultdict(set)


### PR DESCRIPTION
**Motivation and context:**
`depencency` -> `dependency`

`nengo_ocl` also needs to be updated (see https://github.com/nengo/nengo_ocl/pull/140)

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- n/a I have updated the documentation accordingly.
- n/a I have included a changelog entry.
- n/a I have added tests to cover my changes.
- [x] All new and existing tests passed.
