### PR TITLE
Print where affected objects are in the network hierarchy in BuildErrors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Release History
 - Added ``amplitude`` parameter to ``LIF`` and ``LIFRate``,
   which scale the output amplitude.
   (`#1325 <https://github.com/nengo/nengo/pull/1325>`_)
+- A ``BuildError`` caused by the reference ``Simulator`` will print more
+  information about the object involved to aid identifying the root cause.
+  (`#1320 <https://github.com/nengo/nengo/pull/1320>`_)
 
 **Changed**
 

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -213,7 +213,8 @@ class Builder(object):
                 break
         else:
             raise BuildError(
-                "Cannot build object of type %r" % type(obj).__name__)
+                "Cannot build object of type %r" % type(obj).__name__,
+                [obj])
 
         return cls.builders[obj_cls](model, obj, *args, **kwargs)
 

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -93,7 +93,8 @@ def build_linear_system(model, conn, rng):
         raise BuildError(
             "Building %s: 'activites' matrix is all zero for %s. "
             "This is because no evaluation points fall in the firing "
-            "ranges of any neurons." % (conn, conn.pre_obj))
+            "ranges of any neurons." % (conn, conn.pre_obj),
+            [conn, conn.pre_obj])
 
     targets = get_targets(conn, eval_points)
     return eval_points, activities, targets
@@ -130,7 +131,8 @@ def solve_for_decoders(conn, gain, bias, x, targets, rng, E=None):
         raise BuildError(
             "Building %s: 'activities' matrix is all zero for %s. "
             "This is because no evaluation points fall in the firing "
-            "ranges of any neurons." % (conn, conn.pre_obj))
+            "ranges of any neurons." % (conn, conn.pre_obj),
+            [conn, conn.pre_obj])
 
     decoders, solver_info = conn.solver(activities, targets, rng=rng, E=E)
     return decoders, solver_info
@@ -217,11 +219,13 @@ def build_connection(model, conn):
         if target not in model.sig:
             raise BuildError("Building %s: the %r object %s is not in the "
                              "model, or has a size of zero."
-                             % (conn, 'pre' if is_pre else 'post', target))
+                             % (conn, 'pre' if is_pre else 'post', target),
+                             [conn, target])
         if key not in model.sig[target]:
             raise BuildError(
                 "Building %s: the %r object %s has a %r size of zero."
-                % (conn, 'pre' if is_pre else 'post', target, key))
+                % (conn, 'pre' if is_pre else 'post', target, key),
+                [conn, target])
 
         return model.sig[target][key]
 

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -589,7 +589,8 @@ def build_pes(model, pes, rule):
         local_error = correction
     else:
         raise BuildError("'pre' object '%s' not suitable for PES learning"
-                         % (conn.pre_obj))
+                         % (conn.pre_obj),
+                         [conn.pre_obj])
 
     # delta = local_error * activities
     model.add_op(Reset(model.sig[rule]['delta']))

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -37,7 +37,8 @@ def signal_probe(model, key, probe):
         sig = model.sig[probe.obj][key]
     except IndexError:
         raise BuildError(
-            "Attribute %r is not probeable on %s." % (key, probe.obj))
+            "Attribute %r is not probeable on %s." % (key, probe.obj),
+            [probe.obj])
 
     if probe.slice is not None:
         sig = sig[probe.slice]
@@ -102,7 +103,8 @@ def build_probe(model, probe):
             break
     else:
         raise BuildError(
-            "Type %r is not probeable" % type(probe.obj).__name__)
+            "Type %r is not probeable" % type(probe.obj).__name__,
+            [probe.obj])
 
     key = probeables[probe.attr] if probe.attr in probeables else probe.attr
     if key is None:

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -41,7 +41,18 @@ class ReadonlyError(ValidationError):
 
 
 class BuildError(NengoException, ValueError):
-    """A ValueError encountered during the build process."""
+    """A ValueError encountered during the build process.
+
+    Parameters
+    ----------
+    msg : str
+        Error message.
+    related_objects : sequence, optional
+        Nengo objects related to the error. These objects and their location in
+        the network hierarchy will be appended when the *BuildError* is
+        converted to a string and `store_containment_info` has been called
+        before.
+    """
 
     def __init__(self, msg, related_objects=None):
         super(BuildError, self).__init__()
@@ -52,6 +63,17 @@ class BuildError(NengoException, ValueError):
         self.containment = None
 
     def store_containment_info(self, toplevel_net):
+        """Gathers information about the hierarchy of related Nengo objects.
+
+        Once this information has been gathered, it will be appended when the
+        *BuildError* is converted to a string.
+
+        Parameters
+        ----------
+        toplevel_net : Network
+            The toplevel network containing the Nengo objects related to this
+            error.
+        """
         to_process = [(toplevel_net,)]
         self.containment = {}
         while len(to_process) > 0:

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -43,6 +43,12 @@ class ReadonlyError(ValidationError):
 class BuildError(NengoException, ValueError):
     """A ValueError encountered during the build process."""
 
