### PR TITLE
Build docs with TravisCI, use nengo.ai

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - SCIPY="false"
     - COVERAGE="false"
     - STATIC="false"
+    - DOCS="false"
     - CONDA_DEPS="matplotlib jupyter"
     - PIP_DEPS="pytest pytest-xdist"
 
@@ -26,6 +27,7 @@ matrix:
     - env: PYTHON="3.4" NUMPY="1.11"  # 1.12 not packaged for py34 in conda
     - env: PYTHON="3.5"
     - env: PYTHON="3.6" COVERAGE="true" SCIPY="true"
+    - env: PYTHON="3.6" DOCS="true"
 
 # Setup Miniconda
 before_install:
@@ -45,6 +47,9 @@ install:
     elif [[ "$STATIC" == "true" ]]; then
       export CONDA_DEPS="";
       export PIP_DEPS="flake8 pylint";
+    elif [[ "$DOCS" == "true" ]]; then
+      export CONDA_DEPS="matplotlib";
+      export PIP_DEPS="ipython[all]==2.4.1 sphinx ghp-import -e git+https://github.com/tbekolay/guzzle_sphinx_theme.git@use_smartypants#egg=guzzle_sphinx_theme";
     fi
   - if [[ -n "$NUMPY" && "$STATIC" == "false" ]]; then
       export CONDA_DEPS="$CONDA_DEPS numpy=$NUMPY";
@@ -59,19 +64,31 @@ install:
 script:
   - mkdir -p "$HOME/.ipython/profile_default"
   - "echo 'c.HistoryAccessor.enabled = False\n' > $HOME/.ipython/profile_default/ipython_config.py"
-  - if [[ "$STATIC" == "false" ]]; then
+  - if [[ "$STATIC" == "true" ]]; then
+      flake8 -v nengo && pylint nengo;
+    else
       python -c "import numpy; numpy.show_config()";
       python setup.py -q develop;
-      if [[ "$COVERAGE" == "false" ]]; then
-        py.test nengo -n 2 -v --duration 20;
-      else
+      if [[ "$COVERAGE" == "true" ]]; then
         coverage run --rcfile .coveragerc --source nengo -m py.test nengo -v --duration 20 && coverage report;
+      elif [[ "$DOCS" == "true" ]]; then
+        if [[ -n "$TRAVIS_TAG" ]]; then
+          rm "$HOME/.ipython/profile_default/ipython_config.py";
+          sphinx-build -W docs docs/_build;
+        fi
+      else
+        py.test nengo -n 2 -v --duration 20;
       fi
-    else
-      flake8 -v nengo && pylint nengo;
     fi
 
 after_success:
   - if [[ "$COVERAGE" == "true" ]]; then
       eval "bash <(curl -s https://codecov.io/bash)";
+    fi
+  - if [[ -n "$TRAVIS_TAG" && "$DOCS" == "true" ]]; then
+      export DATE=$(date '+%Y-%m-%d %T');
+      git config --global user.email "travis@travis-ci.org";
+      git config --global user.name "TravisCI";
+      ghp-import -m "Last update at $DATE" -b gh-pages docs/_build;
+      git push -fq "https://$GH_TOKEN@github.com/nengo/nengo.git" gh-pages;
     fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,7 +63,7 @@ Release History
   use ``EnsembleArray.n_neurons_per_ensemble``.
   (`#1186 <https://github.com/nengo/nengo/pull/1186>`_)
 - The `Nengo modelling API document
-  <http://pythonhosted.org/nengo/frontend_api.html>`_
+  <https://www.nengo.ai/nengo/frontend_api.html>`_
   now has summaries to help navigate the page.
   (`#1304 <https://github.com/nengo/nengo/pull/1304>`_)
 - The error raised when a ``Connection`` function returns ``None``
@@ -185,7 +185,7 @@ Release History
   (`#1176 <https://github.com/nengo/nengo/issues/1176>`_,
   `#1183 <https://github.com/nengo/nengo/pull/1183>`_)
 - Documentation that applies to all Nengo projects has been moved to
-  https://nengo.github.io/.
+  https://www.nengo.ai/.
   (`#1251 <https://github.com/nengo/nengo/pull/1251>`_)
 
 2.3.0 (November 30, 2016)
@@ -206,7 +206,7 @@ Release History
 - Added ``nengo.dists.get_samples`` function for convenience
   when working with distributions or samples.
   (`#1181 <https://github.com/nengo/nengo/pull/1181>`_,
-  `docs <http://pythonhosted.org/nengo/frontend_api.html#nengo.dists.get_samples>`_)
+  `docs <https://www.nengo.ai/nengo/frontend_api.html#nengo.dists.get_samples>`_)
 
 **Changed**
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,8 +26,7 @@ Ensure that you fill out all sections of the pull request template,
 deleting the comments as you go.
 We check most aspects of code style automatically.
 Please refer to our
-`code style guide
-<http://pythonhosted.org/nengo/dev_introduction.html#code-style>`_
+`code style guide <https://www.nengo.ai/style.html>`_
 for things that we check manually.
 
 Contributor agreement
