### PR TITLE
Fix test for ensemble tuning curves (numpy 1.13 compatibility)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
 
 env:
   global:
-    - NUMPY="1.12"
+    - NUMPY="1.13"
     - SCIPY="false"
     - COVERAGE="false"
     - STATIC="false"
@@ -22,6 +22,7 @@ matrix:
     - env: PYTHON="2.7" NUMPY="1.9"
     - env: PYTHON="2.7" NUMPY="1.10"
     - env: PYTHON="2.7" NUMPY="1.11"
+    - env: PYTHON="2.7" NUMPY="1.12"
     - env: PYTHON="3.4" NUMPY="1.11"  # 1.12 not packaged for py34 in conda
     - env: PYTHON="3.5"
     - env: PYTHON="3.6" COVERAGE="true" SCIPY="true"

--- a/nengo/utils/ensemble.py
+++ b/nengo/utils/ensemble.py
@@ -36,7 +36,7 @@ def tuning_curves(ens, sim, inputs=None):
         The activities of the individual neurons given the `inputs`.
         For ensembles with 1 dimension, the rows correspond to the `inputs`
         and the columns to individual neurons.
-        For ensembles with > 1 dimension, the first dimension enumerates the
+        For ensembles with > 1 dimension, the last dimension enumerates the
         neurons, the remaining dimensions map to `inputs`.
 
     See Also

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -50,8 +50,8 @@ def test_tuning_curves(Simulator, nl_nodirect, plt, seed, dimensions):
 
     assert np.all(activities >= 0)
 
-    d = np.sqrt(np.sum(np.asarray(eval_points) ** 2, axis=0))
-    assert np.all(activities[:, d <= radius] <= max_rate)
+    d = np.sqrt(np.sum(np.asarray(eval_points) ** 2, axis=-1))
+    assert np.all(activities[d <= radius] <= max_rate)
 
 
 @pytest.mark.parametrize('dimensions', [1, 2])


### PR DESCRIPTION
The test was actually broken, but the error was hidden by a deprecation warning.  But that warning becomes an error in numpy 1.13, so we need to fix this for compatibility.

It might be good to make a bugfix release with this soonish, as right now if you do a fresh install of `nengo` it comes with `numpy` 1.13, and the unit tests don't pass.

Also, if we wanted to drop support for any old numpy versions, now might be a good time to do it.

**How has this been tested?**
Fixed one unit tests, and updated travis-ci tests to include numpy 1.13.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
