### PR TITLE
Allow learning_rate=0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release History
 2.5.1 (unreleased)
 ==================
 
+**Changed**
+
+- Learning rules can now have a learning rate of 0.
+  (`#1356 <https://github.com/nengo/nengo/pull/1356>`_)
+
 **Fixed**
 
 - The progress bar that can appear when building a large model

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -70,7 +70,7 @@ class LearningRuleType(FrozenObject):
     modifies = None
     probeable = ()
 
-    learning_rate = NumberParam('learning_rate', low=0, low_open=True)
+    learning_rate = NumberParam('learning_rate', low=0)
     size_in = LearningRuleTypeSizeInParam('size_in', low=0)
 
     def __init__(self, learning_rate=1e-6, size_in=0):


### PR DESCRIPTION
**Motivation and context:**
Often when working with a learning model it is helpful to quickly disable learning by setting the learning rate to 0.  Currently we don't allow this in Nengo, which isn't the end of the world but just makes things a little awkward.  I think there is pretty minimal downside to allowing it; it seems unlikely that users will accidentally set the learning rate to zero when they do actually want learning.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [n/a] All new and existing tests passed.
