### PR TITLE
Allow arbitrary learning rule size_in

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,11 @@ Release History
 
 **Changed**
 
+- Learning rules now have a ``size_in`` parameter and attribute,
+  allowing both integers and strings to define the dimensionality
+  of the learning rule. This replaces the ``error_type`` attribute.
+  (`#1307 <https://github.com/nengo/nengo/issues/1307>`_,
+  `#1310 <https://github.com/nengo/nengo/pull/1310>`_)
 - ``EnsembleArray.n_neurons`` now gives the total number of neurons
   in all ensembles, including those in subnetworks.
   To get the number of neurons in each ensemble,

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -373,23 +373,14 @@ def build_learning_rule(model, rule):
         post = get_post_ens(conn)
         target = model.sig[post]['encoders']
         tag = "encoders += delta"
-        delta = Signal(
-            np.zeros((post.n_neurons, post.dimensions)), name='Delta')
     elif rule.modifies in ('decoders', 'weights'):
-        pre = get_pre_ens(conn)
         target = model.sig[conn]['weights']
         tag = "weights += delta"
-        if not conn.is_decoded:
-            post = get_post_ens(conn)
-            delta = Signal(
-                np.zeros((post.n_neurons, pre.n_neurons)), name='Delta')
-        else:
-            delta = Signal(
-                np.zeros((rule.size_in, pre.n_neurons)), name='Delta')
     else:
         raise BuildError("Unknown target %r" % rule.modifies)
 
-    assert delta.shape == target.shape
+    delta = Signal(np.zeros(target.shape), name='Delta')
+
     model.add_op(
         ElementwiseInc(model.sig['common'][1], delta, target, tag=tag))
     model.sig[rule]['delta'] = delta

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -374,7 +374,7 @@ class Copy(Operator):
 
     def _descstr(self):
         def sigstring(sig, sl):
-            return '%s%s' % (sig, ('[%s]' % sl) if sl is not None else '')
+            return '%s%s' % (sig, ('[%s]' % (sl,)) if sl is not None else '')
         return '%s -> %s, inc=%s' % (sigstring(self.src, self.src_slice),
                                      sigstring(self.dst, self.dst_slice),
                                      self.inc)

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -562,11 +562,6 @@ class LearningRule(object):
         return self._connection
 
     @property
-    def error_type(self):
-        """(str) The type of information expected by the learning rule."""
-        return self.learning_rule_type.error_type
-
-    @property
     def modifies(self):
         """(str) The variable modified by the learning rule."""
         return self.learning_rule_type.modifies
@@ -578,21 +573,12 @@ class LearningRule(object):
 
     @property
     def size_in(self):
-        """(int) Dimensionality of the signal expected by the learning rule."""
-        if self.error_type == 'none':
-            return 0
-        elif self.error_type == 'scalar':
-            return 1
-        elif self.error_type == 'decoded':
+        if self.learning_rule_type.size_in is None:
             return (self.connection.post_obj.ensemble.size_in
-                    if isinstance(self.connection.post_obj, Neurons) else
-                    self.connection.size_out)
-        elif self.error_type == 'neuron':
-            raise NotImplementedError()
+                    if isinstance(self.connection.post_obj, Neurons)
+                    else self.connection.size_out)
         else:
-            raise ValidationError(
-                "Unrecognized error type %r" % self.error_type,
-                attr='error_type', obj=self)
+            return self.learning_rule_type.size_in
 
     @property
     def size_out(self):

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -573,12 +573,22 @@ class LearningRule(object):
 
     @property
     def size_in(self):
-        if self.learning_rule_type.size_in is None:
-            return (self.connection.post_obj.ensemble.size_in
-                    if isinstance(self.connection.post_obj, Neurons)
-                    else self.connection.size_out)
+        conn = self.connection
+        size_in = self.learning_rule_type.size_in
+        if size_in == 'pre':
+            return conn.size_in
+        elif size_in == 'mid':
+            return conn.size_mid
+        elif size_in == 'post':
+            return conn.size_out
+        elif size_in == 'pre_state':
+            return (conn.pre_obj.ensemble.size_out
+                    if isinstance(conn.pre_obj, Neurons) else conn.size_in)
+        elif size_in == 'post_state':
+            return (conn.post_obj.ensemble.size_in
+                    if isinstance(conn.post_obj, Neurons) else conn.size_out)
         else:
