### PR TITLE
Pre post errors

### DIFF
--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -580,8 +580,10 @@ class LearningRule(object):
             return (self.connection.post_obj.ensemble.size_in
                     if isinstance(self.connection.post_obj, Neurons) else
                     self.connection.size_out)
-        elif self.error_type == 'neuron':
-            raise NotImplementedError()
+        elif self.error_type == 'pre':
+            return self.connection.pre_obj.size_out
+        elif self.error_type == 'post':
+            return self.connection.post_obj.size_in
         else:
             raise ValidationError(
                 "Unrecognized error type %r" % self.error_type,

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -29,7 +29,8 @@ class LearningRuleType(FrozenObject):
     * ``'none'``: no error signal
     * ``'scalar'``: scalar error signal
     * ``'decoded'``: vector error signal in decoded space
-    * ``'neuron'``: vector error signal in neuron space
+    * ``'pre'``: vector error signal in pre-object space
+    * ``'post'``: vector error signal in post-object space
 
     The ``modifies`` attribute denotes the signal targeted by the rule.
     Options are:
@@ -318,7 +319,7 @@ class LearningRuleTypeParam(Parameter):
             raise ValidationError(
                 "'%s' must be a learning rule type or a dict or "
                 "list of such types." % rule, attr=self.name, obj=instance)
-        if rule.error_type not in ('none', 'scalar', 'decoded', 'neuron'):
+        if rule.error_type not in ('none', 'scalar', 'decoded', 'pre', 'post'):
             raise ValidationError(
                 "Unrecognized error type %r" % rule.error_type,
                 attr=self.name, obj=instance)

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -331,6 +331,10 @@ class LinearFilter(Synapse):
 class Lowpass(LinearFilter):
     """Standard first-order lowpass filter synapse.
 
+    The impulse-response function is given by::
+
+        f(t) = (t / tau) * exp(-t / tau)
+
     Parameters
     ----------
     tau : float
@@ -366,7 +370,7 @@ class Alpha(LinearFilter):
 
     The impulse-response function is given by::
 
-        alpha(t) = (t / tau) * exp(-t / tau)
+        alpha(t) = (t / tau**2) * exp(-t / tau)
 
     and was found by [1]_ to be a good basic model for synapses.
 

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -188,6 +188,19 @@ class LinearFilter(Synapse):
         return "%s(%s, %s, analog=%r)" % (
             type(self).__name__, self.num, self.den, self.analog)
 
+    def combine(self, obj):
+        """Combine in series with another LinearFilter. """
+        if not isinstance(obj, LinearFilter):
+            raise ValueError("Can only combine with other LinearFilters")
+        if self.analog != obj.analog:
+            raise ValueError("Cannot combine analog and digital filters")
+        num = np.polymul(self.num, obj.num)
+        den = np.polymul(self.den, obj.den)
+        return LinearFilter(num, den, analog=self.analog,
+                            default_size_in=self.default_size_in,
+                            default_size_out=self.default_size_out,
+                            default_dt=self.default_dt, seed=self.seed)
+
     def evaluate(self, frequencies):
         """Evaluate the transfer function at the given frequencies.
 

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -167,6 +167,15 @@ def test_lti_lowpass(rng, plt):
     assert np.allclose(x, y)
 
 
+def test_linearfilter_combine(rng):
+    nt = 3000
+    tau0, tau1 = 0.01, 0.02
+    u = rng.normal(size=(nt, 10))
+    x = LinearFilter([1], [tau0*tau1, tau0+tau1, 1]).filt(u, y0=0)
+    y = Lowpass(tau0).combine(Lowpass(tau1)).filt(u, y0=0)
+    assert np.allclose(x, y)
+
+
 def test_synapseparam():
     """SynapseParam must be a Synapse, and converts numbers to LowPass."""
     class Test(object):


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Some learning rules I'm working on have errors in the space of the pre object or post object. This allows for vector error signals with those number of dimensions.

It also adds a feature to combine LinearFilter synapses, and fixes a bit of the synapse documentation.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

I've tested this with my new learning rules, and it does what I need. Also, it's replacing the ``neurons`` option for learning rules, which was unimplemented.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

The three commits are all independent, so start wherever you want. Really they could be separate PRs, but they're all so small that it doesn't seem worth it.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.