### PR TITLE
Remove deffective links from documentation.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,9 +43,4 @@ different neural simulator.
    user_guide
    dev_guide
 
-Indices and tables
-==================
-
 * :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
**Motivation and context:**
This removes the links to the module index and search page from the documentation front page.

We don't generate a module index because we manually list frontend API
classes (and don't include the documentation of the containing modules).

The link to the search page is not required as the actual search
function is provided in the sidebar for the theme that we use. (It
could work better, in particular provide better suggestions when
typing, but it isn't completely broken.)

Fixes #1316.

**Interactions with other PRs:**
none

**How has this been tested?**
documentation change only

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.