### PR TITLE
Use Jupyter notebook terminology consistently

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,8 +19,8 @@ prune dist
 
 # Patterns to exclude from any directory
 global-exclude *.git*
-global-exclude *.ipynb_checkpoints*
 global-exclude *.tox*
+global-exclude *-checkpoint.ipynb
 
 # Exclude all bytecode
 global-exclude *.pyc *.pyo *.pyd

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -108,7 +108,7 @@ and ``requirements-docs.txt``, and can be installed with ``pip``:
    pip install -r requirements-test.txt
    pip install -r requirements-docs.txt
 
-However, one additional requirement for building the IPython notebooks
+However, one additional requirement for building the Jupyter notebooks
 that we include in the documentation is Pandoc_.
 If you use a package manager (e.g., Homebrew, ``apt``)
 you should be able to install Pandoc_ through your package manager.

--- a/nengo/ipynb.py
+++ b/nengo/ipynb.py
@@ -1,8 +1,8 @@
-"""IPython extension that activates special IPython notebook features of Nengo.
+"""IPython extension that activates special Jupyter notebook features of Nengo.
 
 At the moment this only activates the improved progress bar.
 
-Use ``%load_ext nengo.ipynb`` in an IPython notebook to load the extension.
+Use ``%load_ext nengo.ipynb`` in a Jupyter notebook to load the extension.
 
 Note
 ----

--- a/nengo/utils/docutils.py
+++ b/nengo/utils/docutils.py
@@ -112,9 +112,9 @@ class NotebookDirective(Directive):
             nb, image_dir=image_dir, image_rel_dir=image_rel_dir)
 
         # Create link to notebook and script files
-        link_rst = "Download ``%s`` as an %s or %s." % (
+        link_rst = "Download ``%s`` as a %s or %s." % (
             os.path.splitext(nb_basename)[0],
-            formatted_link(nb_basename, "IPython notebook"),
+            formatted_link(nb_basename, "Jupyter notebook"),
             formatted_link(rel_path_py, "Python script"))
 
         self.state_machine.insert_input([link_rst], rst_file)
@@ -158,7 +158,7 @@ def formatted_link(path, text=None):
 
 
 class notebook_node(nodes.raw):
-    """An evaluated IPython notebook"""
+    """An evaluated Jupyter notebook"""
 
 
 def visit_notebook_node(self, node):

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -102,7 +102,7 @@ def has_ipynb_widgets():
 
 
 def hide_input():
-    """Hide the input of the IPython notebook input block this is executed in.
+    """Hide the input of the Jupyter notebook input block this is executed in.
 
     Returns a link to toggle the visibility of the input block.
     """


### PR DESCRIPTION
**Motivation and context:**
The IPython notebook was rebranded the Jupyter notebook some time ago. We still had some instances of calling the notebook the IPython notebook; this PR ensures that we use "Jupyter notebook" in all instances.

Also made a minor change to the manifest to try to make sure `.ipynb_checkpoints` folders are not included in releases. For some reason excluding the folder is not sufficient (though it is sufficient for `.git` and others :confused:)

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [NA] I have included a changelog entry.
- [NA] I have added tests to cover my changes.
- [x] All new and existing tests passed.
