### PR TITLE
Raise an error if sim is run for < dt seconds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,0 @@
-comment: false
-coverage:
-  status:
-    project: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,5 +48,5 @@
 - [ ] I have run the test suite locally and all tests passed.
 
 **Still to do:**
-<!--- If this is a work in progress, note below what you stil plan to do. -->
+<!--- If this is a work in progress, note below what you still plan to do. -->
 <!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,10 @@ Release History
   (`#947 <https://github.com/nengo/nengo/issues/947>`_)
 - Learning rules can now have a learning rate of 0.
   (`#1356 <https://github.com/nengo/nengo/pull/1356>`_)
+- Running the simulator for zero timesteps will now issue a warning,
+  and running for negative time will error.
+  (`#1354 <https://github.com/nengo/nengo/issues/1354>`_,
+  `#1357 <https://github.com/nengo/nengo/pull/1357>`_)
 
 **Fixed**
 

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -8,7 +8,7 @@ from nengo.builder import Model
 from nengo.builder.ensemble import BuiltEnsemble
 from nengo.builder.operator import DotInc
 from nengo.builder.signal import Signal
-from nengo.exceptions import ObsoleteError, SimulatorClosed
+from nengo.exceptions import ObsoleteError, SimulatorClosed, ValidationError
 from nengo.utils.compat import ResourceWarning
 from nengo.utils.testing import warns
 
@@ -274,3 +274,14 @@ def test_probe_cache(Simulator):
         ub = np.array(sim.data[up])
 
     assert not np.allclose(ua, ub, atol=1e-1)
+
+
+def test_invalid_run_time(Simulator):
+    net = nengo.Network()
+    with Simulator(net) as sim:
+        with pytest.raises(ValidationError):
+            sim.run(-0.0001)
+        with warns(UserWarning):
+            sim.run(0)
+        sim.run(0.0006)  # Rounds up to 0.001
+        assert sim.n_steps == 1

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -73,6 +73,10 @@ class Progress(object):
     """
 
     def __init__(self, max_steps):
+        if max_steps <= 0:
+            raise ValidationError("must be at least 1 (got %d)"
+                                  % (max_steps,), attr="max_steps")
+
         self.n_steps = 0
         self.max_steps = max_steps
         self.start_time = self.end_time = time.time()

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -1,5 +1,8 @@
 import time
 
+import pytest
+
+from nengo.exceptions import ValidationError
 from nengo.utils.progress import (
     AutoProgressBar, UpdateEveryN, UpdateEveryT, UpdateN, Progress,
     ProgressBar, ProgressTracker)
@@ -57,6 +60,15 @@ class TestProgress(object):
             assert p.eta() == -1  # no estimate available yet
             p.step()
             assert p.eta() >= 0.
+
+    def test_max_steps(self):
+        with pytest.raises(ValidationError):
+            with Progress(0):
+                pass
+
+        with pytest.raises(ValidationError):
+            with Progress(-1):
+                pass
 
 
 class TestAutoProgressBar(object):


### PR DESCRIPTION
**Motivation and context:**
If you pass a number less than `dt` to `sim.run`, we might raise a `ZeroDivisionError` or we might do something even weirder; see #1354. This raises an explicit error if `sim.run` is called with a value less than `dt`.

**How has this been tested?**
A unit test is included.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.