### PR TITLE
No memoize

### DIFF
--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -6,7 +6,6 @@ import nengo
 from nengo.exceptions import ValidationError
 from nengo.networks.product import Product
 from nengo.utils.compat import range
-from nengo.utils.magic import memoize
 
 
 def circconv(a, b, invert_a=False, invert_b=False, axis=-1):
@@ -20,7 +19,6 @@ def circconv(a, b, invert_a=False, invert_b=False, axis=-1):
     return np.fft.ifft(A * B, axis=axis).real
 
 
-@memoize
 def transform_in(dims, align, invert):
     """Create a transform to map the input into the Fourier domain.
 
@@ -83,7 +81,6 @@ def remove_imag_rows(tr):
         tr = tr[(i == 0) | (i > 3)]
 
 
-@memoize
 def dft_half(n):
     x = np.arange(n)
     w = np.arange(n // 2 + 1)

--- a/nengo/utils/magic.py
+++ b/nengo/utils/magic.py
@@ -263,41 +263,6 @@ def decorator(wrapper):
     return FunctionWrapper(wrapper, _wrapper)
 
 
-def callable_decorator(callable_wrapper):
-    """Decorates callable decorators.
-
-    Similar to @decorator, except applied to anything that returns a wrapper
-    function, such as a callable class. Every use of the decorator results
-    in a different callable. This is useful if your callable decorator needs to
-    maintain state pertaining to the wrapped function, such as a cache.
-
-    The wrapping callable can be accessed via func.wrapper, where func is the
-    wrapped function. See memoize for an example.
-    """
-    def wrapper(wrapped):
-        return decorator(callable_wrapper())(wrapped)
-    return wrapper
-
-
-@callable_decorator
-class memoize(object):
-    """Memoizes a function based on the given arguments."""
-
-    def __init__(self):
-        self._cache = {}
-        self.hits = 0
-        self.misses = 0
-
-    def __call__(self, wrapped, instance, args, kwargs):
-        key = (instance, tuple(args), tuple(sorted(iteritems(kwargs))))
-        if key not in self._cache:
-            self._cache[key] = wrapped(*args, **kwargs)
-            self.misses += 1
-        else:
-            self.hits += 1
-        return self._cache[key]
-
-
 class DocstringInheritor(type):
     '''Metaclass to inherit docstrings from parents.
 

--- a/nengo/utils/tests/test_magic.py
+++ b/nengo/utils/tests/test_magic.py
@@ -1,6 +1,6 @@
 import inspect
 
-from nengo.utils.magic import decorator, memoize
+from nengo.utils.magic import decorator
 
 state = None  # Used to make sure decorators are running
 
@@ -204,62 +204,3 @@ def test_class():
                                     '        def __init__(self, a, b):\n'
                                     '            self.a = a\n'
                                     '            self.b = b\n')
-
-
-def test_memoize():  # noqa: C901
-    """Test that the memoize decorator works in several contexts."""
-
-    @memoize
-    def f():
-        return 'f'
-
-    @memoize
-    def f_args(a, b=5):
-        return a + b
-
-    class Test(object):
-        @memoize
-        def inst_f(self):
-            return 'inst_f'
-
-        @memoize
-        @classmethod
-        def cls_f(cls):
-            return 'cls_f'
-
-        @memoize
-        @staticmethod
-        def static_f():
-            return 'static_f'
-
-        @property
-        @memoize
-        def prop(self):
-            return 'prop'
-
-    def check_all(inst, hits, misses):
-        # Check return values
-        assert f() == f.__name__
-        assert inst.inst_f() == inst.inst_f.__name__
-        assert Test.cls_f() == Test.cls_f.__name__
-        assert Test.static_f() == Test.static_f.__name__
-        assert inst.prop == 'prop'
-        assert f_args(1) == 6
-        assert f_args(a=10) == 15
-        assert f_args(1, 2) == 3
-        assert f_args(1, b=100) == 101
-
-        # Check hits and misses
-        for func in f, inst.inst_f, Test.cls_f, Test.static_f, Test.prop.fget:
-            assert func.wrapper.hits == hits
-            assert func.wrapper.misses == misses
-        assert f_args.wrapper.hits == 4 * hits
-        assert f_args.wrapper.misses == 4 * misses
-
-    inst = Test()
-
-    # First run should be all misses
-    check_all(inst, 0, 1)
-
-    # Second run should be all hits
-    check_all(inst, 1, 1)


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->
I was changing the transforms on the connections of `CircularConvolution` in place. This had the effect of not only changing a single instance, but messing with all `CircularConvolution` instances (including future ones). It took me quite a while to figure out what was going on: [The `memoize` property on the input transform](https://github.com/nengo/nengo/blob/master/nengo/networks/circularconvolution.py#L23) caches the matrix to be reused by all circluar convolutions (of given dimension). This PR removes the memoize property from the input transform

This is only relevant in very specific cases, but then again it doesn't seem like the memoize optimization will give a large speed up.

Because `memoize` was only used in one more place where it also doesn't seem very necessary, I removed `memoize` and related code completely in a second commit. It does not make that much sense to keep that code around and maintain if it is not really used and if we ever need it back, it can be retrieved from the VCS/git.

But I'm willing ok with not merging either or both commits if there is some opposition.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
nengo_spa needs a similar PR as it copied the circular convolution implementation.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
existing tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.