### PR TITLE
Prevent crash when cache shrink fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ Release History
   Previously, this was the case for decoded connections
   but not neuron-to-neuron connections.
   (`#1330 <https://github.com/nengo/nengo/pull/1330>`_)
+- Fixed a crash when a lock cannot be acquired while shrinking the cache.
+  (`#1335 <https://github.com/nengo/nengo/issues/1335>`_,
+  `#1336 <https://github.com/nengo/nengo/pull/1336>`_)
 
 2.4.0 (April 18, 2017)
 ======================

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -606,13 +606,16 @@ class DecoderCache(object):
         # Remove the least recently accessed first
         fileinfo.sort()
 
-        with self._index:
-            for _, size, path in fileinfo:
-                if excess <= 0:
-                    break
+        try:
+            with self._index:
+                for _, size, path in fileinfo:
+                    if excess <= 0:
+                        break
 
-                excess -= size
-                self.remove_file(path)
+                    excess -= size
+                    self.remove_file(path)
+        except TimeoutError:
+            logger.debug("Not shrinking cache. Lock could not be acquired.")
 
     def remove_file(self, path):
         """Removes the file at ``path`` from the cache."""

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -648,3 +648,12 @@ def test_writeablecacheindex_warning(monkeypatch, tmpdir):
     with warns(CacheIOWarning):
         with WriteableCacheIndex(cache_dir=str(tmpdir)):
             pass
+
+
+def test_shrink_does_not_fail_if_lock_cannot_be_acquired(tmpdir):
+    cache = DecoderCache(cache_dir=str(tmpdir))
+    cache._index._lock.timeout = 1.
+    with cache:
+        cache.wrap_solver(SolverMock())(**get_solver_test_args())
+    with cache._index._lock:
+        cache.shrink(limit=0)


### PR DESCRIPTION
**Motivation and context:**
This prevents from Nengo crashing (exiting with an exception) when the cache shrink fails because of an unavailable lock.

Fixes #1335.

**Interactions with other PRs:**
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Added a test. It needs to access some cache internals which might not be the best style, but it seems to be the easiest way to test it and I don't think the index or lock should be public.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.