### PR TITLE
Release file locks on termination signals.

### DIFF
--- a/nengo/utils/lock.py
+++ b/nengo/utils/lock.py
@@ -38,7 +38,7 @@ def _release_locks_handler(sig, frame):
 # signals will slightly differ depending on the platform (i.e. Windows does
 # not support some signals). We do not include SIGINT which is translated to
 # an exception by Python by default and SIGKILL for which no signal handler
-# can be registered. This also assumes that these signals are not “mis-used”
+# can be registered. This also assumes that these signals are not "mis-used"
 # for things that will not terminate the process (because in that case we
 # did not want to release the file locks). Because SIGUSR1 and SIGUSR2 are
 # commonly used as non-terminating signal, we only register the signal handler

--- a/nengo/utils/lock.py
+++ b/nengo/utils/lock.py
@@ -1,9 +1,65 @@
 import errno
 import os
 import os.path
+import platform
+import signal
 import time
+import weakref
 
 from nengo.exceptions import TimeoutError
+
+
+_locks = weakref.WeakSet()
+
+
+def _prepend_sig_handler(sig, fn):
+    current_handler = signal.getsignal(sig)
+    if current_handler == signal.SIG_DFL:
+        def prepended_handler(sig, frame):
+            fn(sig, frame)
+            h = signal.signal(sig, signal.SIG_DFL)
+            os.kill(os.getpid(), sig)
+            signal.signal(sig, h)
+    elif current_handler is None or current_handler == signal.SIG_IGN:
+        prepended_handler = fn
+    else:
+        def prepended_handler(sig, frame):
+            fn(sig, frame)
+            current_handler(sig, frame)
+    signal.signal(sig, prepended_handler)
+
+
+def _release_locks_handler(sig, frame):
+    for lock in _locks:
+        lock.release()
+
+
+# Build up a list of signals that terminate the process. The list of available
+# signals will slightly differ depending on the platform (i.e. Windows does
+# not support some signals). We do not include SIGINT which is translated to
+# an exception by Python by default and SIGKILL for which no signal handler
+# can be registered. This also assumes that these signals are not “mis-used”
+# for things that will not terminate the process (because in that case we
+# did not want to release the file locks). Because SIGUSR1 and SIGUSR2 are
+# commonly used as non-terminating signal, we only register the signal handler
+# if they still use the default (terminating) handler.
+_termination_signals = [
+    signal.SIGILL,
+    signal.SIGABRT,
+    signal.SIGFPE,
+    signal.SIGSEGV,
+    signal.SIGTERM,
+
+]
+if platform.system() not in ('', 'Windows'):
+    _termination_signals.append(signal.SIGHUP)
+    _termination_signals.append(signal.SIGQUIT)
+    for sig in (signal.SIGUSR1, signal.SIGUSR2):
+        if signal.getsignal(sig) == signal.SIG_DFL:
+            _termination_signals.append(sig)
+
+for sig in _termination_signals:
+    _prepend_sig_handler(sig, _release_locks_handler)
 
 
 class FileLock(object):
@@ -12,6 +68,7 @@ class FileLock(object):
         self.timeout = timeout
         self.poll = poll
         self._fd = None
+        _locks.add(self)
 
     def acquire(self):
         start = time.time()


### PR DESCRIPTION
**Motivation and context:**
If a Nengo process is terminated abnormally by a signal other than SIGINT (Ctrl+C), e.g. with the kill command, file locks acquired by the cache will not be released. That prevents all future Nengo instance from acquiring writing to the cache until the file lock in manually removed. This PR adds code to install signal handlers to release file locks before such an abnormal termination.

While this solves one problem, it may introduce another problem. Modifying signal handlers is a global operation. The PR makes some effort to call previously installed handlers (or the default handler) after releasing the file locks. However, the user could set signal handlers after the file lock handler has been installed and overwrite it unknowningly (but argubly that leaves us off not any worse than without this PR). More critically, the user could change the signal handling to a non terminating signal handler before the file lock handler is installed. In that case, the file lock might be released too early. Though, for most of the signals this would be somewhat bad coding practice as they are intended to terminate the program. SIGUSR1 and SIGUSR2, however, are sometimes used for things other than program termination (e.g. some versions `dd` will output a progress report on `SIGUSR1`). Thus, the file lock handler will only be installed for these two signals if the default handler (that terminates) has not been changed.

There might be an argument to reduce the number of signals that the file lock handler is registered for. SIGABRT, SIGILL, SIGFPE, SIGSEGV should normally not occur and are the indication of quite a severe problem, probably with the Python interpreter. It is not clear to me whether in those case the signal handler can still properly run at all. SIGUSR1 and SIGUSR2 are not necessarily used for termination (see above). The following three signals, however, should be included in my opinion if we install a signal handler at all:
* SIGHUP: Get send when the parent process exits. For example, when the user closes the terminal that is running the Nengo instance.
* SIGTERM: When killing the Nengo process with `kill`, it is the default signal that is sent.
* SIGQUIT: This can be sent with a keyboard short cut (it is different from SIGINT send with Ctrl+C, because by default it will produce a core dump, maybe there is an argument to not install the handler for it to not change the core dump)

Another potential issue is that all signal handler manipulations have to be done in the main thread. In theory, it would be possible to import Nengo not in the main thread, but only in child threads which would make the code fail.

**Interactions with other PRs:**
none

**How has this been tested?**
Unit tests still pass, I tested parts of the code overwriting the signal handling manually. It would be nice to have unit tests for it, but not sure how to test this as it seems problematic to globally mess with the signal handles within the unit tests.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
Helpful references:
* [signal man page](http://man7.org/linux/man-pages/man7/signal.7.html)
* [Invoking the default signal handler](http://stackoverflow.com/questions/6015498/executing-default-signal-handler)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
