### PR TITLE
Fix Connection transform validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ Release History
 - The error raised when a ``Connection`` function returns ``None``
   is now more clear.
   (`#1319 <https://github.com/nengo/nengo/pull/1319>`_)
+- We now raise an error when a ``Connection`` transform is set to ``None``.
+  (`#1326 <https://github.com/nengo/nengo/pull/1326>`_)
 
 **Fixed**
 

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -223,7 +223,7 @@ class TransformParam(DistOrArrayParam):
             name, default, (), optional, readonly)
 
     def coerce(self, conn, transform):
-        if not isinstance(transform, Distribution):
+        if transform is not None and not isinstance(transform, Distribution):
             # if transform is an array, figure out what the correct shape
             # should be
             transform = np.asarray(transform, dtype=np.float64)

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -965,3 +965,11 @@ def test_function_returns_none_error(Simulator):
     with pytest.raises(BuildError):
         with nengo.Simulator(model):
             pass
+
+
+def test_connection_none_error():
+    with nengo.Network():
+        a = nengo.Node([0])
+        b = nengo.Node(size_in=1)
+        with pytest.raises(ValidationError):
+            nengo.Connection(a, b, transform=None)


### PR DESCRIPTION
It should raise an error if `transform=None` (since `optional=False`), but it wasn't because it was being cast to `np.array(None)`.

**How has this been tested?**
Added a new test, existing tests pass.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
