### PR TITLE
Added 'NoSolver' solver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ Release History
 2.5.1 (unreleased)
 ==================
 
+**Added**
+
+- Added a ``NoSolver`` solver that can be used to manually pass in
+  a predefined set of decoders or weights to a connection.
+  (`#1352 <https://github.com/nengo/nengo/pull/1352>`_)
+
 **Changed**
 
 - Learning rules can now have a learning rate of 0.

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -204,6 +204,7 @@ Decoder and connection weight solvers
    nengo.solvers.Nnls
    nengo.solvers.NnlsL2
    nengo.solvers.NnlsL2nz
+   nengo.solvers.NoSolver
 
 .. autoclass:: nengo.solvers.Solver
    :special-members: __call__
@@ -227,3 +228,5 @@ Decoder and connection weight solvers
 .. autoclass:: nengo.solvers.NnlsL2
 
 .. autoclass:: nengo.solvers.NnlsL2nz
+
+.. autoclass:: nengo.solvers.NoSolver

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -13,7 +13,8 @@ import numpy as np
 
 import nengo.utils.least_squares_solvers as lstsq
 from nengo.exceptions import ValidationError
-from nengo.params import BoolParam, FrozenObject, NumberParam, Parameter
+from nengo.params import (
+    BoolParam, FrozenObject, NdarrayParam, NumberParam, Parameter)
 from nengo.utils.compat import range, with_metaclass
 from nengo.utils.least_squares_solvers import (
     format_system, rmses, LeastSquaresSolverParam)
@@ -50,7 +51,7 @@ class Solver(with_metaclass(DocstringInheritor, FrozenObject)):
 
         Returns
         -------
-        X :  (n_neurons, dimensions) or (n_neurons, post.n_neurons) ndarray
+        X : (n_neurons, dimensions) or (n_neurons, post.n_neurons) ndarray
             (n_neurons, dimensions) array of decoders (if ``solver.weights``
             is False) or (n_neurons, post.n_neurons) array of weights
             (if ``'solver.weights`` is True).
@@ -495,3 +496,50 @@ class NnlsL2nz(NnlsL2):
         sigma = (self.reg * A.max()) * np.sqrt((A > 0).mean(axis=0))
         sigma[sigma == 0] = 1
         return self._solve(A, Y, rng, E, sigma=sigma)
+
+
+class NoSolver(Solver):
+    """Manually pass in weights, bypassing the decoder solver.
+
+    Parameters
+    ----------
+    values : (n_neurons, n_weights) array_like, optional (Default: None)
+        The array of decoders or weights to use.
+        If ``weights`` is ``False``, ``n_weights`` is the expected
+        output dimensionality. If ``weights`` is ``True``,
+        ``n_weights`` is the number of neurons in the post ensemble.
+        If ``None``, which is the default, the solver will return an
+        appropriately sized array of zeros.
+    weights : bool, optional (Default: False)
+        If False, ``values`` is interpreted as decoders.
+        If True, ``values`` is interpreted as weights.
+
+    Attributes
+    ----------
+    values : (n_neurons, n_weights) array_like, optional (Default: None)
+        The array of decoders or weights to use.
+        If ``weights`` is ``False``, ``n_weights`` is the expected
+        output dimensionality. If ``weights`` is ``True``,
+        ``n_weights`` is the number of neurons in the post ensemble.
+        If ``None``, which is the default, the solver will return an
+        appropriately sized array of zeros.
+    weights : bool, optional (Default: False)
+        If False, ``values`` is interpreted as decoders.
+        If True, ``values`` is interpreted as weights.
+    """
+
+    values = NdarrayParam("values", optional=True, shape=("*", "*"))
+
+    def __init__(self, values=None, weights=False):
+        super(NoSolver, self).__init__(weights=weights)
+        self.values = values
+
+    def __call__(self, A, Y, rng=None, E=None):
+        if self.values is None:
+            n_neurons = np.asarray(A).shape[1]
+            if self.weights:
+                return np.zeros((n_neurons, np.asarray(E).shape[1])), {}
+            else:
+                return np.zeros((n_neurons, np.asarray(Y).shape[1])), {}
+
+        return self.values, {}


### PR DESCRIPTION
**Motivation and context:**
It has come up a few times that it would be nice to set decoders or weights directly. More specifically, loading from previous runs as mentioned in #649, #608. This doesn't facilitate saving and loading per se, but does allow the user to set decoders or weights even if they do not have access to `pre.neurons`. This can be used to help load and save decoders or weights as outlined in nengo/nengo_extras#35.

**How has this been tested?**
Added a new test, all current tests passed.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
Just look at the commit.

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
- [ ] Add some error checking on `values` to give better error messages for shape mismatch
