### PR TITLE
Use Simulator with `with` in documenation.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,8 +24,8 @@ with sensible defaults in few lines of code::
         # View the decoded output of sin_squared
         squared_probe = nengo.Probe(sin_squared, synapse=0.01)
 
-    sim = nengo.Simulator(net)
-    sim.run(5.0)
+    with nengo.Simulator(net) as sim:
+        sim.run(5.0)
     plt.plot(sim.trange(), sim.data[squared_probe])
     plt.show()
 


### PR DESCRIPTION
**Motivation and context:**
Use the simulator in the introductory example in the documentaiton within a `with` statement to be consistent with other examples and because it is best practice (in case the reference Simulator is replaced by one that requires a close).

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
documentation change only

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry. (I don't think this needs a changelog entry, or does it?)
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
