### PR TITLE
Allow multiple error signals of arbitrary size for learning rules

### DIFF
--- a/nengo/base.py
+++ b/nengo/base.py
@@ -211,7 +211,8 @@ class NengoObjectParam(Parameter):
             NengoObject,
             ObjView,
             nengo.ensemble.Neurons,
-            nengo.connection.LearningRule
+            nengo.connection.LearningRule,
+            nengo.connection.ErrorSignal,
         )
         if not isinstance(nengo_obj, nengo_objects):
             raise ValidationError("'%s' is not a Nengo object" % nengo_obj,

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -365,6 +365,15 @@ def build_learning_rule(model, rule):
 
     conn = rule.connection
 
+    # --- Set up error signals
+    for err_sig in rule.error_signals:
+        error = Signal(
+            np.zeros(err_sig.size_in), name="learning_rule:" + err_sig.name)
+        model.add_op(Reset(error))
+        model.sig[err_sig]['in'] = error  # error connection will attach here
+    if len(rule.error_signals) == 1:
+        model.sig[rule]['in'] = model.sig[next(iter(rule.error_signals))]['in']
+
     # --- Set up delta signal
     if rule.modifies == 'encoders':
         if not conn.is_decoded:
@@ -385,7 +394,7 @@ def build_learning_rule(model, rule):
                 np.zeros((post.n_neurons, pre.n_neurons)), name='Delta')
         else:
             delta = Signal(
-                np.zeros((rule.size_in, pre.n_neurons)), name='Delta')
+                np.zeros((conn.post.size_in, pre.n_neurons)), name='Delta')
     else:
         raise BuildError("Unknown target %r" % rule.modifies)
 

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -15,6 +15,7 @@ http://nbviewer.ipython.org/urls/gist.github.com/ChrisBeaumont/5758381/raw/descr
 import inspect
 import sys
 
+import nengo
 from nengo.exceptions import ConfigError, ValidationError
 from nengo.params import Default, is_param, iter_params
 from nengo.rc import rc
@@ -456,3 +457,15 @@ class SupportDefaultsMixin(object):
                 reraise(exc_info[0], exc_info[1], None)
         else:
             super(SupportDefaultsMixin, self).__setattr__(name, val)
+
+
+class ConfigParam(nengo.params.TypeCheckedParameter):
+    """A parameter that accepts a Config object."""
+
+    def __init__(self, name, **kwargs):
+        super(ConfigParam, self).__init__(name, Config, **kwargs)
+
+    def validate(self, instance, value):
+        if value is None:
+            value = Config()
+        return super(ConfigParam, self).validate(instance, value)

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -17,7 +17,9 @@ class OutputParam(Parameter):
         super(OutputParam, self).__init__(name, default, optional, readonly)
 
     def __set__(self, node, output):
-        super(OutputParam, self).validate(node, output)
+        new_output = super(OutputParam, self).validate(node, output)
+        if new_output is not None:
+            output = new_output
 
         size_in_set = node.size_in is not None
         node.size_in = node.size_in if size_in_set else 0

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -41,6 +41,8 @@ class Parameter(object):
 
     Parameters
     ----------
+    name : str
+        Name of the parameter.
     default : object
         The value returned if the parameter hasn't been explicitly set.
     optional : bool, optional

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -111,8 +111,9 @@ class Parameter(object):
         self.data[instance] = value
 
     def __repr__(self):
-        return "%s(default=%s, optional=%s, readonly=%s)" % (
+        return "%s(%r, default=%s, optional=%s, readonly=%s)" % (
             type(self).__name__,
+            self.name,
             self.default,
             self.optional,
             self.readonly)

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -6,7 +6,7 @@ import numpy as np
 from nengo.exceptions import (
     ConfigError, ObsoleteError, ReadonlyError, ValidationError)
 from nengo.utils.compat import (
-    is_array, is_integer, is_number, is_string, itervalues)
+    is_array, is_array_like, is_integer, is_number, is_string, itervalues)
 from nengo.utils.numpy import array_hash, compare
 from nengo.utils.stdlib import WeakKeyIDDictionary, checked_call
 
@@ -144,8 +144,10 @@ class Parameter(object):
         a = self.__get__(instance_a, None)
         b = self.__get__(instance_b, None)
         if self.equatable:
-            # always use array_equal, in case one argument is an array
-            return np.array_equal(a, b)
+            if is_array_like(a) or is_array_like(b):
+                return np.array_equal(a, b)
+            else:
+                return a == b
         else:
             return a is b
 

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -379,6 +379,43 @@ class ShapeParam(TupleParam):
                     attr=self.name, obj=instance)
 
 