@@ -35,11 +34,11 @@ Contributor agreement
 
 We require that all contributions be covered under
 our contributor assignment agreement. Please see
-`the agreement <https://nengo.github.io/caa.html>`_
+`the agreement <https://www.nengo.ai/caa.html>`_
 for instructions on how to sign.
 
 More details
 ============
 
 For more details on how to contribute to Nengo, please see our
-`developer guide <http://pythonhosted.org/nengo/dev_guide.html>`_.
+`developer guide <https://www.nengo.ai/developers.html>`_.

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -9,7 +9,7 @@ all Nengo code, except for code that is used under
 various licenses, as described in the ``LICENSE.rst`` file.
 
 By adding your name to this file, you are agreeing to the
-`Nengo Contributor Assignment Agreement <https://nengo.github.io/caa.html>`_.
+`Nengo Contributor Assignment Agreement <https://www.nengo.ai/caa.html>`_.
 If you agree, then add yourself to the file like so::
 
   - Name <email address>

--- a/README.rst
+++ b/README.rst
@@ -37,11 +37,11 @@ To install Nengo::
 If you have difficulty installing Nengo or NumPy,
 please read the more detailed
 `Nengo installation instructions
-<https://pythonhosted.org/nengo/getting_started.html#installation>`_ first.
+<https://www.nengo.ai/nengo/getting_started.html#installation>`_ first.
 
 If you'd like to install Nengo from source,
 please read the `developer installation instructions
-<https://pythonhosted.org/nengo/contributing.html#developer-installation>`_.
+<https://www.nengo.ai/nengo/contributing.html#developer-installation>`_.
 
 Nengo is tested to work on Python 2.7 and 3.4+.
 
@@ -49,34 +49,34 @@ Examples
 ========
 
 Here are six of
-`many examples <https://pythonhosted.org/nengo/examples.html>`_
+`many examples <https://www.nengo.ai/nengo/examples.html>`_
 showing how Nengo enables the creation and simulation of
 large-scale neural models in few lines of code.
 
 1. `100 LIF neurons representing a sine wave
-   <https://pythonhosted.org/nengo/examples/many_neurons.html>`_
+   <https://www.nengo.ai/nengo/examples/many_neurons.html>`_
 2. `Computing the square across a neural connection
-   <https://pythonhosted.org/nengo/examples/squaring.html>`_
+   <https://www.nengo.ai/nengo/examples/squaring.html>`_
 3. `Controlled oscillatory dynamics with a recurrent connection
-   <https://pythonhosted.org/nengo/examples/controlled_oscillator.html>`_
+   <https://www.nengo.ai/nengo/examples/controlled_oscillator.html>`_
 4. `Learning a communication channel with the PES rule
-   <https://pythonhosted.org/nengo/examples/learn_communication_channel.html>`_
+   <https://www.nengo.ai/nengo/examples/learn_communication_channel.html>`_
 5. `Simple question answering with the Semantic Pointer Architecture
-   <https://pythonhosted.org/nengo/examples/question.html>`_
+   <https://www.nengo.ai/nengo/examples/question.html>`_
 6. `A summary of the principles underlying all of these examples
-   <https://pythonhosted.org/nengo/examples/nef_summary.html>`_
+   <https://www.nengo.ai/nengo/examples/nef_summary.html>`_
 
 Documentation
 =============
 
 Usage and API documentation can be found at
-`<https://pythonhosted.org/nengo/>`_.
+`<https://www.nengo.ai/nengo/>`_.
 
 Development
 ===========
 
 Information for current or prospective developers can be found
-at `<https://pythonhosted.org/nengo/dev_guide.html>`_.
+at `<https://www.nengo.ai/developers.html>`_.
 
 Getting Help
 ============

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,16 @@
+.MathJax .mi, .MathJax .mo {
+    color: inherit;
+}
+
+pre, kdb, samp, code, .rst-content tt, .rst-content code {
+    word-break: inherit;
+}
+
 code, .rst-content tt, .rst-content code {
     white-space: pre-wrap;
+}
+
+#notebook .container {
+    padding-left: 0;
+    width: inherit;
 }