-            return self.learning_rule_type.size_in
+            return size_in  # should be an integer
 
     @property
     def size_out(self):

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -1,16 +1,8 @@
 import warnings
 
-from nengo.base import NengoObjectParam
 from nengo.exceptions import ValidationError
-from nengo.params import FrozenObject, NumberParam, Parameter
+from nengo.params import IntParam, FrozenObject, NumberParam, Parameter
 from nengo.utils.compat import is_iterable, itervalues
-
-
-class ConnectionParam(NengoObjectParam):
-    def coerce(self, instance, conn):
-        from nengo.connection import Connection
-        self.check_type(instance, conn, Connection)
-        return super(ConnectionParam, self).coerce(instance, conn)
 
 
 class LearningRuleType(FrozenObject):
@@ -22,12 +14,9 @@ class LearningRuleType(FrozenObject):
     Each learning rule exposes two important pieces of metadata that the
     builder uses to determine what information should be stored.
 
-    The ``error_type`` is the type of the incoming error signal. Options are:
-
-    * ``'none'``: no error signal
-    * ``'scalar'``: scalar error signal
-    * ``'decoded'``: vector error signal in decoded space
-    * ``'neuron'``: vector error signal in neuron space
+    The ``size_in`` is the dimensionality of the incoming error signal. Setting
+    ``size_in`` to ``None`` will use the dimensionality of the post-synaptic
+    ensemble.
 
     The ``modifies`` attribute denotes the signal targeted by the rule.
     Options are:
@@ -40,27 +29,31 @@ class LearningRuleType(FrozenObject):
     ----------
     learning_rate : float, optional (Default: 1e-6)
         A scalar indicating the rate at which ``modifies`` will be adjusted.
+    size_in : int, optional (Default: 0)
+        Dimensionality of the error signal (setting to ``None`` will use the
+        dimensionality of the post-synaptic ensemble).
 
     Attributes
     ----------
-    error_type : str
-        The type of the incoming error signal. This also determines
-        the dimensionality of the error signal.
     learning_rate : float
         A scalar indicating the rate at which ``modifies`` will be adjusted.
+    size_in : int
+        Dimensionality of the error signal (setting to ``None`` will use the
+        dimensionality of the post-synaptic ensemble).
     modifies : str
         The signal targeted by the learning rule.
     """
 
-    error_type = 'none'
     modifies = None
     probeable = ()
 
     learning_rate = NumberParam('learning_rate', low=0, low_open=True)
+    size_in = IntParam('size_in', low=0, optional=True)
 
-    def __init__(self, learning_rate=1e-6):
+    def __init__(self, learning_rate=1e-6, size_in=0):
         super(LearningRuleType, self).__init__()
         self.learning_rate = learning_rate
+        self.size_in = size_in
 
     def __repr__(self):
         return '%s(%s)' % (type(self).__name__, ", ".join(self._argreprs))
@@ -92,7 +85,6 @@ class PES(LearningRuleType):
         Filter constant on activities of neurons in pre population.
     """
 
-    error_type = 'decoded'
     modifies = 'decoders'
     probeable = ('error', 'correction', 'activities', 'delta')
 
@@ -103,7 +95,7 @@ class PES(LearningRuleType):
             warnings.warn("This learning rate is very high, and can result "
                           "in floating point errors from too much current.")
         self.pre_tau = pre_tau
-        super(PES, self).__init__(learning_rate)
+        super(PES, self).__init__(learning_rate, size_in=None)
 
     @property
     def _argreprs(self):
