### PR TITLE
Raise BuildError if conn function returns None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,9 @@ Release History
   <http://pythonhosted.org/nengo/frontend_api.html>`_
   now has summaries to help navigate the page.
   (`#1304 <https://github.com/nengo/nengo/pull/1304>`_)
+- The error raised when a ``Connection`` function returns ``None``
+  is now more clear.
+  (`#1319 <https://github.com/nengo/nengo/pull/1319>`_)
 
 2.4.0 (April 18, 2017)
 ======================

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -76,7 +76,11 @@ def get_targets(conn, eval_points):
     else:
         targets = np.zeros((len(eval_points), conn.size_mid))
         for i, ep in enumerate(eval_points[:, conn.pre_slice]):
-            targets[i] = conn.function(ep)
+            out = conn.function(ep)
+            if out is None:
+                raise BuildError("Building %s: Connection function returned "
+                                 "None. Cannot solve for decoders." % (conn,))
+            targets[i] = out
 
     return targets
 

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -953,3 +953,15 @@ def test_zero_activities_error(Simulator):
     with pytest.raises(BuildError):
         with nengo.Simulator(model):
             pass
+
+
+def test_function_returns_none_error(Simulator):
+    with nengo.Network() as model:
+        a = nengo.Ensemble(10, 1)
+        nengo.Connection(a, nengo.Node(size_in=1),
+                         eval_points=[[0], [1]],
+                         function=lambda x: x if x < 0.5 else None)
+
+    with pytest.raises(BuildError):
+        with nengo.Simulator(model):
+            pass


### PR DESCRIPTION
**Motivation and context:**
In #1318 @ikajic reported that we don't raise a nice error if someone forgets to return a value from a connection function (which is a common thing to forget, especially when moving from a lambda to a named function). This raises a nice error when that happens.

**How has this been tested?**
Added a test that the error gets raised.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Discussion points**

This error gets raised at build time, not a model creation time. This is because running a connection function might not be something the user expects when defining the model. It already gets run at build time, so this keeps the user's expectations the same. We could do this at model creation time though, if the consensus prefers that.
