### PR TITLE
Add functions to compute max_rates and intercepts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Release History
 - Added ``LinearFilter.combine`` method to
   combine two ``LinearFilter`` instances.
   (`#1312 <https://github.com/nengo/nengo/pull/1312>`_)
+- Added a method to all neuron types to compute ensemble
+  ``max_rates`` and ``intercepts`` given ``gain`` and ``bias``.
+  (`#1334 <https://github.com/nengo/nengo/pull/1334>`_)
 
 **Changed**
 

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -86,7 +86,8 @@ def get_gain_bias(ens, rng=np.random):
     if ens.gain is not None and ens.bias is not None:
         gain = get_samples(ens.gain, ens.n_neurons, rng=rng)
         bias = get_samples(ens.bias, ens.n_neurons, rng=rng)
-        max_rates, intercepts = None, None  # TODO: determine from gain & bias
+        max_rates, intercepts = ens.neuron_type.max_rates_intercepts(
+            gain, bias)
     elif ens.gain is not None or ens.bias is not None:
         # TODO: handle this instead of error
         raise NotImplementedError("gain or bias set for %s, but not both. "

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
 import logging
+import warnings
 
 import numpy as np
 
@@ -88,7 +89,7 @@ class NeuronType(FrozenObject):
             J_max += 10
             J = np.linspace(-J_max, J_max, J_steps)
             rate = self.rates(J, gain, bias)
-        J_threshold = J[np.where(rate <= 1e-16)[0][-1]]
+        J_threshold = J[np.where(rate <= 0)[0][-1]]
 
         gain = np.zeros_like(max_rates)
         bias = np.zeros_like(max_rates)
@@ -108,6 +109,37 @@ class NeuronType(FrozenObject):
             bias[i] = J_top - gain[i]
 
         return gain, bias
+
+    def max_rates_intercepts(self, gain, bias):
+        """Compute the max_rates and intercepts given gain and bias.
+
+        Note that this default implementation is very slow! Whenever possible,
+        subclasses should override this with a neuron-specific implementation.
+
+        Parameters
+        ----------
+        gain : (n_neurons,) array_like
+            Gain associated with each neuron. Sometimes denoted alpha.
+        bias : (n_neurons,) array_like
+            Bias current associated with each neuron.
+
+        Returns
+        -------
+        max_rates : (n_neurons,) array_like
+            Maximum firing rates of neurons.
+        intercepts : (n_neurons,) array_like
+            X-intercepts of neurons.
+        """
+
+        max_rates = self.rates(np.ones_like(gain), gain, bias)
+
+        x_range = np.linspace(-1, 1, 101)
+        rates = np.asarray([self.rates(np.ones_like(gain) * x, gain, bias)
+                            for x in x_range])
+        last_zeros = np.maximum(np.argmax(rates > 0, axis=0) - 1, 0)
+        intercepts = x_range[last_zeros]
+
+        return max_rates, intercepts
 
     def rates(self, x, gain, bias):
         """Compute firing rates (in Hz) for given vector input, ``x``.
@@ -168,6 +200,10 @@ class Direct(NeuronType):
         """Always returns ``None, None``."""
         return None, None
 
+    def max_rates_intercepts(self, gain, bias):
+        """Always returns ``None, None``."""
+        return None, None
+
     def rates(self, x, gain, bias):
         """Always returns ``x``."""
         return np.array(x, dtype=float, copy=False, ndmin=1)
@@ -203,6 +239,12 @@ class RectifiedLinear(NeuronType):
         bias = -intercepts * gain
         return gain, bias
 
+    def max_rates_intercepts(self, gain, bias):
+        """Compute the inverse of gain_bias."""
+        intercepts = -bias / gain
+        max_rates = gain * (1 - intercepts)
+        return max_rates, intercepts
+
     def step_math(self, dt, J, output):
         """Implement the rectification nonlinearity."""
         output[...] = np.maximum(0., J)
@@ -237,6 +279,14 @@ class Sigmoid(NeuronType):
         gain = inverse / (1. - intercepts)
         bias = inverse - gain
         return gain, bias
+
+    def max_rates_intercepts(self, gain, bias):
+        """Compute the inverse of gain_bias."""
+        inverse = gain + bias
+        intercepts = 1 - inverse / gain
+        lim = 1. / self.tau_ref
+        max_rates = lim / (1 + np.exp(-inverse))
+        return max_rates, intercepts
 
     def step_math(self, dt, J, output):
         """Implement the sigmoid nonlinearity."""
@@ -291,6 +341,16 @@ class LIFRate(NeuronType):
         gain = (1 - x) / (intercepts - 1.0)
         bias = 1 - gain * intercepts
         return gain, bias
+
+    def max_rates_intercepts(self, gain, bias):
+        """Compute the inverse of gain_bias."""
+        intercepts = (1 - bias) / gain
+        max_rates = 1.0 / (self.tau_ref - self.tau_rc * np.log1p(
+            1.0 / (gain * (intercepts - 1) - 1)))
+        if not np.all(np.isfinite(max_rates)):
+            warnings.warn("Non-finite values detected in `max_rates`; this "
+                          "probably means that `gain` was too small.")
+        return max_rates, intercepts
 
     def rates(self, x, gain, bias):
         """Always use LIFRate to determine rates."""

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -886,13 +886,13 @@ def test_function_points(Simulator, seed, rng, plt):
                     buf=0.01, delay=0.005, atol=5e-2, rtol=3e-2, plt=plt)
 
 
-def test_connectionfunctionparam_array(RefSimulator):
+def test_connectionfunctionparam_array(RefSimulator, seed):
     points_1d = np.zeros((100, 1))
     points_2d = np.zeros((100, 2))
     points_v = np.zeros((100,))
     points_50 = np.zeros((50, 1))
 
-    with nengo.Network() as model:
+    with nengo.Network(seed=seed) as model:
         a = nengo.Ensemble(10, 1)
         b = nengo.Ensemble(10, 1)
 
@@ -913,7 +913,9 @@ def test_connectionfunctionparam_array(RefSimulator):
             nengo.Connection(a, b, eval_points=points_1d, function=points_2d)
 
         nengo.Connection(a, b, eval_points=points_1d, function=points_1d)
-        nengo.Connection(a, b, eval_points=points_1d, function=points_2d,
+        nengo.Connection(a, b,
+                         eval_points=points_1d,
+                         function=points_2d,
                          transform=np.ones((1, 2)))
 
     with RefSimulator(model):


### PR DESCRIPTION
**Motivation and context:**

Each neuron type has a function that computes gains and biases given max_rates and intercepts.  This adds a function to each neuron type that does the inverse, computing max_rates and intercepts from gains and biases.

I don't love the name `max_rates_intercepts`, given the awkward double `_`, but I went with that for symmetry with `gain_bias`.

**How has this been tested?**
Added a new unit test, see `test_neurons.py:test_gain_bias`

**How long should this take to review?**
- Average (neither quick nor lengthy)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
