### PR TITLE
Add summaries to API docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,10 @@ Release History
   To get the number of neurons in each ensemble,
   use ``EnsembleArray.n_neurons_per_ensemble``.
   (`#1186 <https://github.com/nengo/nengo/pull/1186>`_)
+- The `Nengo modelling API document
+  <http://pythonhosted.org/nengo/frontend_api.html>`_
+  now has summaries to help navigate the page.
+  (`#1304 <https://github.com/nengo/nengo/pull/1304>`_)
 
 2.4.0 (April 18, 2017)
 ======================

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -7,6 +7,17 @@ Nengo Modelling API
 Nengo Objects
 =============
 
+.. autosummary::
+   :nosignatures:
+
+   nengo.Network
+   nengo.Ensemble
+   nengo.ensemble.Neurons
+   nengo.Node
+   nengo.Connection
+   nengo.connection.LearningRule
+   nengo.Probe
+
 .. autoclass:: nengo.Network
 
 .. autoclass:: nengo.Ensemble
@@ -23,6 +34,22 @@ Nengo Objects
 
 Distributions
 =============
+
+.. autosummary::
+   :nosignatures:
+
+   nengo.dists.Distribution
+   nengo.dists.get_samples
+   nengo.dists.Uniform
+   nengo.dists.Gaussian
+   nengo.dists.Exponential
+   nengo.dists.UniformHypersphere
+   nengo.dists.Choice
+   nengo.dists.Samples
+   nengo.dists.PDF
+   nengo.dists.SqrtBeta
+   nengo.dists.SubvectorLength
+   nengo.dists.CosineSimilarity
 
 .. autoclass:: nengo.dists.Distribution
    :exclude-members: sample
@@ -54,6 +81,19 @@ Distributions
 Neuron types
 ============
 
+.. autosummary::
+   :nosignatures:
+
+   nengo.neurons.NeuronType
+   nengo.Direct
+   nengo.RectifiedLinear
+   nengo.Sigmoid
+   nengo.LIF
+   nengo.LIFRate
+   nengo.AdaptiveLIF
+   nengo.AdaptiveLIFRate
+   nengo.Izhikevich
+
 .. autoclass:: nengo.neurons.NeuronType
 
 .. autoclass:: nengo.Direct
@@ -75,6 +115,15 @@ Neuron types
 Learning rule types
 ===================
 
+.. autosummary::
+   :nosignatures:
+
+   nengo.learning_rules.LearningRuleType
+   nengo.PES
+   nengo.BCM
+   nengo.Oja
+   nengo.Voja
+
 .. autoclass:: nengo.learning_rules.LearningRuleType
 
 .. autoclass:: nengo.PES
@@ -87,6 +136,16 @@ Learning rule types
 
 Processes
 =========
+
+.. autosummary::
+   :nosignatures:
+
+   nengo.Process
+   nengo.processes.PresentInput
+   nengo.processes.FilteredNoise
+   nengo.processes.BrownNoise
+   nengo.processes.WhiteNoise
+   nengo.processes.WhiteSignal
 
 .. autoclass:: nengo.Process
 
@@ -102,6 +161,17 @@ Processes
 
 Synapse models
 ==============
+
+.. autosummary::
+   :nosignatures:
+
+   nengo.synapses.Synapse
+   nengo.synapses.filt
+   nengo.synapses.filtfilt
+   nengo.LinearFilter
+   nengo.Lowpass
+   nengo.Alpha
+   nengo.synapses.Triangle
 
 .. autoclass:: nengo.synapses.Synapse
 
@@ -119,6 +189,21 @@ Synapse models
 
 Decoder and connection weight solvers
 =====================================
+
+.. autosummary::
+   :nosignatures:
+
+   nengo.solvers.Solver
+   nengo.solvers.Lstsq
+   nengo.solvers.LstsqNoise
+   nengo.solvers.LstsqMultNoise
+   nengo.solvers.LstsqL2
+   nengo.solvers.LstsqL2nz
+   nengo.solvers.LstsqL1
+   nengo.solvers.LstsqDrop
+   nengo.solvers.Nnls
+   nengo.solvers.NnlsL2
+   nengo.solvers.NnlsL2nz
 
 .. autoclass:: nengo.solvers.Solver
    :special-members: __call__

--- a/docs/networks.rst
+++ b/docs/networks.rst
@@ -22,6 +22,19 @@ The following examples will help you to build your own networks:
 
 You may also find the :doc:`config system documentation <config>` useful.
 
+.. autosummary::
+   :nosignatures:
+
+   nengo.networks.EnsembleArray
+   nengo.networks.BasalGanglia
+   nengo.networks.Thalamus
+   nengo.networks.AssociativeMemory
+   nengo.networks.CircularConvolution
+   nengo.networks.Integrator
+   nengo.networks.Oscillator
+   nengo.networks.Product
+   nengo.networks.InputGatedMemory
+
 .. autoclass:: nengo.networks.EnsembleArray
 
 .. autofunction:: nengo.networks.BasalGanglia


### PR DESCRIPTION
**Motivation and context:**
@celiasmith pointed out that the API docs pages are long and hard to navigate. This PR adds summaries to `frontend_api` and `networks` to (hopefully) make them easier to navigate.

When built, `networks` looks like this:

![netsummary](https://cloud.githubusercontent.com/assets/203709/25246216/f6c178c8-25d4-11e7-9a76-efa864383ece.png)

And `frontend_api` looks like this:

![api](https://cloud.githubusercontent.com/assets/203709/25246228/fd5eedd2-25d4-11e7-9ce2-011d701e5dd1.png)

That's only the amount that would fit on the screen, it goes on for a while more.

**How has this been tested?**
Built the docs to see how it renders.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**

One thing we should discuss is whether the `frontend_api` summary should contain _all_ things that are listed on that page, or if we should omit things that users aren't likely to interact with very much, like base classes and `LearningRule`, Thoughts?