+    def __init__(self, msg, related_objects=None):
+        super(BuildError, self).__init__(msg)
+        if related_objects is None:
+            related_objects = []
+        self.related_objects = related_objects
+
 
 class ObsoleteError(NengoException):
     """A feature that has been removed in a backwards-incompatible way."""

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -11,7 +11,8 @@ from nengo.builder import Model
 from nengo.builder.optimizer import optimize as opmerge_optimize
 from nengo.builder.signal import SignalDict
 from nengo.cache import get_default_decoder_cache
-from nengo.exceptions import ReadonlyError, SimulatorClosed, ValidationError
+from nengo.exceptions import (
+    BuildError, ReadonlyError, SimulatorClosed, ValidationError)
 from nengo.utils.compat import range, ResourceWarning
 from nengo.utils.graphs import toposort
 from nengo.utils.progress import ProgressTracker
@@ -154,7 +155,11 @@ class Simulator(object):
 
         if network is not None:
             # Build the network into the model
-            self.model.build(network, progress_bar=self.progress_bar)
+            try:
+                self.model.build(network, progress_bar=self.progress_bar)
+            except BuildError as err:
+                err.store_containment_info(network)
+                raise err
 
         # Order the steps (they are made in `Simulator.reset`)
         self.dg = operator_dependency_graph(self.model.operators)


### PR DESCRIPTION
**Motivation and context:**
BuildErrors often reference Nengo objects that caused the build failure. Unfortunately, it is usually hard to identify these objects in the model code if they do not have unique labels and we cannot provide the line number where the objects where defined. (I ran into this problem today while refactoring one of my models.) This PR adds information about the network hierarchy for the objects mentioned in the error message. While these could still all be unlabeled objects, it is much more common to have a network labeled than an other Nengo objects that are usually mentioned in the error message. It also tells you how deep in the hierarchy the object. Thus, I think this can make it significantly easier to identify the offending object.

At the current stage, this is primarily a proof of concept a working example to discuss. If there is consensus, that this is a worthwhile addition, I will think about adding a unit test and other code improvement (suggestions are also welcome).

**Interactions with other PRs:**
This is somewhat related to [discussion in](https://github.com/nengo/nengo/pull/1319#discussion_r120403498) #1319 whether to remove the memory addresses from the error messages. While this is technically independent, the added information could be less useful without a unique identifier (because you have to cross-reference the object from the object message to the network hierarchy display).

**How has this been tested?**
So far only manually with this script:
```python
import nengo

with nengo.Network(label='m1') as m1:
    n = nengo.Node(lambda t: t)

with nengo.Network(label='m2') as m2:
    e = nengo.Ensemble(10, 1)
    nengo.Connection(n, e)

with nengo.Simulator(m2) as sim:
    pass
```
The output is:
```
Building finished in 0:00:01.
Traceback (most recent call last):
  File "test.py", line 10, in <module>
    with nengo.Simulator(m2) as sim:
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/simulator.py", line 157, in __init__
    raise err
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/simulator.py", line 154, in __init__
    self.model.build(network, progress_bar=self.progress_bar)
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/builder/builder.py", line 123, in build
    built = self.builder.build(self, obj, *args, **kwargs)
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/builder/builder.py", line 219, in build
    return cls.builders[obj_cls](model, obj, *args, **kwargs)
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/builder/network.py", line 115, in build_network
    model.build(conn)
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/builder/builder.py", line 123, in build
    built = self.builder.build(self, obj, *args, **kwargs)
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/builder/builder.py", line 219, in build
    return cls.builders[obj_cls](model, obj, *args, **kwargs)
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/builder/connection.py", line 216, in build_connection
    model.sig[conn]['in'] = get_prepost_signal(is_pre=True)
  File "/Volumes/Home/blubb/Documents/projects/uni/nengo/nengo/builder/connection.py", line 207, in get_prepost_signal
    [conn, target])
nengo.exceptions.BuildError: Building <Connection from <Node (unlabeled) at 0x1033022b0> to <Ensemble (unlabeled) at 0x1058e1b70>>: the 'pre' object <Node (unlabeled) at 0x1033022b0> is not in the model, or has a size of zero.
Related objects:
    <Connection from <Node (unlabeled) at 0x1033022b0> to <Ensemble (unlabeled) at 0x1058e1b70>>
        in <Network "m2">
    <Node (unlabeled) at 0x1033022b0>
        (not in model)

```
Note that this makes it also evident that in this case the problem is the object not being in the model and not zero size.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.