### PR TITLE
Report the number of runnable tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ Release History
 - We now warn that the progress bar is not supported in Jupyter Notebook <5.
   (`#1428 <https://github.com/nengo/nengo/pull/1428>`__,
   `#1426 <https://github.com/nengo/nengo/issues/1426>`__)
+- Added information about number of runnable tests to pytest summary
+  (`#1082 <https://github.com/nengo/nengo/issues/1082>`_,
+  `#1350 <https://github.com/nengo/nengo/pull/1350>`_)
 
 **Changed**
 


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->
This adds a line (or more) to the pytest output indicating the number of total runnable tests and how many have run. It also adds lines explaining why some tests are not runnable. For example compare and non-compare tests are mutually exclusive and frontend tests aren't run for non-reference backends. But these will still be counted in the number of skipped tests which means that number will never be zero and thus cannot be used as an indicator whether the complete test suite ran.

I'm not entirely sure about the best way to present this information and the wording can probably be still improved. But at least the harder (?) part of writing the logic is done.

Closes #1082.

**Interactions with other PRs:**
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Manually by running pytest with different arguments.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you stil plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [ ] better wording maybe?