### PR TITLE
Fix PES learning with sliced post

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ Release History
 
 **Fixed**
 
+- Fixed an issue in which the PES learning rule could not be used
+  on connections to an ``ObjView`` when using a weight solver.
+  (`#1317 <https://github.com/nengo/nengo/pull/1317>`_)
 - The progress bar that can appear when building a large model
   will now appear earlier in the build process.
   (`#1340 <https://github.com/nengo/nengo/pull/1340>`_)

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -578,7 +578,7 @@ def build_pes(model, pes, rule):
     if not conn.is_decoded:
         post = get_post_ens(conn)
         weights = model.sig[conn]['weights']
-        encoders = model.sig[post]['encoders']
+        encoders = model.sig[post]['encoders'][:, conn.post_slice]
 
         # encoded = dot(encoders, correction)
         encoded = Signal(np.zeros(weights.shape[0]), name="PES:encoded")


### PR DESCRIPTION
**Motivation and context:**
@celiasmith was having issues doing learning on a connection in which the `post` was an `ObjView`. This was failed when using a weight-based solver because we used the full encoder matrix. This PR adds a test for that case, and fixes the builder to slice the encoder matrix when the post object is an `ObjView`.

One discussion point:

Currently, this slices the `post` by slicing into the `encoders` signal. However, in `builder/connections.py`, we have a `slice_signal` helper function that is required for advanced indexing. I seem to recall that we talked about disallowing advanced indexing for Nengo objects, but I think it is still possible. Are we allowing advanced indexes?

**How has this been tested?**
Added a unit test which fails without this PR.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