+class FrozenMap(collections.Mapping):
+    def __init__(self, values=None):
+        if values is None:
+            values = {}
+        self._values = dict(values)
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __len__(self):
+        return len(self._values)
+
+    def __eq__(self, other):
+        return frozenset(self.keys()) == frozenset(other.keys()) and all(
+            self[k] == other[k] for k in self)
+
+    def __hash__(self):
+        return hash(frozenset(self.keys()))
+
+
+class FrozenMapParam(TypeCheckedParameter):
+    """A parameter where the value is a FrozenMap."""
+
+    equatable = True
+
+    def __init__(self, name, **kwargs):
+        super(FrozenMapParam, self).__init__(name, FrozenMap, **kwargs)
+
+    def validate(self, instance, value):
+        if value is not None and not isinstance(value, FrozenMap):
+            value = FrozenMap(value)
+        return super(FrozenMapParam, self).validate(instance, value)
+
+
 class DictParam(TypeCheckedParameter):
     """A parameter where the value is a dictionary."""
 

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -17,12 +17,12 @@ class TargetParam(NengoObjectParam):
 
         # do this after; better to know that type is not Probable first
         if not isinstance(obj, LearningRule):
-            super(TargetParam, self).validate(probe, target)
+            return super(TargetParam, self).validate(probe, target)
 
 
 class AttributeParam(StringParam):
     def validate(self, probe, attr):
-        super(AttributeParam, self).validate(probe, attr)
+        value = super(AttributeParam, self).validate(probe, attr)
         if attr in ('decoders', 'transform'):
             raise ObsoleteError("'decoders' and 'transform' are now combined "
                                 "into 'weights'. Probe 'weights' instead.",
@@ -32,6 +32,7 @@ class AttributeParam(StringParam):
                                   "Probeable attributes: %s"
                                   % (attr, probe.obj, probe.obj.probeable),
                                   attr=self.name, obj=probe)
+        return value
 
 
 class ProbeSolverParam(SolverParam):
@@ -42,11 +43,12 @@ class ProbeSolverParam(SolverParam):
         super(ProbeSolverParam, self).__set__(instance, value)
 
     def validate(self, conn, solver):
-        super(ProbeSolverParam, self).validate(conn, solver)
+        value = super(ProbeSolverParam, self).validate(conn, solver)
         if solver is not None and solver.weights:
             raise ValidationError("weight solvers only work for ensemble to "
                                   "ensemble connections, not probes",
                                   attr=self.name, obj=conn)
+        return value
 
 
 class Probe(NengoObject):

--- a/nengo/spa/vocab.py
+++ b/nengo/spa/vocab.py
@@ -480,15 +480,8 @@ class Vocabulary(object):
         return subset
 
 
-class VocabularyParam(nengo.params.Parameter):
+class VocabularyParam(nengo.params.TypeCheckedParameter):
     """Can be a Vocabulary."""
 
-    def validate(self, instance, vocab):
-        super(VocabularyParam, self).validate(instance, vocab)
-
-        if vocab is not None and not isinstance(vocab, Vocabulary):
-            raise ValidationError("Must be of type 'Vocabulary' (got type %r)."
-                                  % type(vocab).__name__,
-                                  attr=self.name, obj=instance)
-
-        return vocab
+    def __init__(self, name, **kwargs):
+        super(VocabularyParam, self).__init__(name, Vocabulary, **kwargs)


### PR DESCRIPTION
**Motivation and context:**
I'm currently working on a new learning rule that I call the Association Matrix Learning rule (AML). Essentially it learns associations from vectors u_i to v_i by learning an outer product transform matrix \sum_i v_i u_i^T. I am experimenting with different ways of implementing this learning rule (corresponding to different biological interpretations). In the two most general formulations, I end up either with a single d*d error signal or with two d-dimensional error signals. Currently, Nengo does not allow error signals of arbitrary size (d * d) or multiple error signals (note, that I cannot use slices into a single error signal because of the size limitations). To test these formulations of the learning rule, I extended Nengo to support multiple error signals of arbitrary size for learning rules.

There a still a few things to clean up and do to make this production quality code, but before I invest time in that, it would be good to know:

* Do we in general want the functionality for multiple error signals?
* How feel people about my choice of connection syntax? For learning rules with no or one error signal nothing changes, but if there are more error signal one would connect to named attributes of the learning rule. For example, `conn.learning_rule.error1` and `conn.learning_rule.error2` or `conn.learning_rule.cue` and `conn.learning_rule.target` (the names I chose for the AML). I think we had some related discussion in #553 and there was some concern that this is not consistent with how Nengo works in other cases. Though, I disagree because to me it is very similar to `ensemble.neurons`.
* Do we want to keep backwards compatibility for this? (It might make sense to disallow connections to `conn.learning_rule` and always require to use the name of the error signal.)

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
This is currently based on #1207 because it made the implementation easier and faster for me, but technically the code could be changed to not depend on that.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Unit tests still pass without changes (-> backwards compatible). Tested arbitrary size error signal and multiple error signals with my AML implementations that I have somewhere else. If this is polished up to production quality, unit tests need to be added accordingly.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

Not ready for review yet. Just looking for feedback if this is a desirable feature.

- Quick (less than 40 lines changed or changes are straightforward)
- Average (neither quick nor lengthy)
- Lengthy (more than 150 lines changed or changes are complicated)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->
tbd

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

tbd

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that causes existing functionality to change)
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you stil plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [ ] PES is still constructing it's own error signal I believe instead of using the signal constructed in `build_learning_rule`.
- [ ] `params.py` might not be the best place for `FrozenMap`