--- a/docs/_templates/globaltoc.html
+++ b/docs/_templates/globaltoc.html
@@ -1,0 +1,13 @@
+<div class="sidebar-block">
+  <div class="sidebar-wrapper">
+    <h2>{{ _('Table Of Contents') }}</h2>
+  </div>
+  <div class="sidebar-toc">
+    {% set toctree = toctree(maxdepth=3, collapse=True) %}
+    {% if toctree %}
+      {{ toctree }}
+    {% else %}
+      {{ toc }}
+    {% endif %}
+  </div>
+</div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,8 @@
+{# Import the theme's layout. #}
+{% extends "!layout.html" %}
+
+{%- block extrahead %}
+<link rel="stylesheet" type="text/css" href="{{ pathto("_static/custom.css", 1) }}">
+{# Call the parent block #}
+{{ super() }}
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ html_theme = "guzzle_sphinx_theme"
 
 html_theme_options = {
     "project_nav_name": "Nengo core %s" % (version,),
-    "base_url": "http://www.nengo.ai/nengo",
+    "base_url": "https://www.nengo.ai/nengo",
 }
 
 html_title = "Nengo core {0} docs".format(release)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,9 +8,9 @@ import sys
 
 try:
     import nengo
-    import sphinx_rtd_theme
+    import guzzle_sphinx_theme
 except ImportError:
-    print("To build the documentation, nengo and sphinx_rtd_theme must be "
+    print("To build the documentation, nengo and guzzle_sphinx_theme must be "
           "installed in the current environment. Please install these and "
           "their requirements first. A virtualenv is recommended!")
     sys.exit(1)
@@ -18,10 +18,12 @@ except ImportError:
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.githubpages',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'guzzle_sphinx_theme',
     'numpydoc',
     'nengo.utils.docutils',
 ]
@@ -62,15 +64,20 @@ pygments_style = 'default'
 
 # -- Options for HTML output --------------------------------------------------
 
-html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_title = "Nengo {0} docs".format(release)
-html_static_path = ['_static']
-html_context = {
-    'css_files': [os.path.join('_static', 'custom.css')],
+pygments_style = "sphinx"
+templates_path = ["_templates"]
+html_static_path = ["_static"]
+
+html_theme_path = guzzle_sphinx_theme.html_theme_path()
+html_theme = "guzzle_sphinx_theme"
+
+html_theme_options = {
+    "project_nav_name": "Nengo core %s" % (version,),
+    "base_url": "http://www.nengo.ai/nengo",
 }
-html_use_smartypants = True
-htmlhelp_basename = 'Nengodoc'
+
+html_title = "Nengo core {0} docs".format(release)
+htmlhelp_basename = 'Nengo core'
 html_last_updated_fmt = ''  # Suppress 'Last updated on:' timestamp
 html_show_sphinx = False
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,7 +5,7 @@ Contributing to Nengo
 .. default-role:: obj
 
 Please read our
-`general contributing guide <https://nengo.github.io/contributing.html>`_
+`general contributing guide <https://www.nengo.ai/contributing.html>`_
 first.
 The instructions below specifically apply
 to the ``nengo`` project.

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -3,7 +3,7 @@ Nengo examples
 **************
 
 For more information about these examples, see the
-`Nengo documentation <https://pythonhosted.org/nengo/examples.html>`_.
+`Nengo documentation <https://www.nengo.ai/nengo/examples.html>`_.
 
 ``basic``: Basic models
 =======================

--- a/examples/basic/multiplication.ipynb
+++ b/examples/basic/multiplication.ipynb
@@ -327,7 +327,7 @@
      "metadata": {},
      "source": [
       "Alternatively, you can use Nengo's built in\n",
-      "[`nengo.networks.Product` network](http://pythonhosted.org/nengo/networks.html#product).\n",
+      "[`nengo.networks.Product` network](https://www.nengo.ai/nengo/networks.html#nengo.networks.Product).\n",
       "This network works with input of any dimensionality\n",
       "(e.g., to compute the dot product of two large vectors)\n",
       "and uses special optimizatons to make the product\n",

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -9,7 +9,7 @@ https://www.github.com/nengo/nengo. Examples of models can be found
 in the `examples` directory of the source code repository.
 """
 
-__copyright__ = "2013-2014, Applied Brain Research"
+__copyright__ = "2013-2017, Applied Brain Research"
 __license__ = "Free for non-commercial use; see LICENSE.rst"
 from .version import version as __version__
 

--- a/nengo/networks/product.py
+++ b/nengo/networks/product.py
@@ -12,7 +12,7 @@ def Product(n_neurons, dimensions, input_magnitude=1., net=None, **kwargs):
     The network used to calculate the product is described in
     `Gosmann, 2015`_. A simpler version of this network can be found in the
     `Multiplication example
-    <http://pythonhosted.org/nengo/examples/multiplication.html>`_.
+    <https://www.nengo.ai/nengo/examples/multiplication.html>`_.
 
     Note that this network is optimized under the assumption that both input
     values (or both values for each input dimensions of the input vectors) are


### PR DESCRIPTION
**Motivation and context:**
Currently Nengo core's documentation is the only set of docs hosted on pythonhosted.org. It's pretty unreliable, and really all of the docs should be found on the nengo.ai domain.

This PR has TravisCI build the docs and push them to `gh-pages` when tags are pushed, but not when any branch is pushed, since building the docs takes some time. This also switches the doc theme to Guzzle, which the rest of the docs use.

**How has this been tested?**
I originally had this build on all pushes to generate http://www.nengo.ai/nengo/ ; I then amended in the check for the `$TRAVIS_TAG` environment variable.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
Probably check `.travis.yml` first. For reviewing doc changes, the rendered version is at http://www.nengo.ai/nengo/

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] All new and existing tests passed.