@@ -156,7 +148,6 @@ class BCM(LearningRuleType):
         A scalar indicating the time constant for theta integration.
     """
 
-    error_type = 'none'
     modifies = 'weights'
     probeable = ('theta', 'pre_filtered', 'post_filtered', 'delta')
 
@@ -169,7 +160,7 @@ class BCM(LearningRuleType):
         self.theta_tau = theta_tau
         self.pre_tau = pre_tau
         self.post_tau = post_tau if post_tau is not None else pre_tau
-        super(BCM, self).__init__(learning_rate)
+        super(BCM, self).__init__(learning_rate, size_in=0)
 
     @property
     def _argreprs(self):
@@ -227,7 +218,6 @@ class Oja(LearningRuleType):
         Filter constant on activities of neurons in pre population.
     """
 
-    error_type = 'none'
     modifies = 'weights'
     probeable = ('pre_filtered', 'post_filtered', 'delta')
 
@@ -240,7 +230,7 @@ class Oja(LearningRuleType):
         self.pre_tau = pre_tau
         self.post_tau = post_tau if post_tau is not None else pre_tau
         self.beta = beta
-        super(Oja, self).__init__(learning_rate)
+        super(Oja, self).__init__(learning_rate, size_in=0)
 
     @property
     def _argreprs(self):
@@ -280,7 +270,6 @@ class Voja(LearningRuleType):
         Filter constant on activities of neurons in post population.
     """
 
-    error_type = 'scalar'
     modifies = 'encoders'
     probeable = ('post_filtered', 'scaled_encoders', 'delta')
 
@@ -288,7 +277,7 @@ class Voja(LearningRuleType):
 
     def __init__(self, post_tau=0.005, learning_rate=1e-2):
         self.post_tau = post_tau
-        super(Voja, self).__init__(learning_rate)
+        super(Voja, self).__init__(learning_rate, size_in=1)
 
     @property
     def _argreprs(self):
@@ -308,10 +297,6 @@ class LearningRuleTypeParam(Parameter):
             raise ValidationError(
                 "'%s' must be a learning rule type or a dict or "
                 "list of such types." % rule, attr=self.name, obj=instance)
-        if rule.error_type not in ('none', 'scalar', 'decoded', 'neuron'):
-            raise ValidationError(
-                "Unrecognized error type %r" % rule.error_type,
-                attr=self.name, obj=instance)
         if rule.modifies not in ('encoders', 'decoders', 'weights'):
             raise ValidationError("Unrecognized target %r" % rule.modifies,
                                   attr=self.name, obj=instance)

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from nengo.exceptions import (
     ConfigError, ObsoleteError, ReadonlyError, ValidationError)
-from nengo.utils.compat import (int_types, is_array, is_integer, is_number,
-                                is_string, itervalues, string_types)
+from nengo.utils.compat import (int_types, is_array, is_array_like, is_integer,
+                                is_number, is_string, itervalues, string_types)
 from nengo.utils.numpy import array_hash, compare
 from nengo.utils.stdlib import WeakKeyIDDictionary, checked_call
 
@@ -160,8 +160,10 @@ class Parameter(object):
         a = self.__get__(instance_a, None)
         b = self.__get__(instance_b, None)
         if self.equatable:
-            # always use array_equal, in case one argument is an array
-            return np.array_equal(a, b)
+            if is_array_like(a) or is_array_like(b):
+                return np.array_equal(a, b)
+            else:
+                return a == b
         else:
             return a is b
 


### PR DESCRIPTION
**Motivation and context:**
This is the resolution to #1307, allowing learning rules to be defined with arbitrary `size_in`.  Allows for more flexibility in the types of learning rules that can be implemented.

Also removes `ConnectionParam`, which wasn't actually being used anywhere.

I wasn't sure if we want a changelog entry for this (it's kind of user-facing, but only insofar as users are using the pluggable builder system).

**Interactions with other PRs:**
Based on discussion in #1307

**How has this been tested?**
This doesn't actually change anything in the current code base (since we don't have any rules with `size_in` that aren't covered by the previous `error_type`).  But I added a test with a custom rule type
that has a non-standard `size_in`.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
