### PR TITLE
Set rng explicitly when caching solver.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ Release History
 
 - Better error message for invalid return values in ``nengo.Node`` functions.
   (`#1317 <https://github.com/nengo/nengo/pull/1317>`_)
+- Fixed an issue in which accepting and passing ``(*args, **kwargs)``
+  could not be used in custom solvers.
+  (`#1358 <https://github.com/nengo/nengo/issues/1358>`_,
+  `#1359 <https://github.com/nengo/nengo/pull/1359>`_)
 
 2.6.0 (October 6, 2017)
 =======================

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -640,15 +640,12 @@ class DecoderCache(object):
         """
 
         def cached_solver(conn, gain, bias, x, targets,
-                          rng=None, E=None, **uncached_kwargs):
+                          rng=np.random, E=None, **uncached_kwargs):
             if not self._in_context:
                 warnings.warn("Cannot use cached solver outside of "
                               "`with cache` block.")
                 return solver_fn(conn, gain, bias, x, targets,
                                  rng=rng, E=E, **uncached_kwargs)
-
-            if rng is None:
-                rng = np.random
 
             try:
                 key = self._get_cache_key(conn.solver,

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -2,7 +2,6 @@
 
 import errno
 import hashlib
-import inspect
 import logging
 import os
 import shutil
@@ -648,15 +647,8 @@ class DecoderCache(object):
                 return solver_fn(conn, gain, bias, x, targets,
                                  rng=rng, E=E, **uncached_kwargs)
 
-            try:
-                args, _, _, defaults = inspect.getargspec(conn.solver)
-            except TypeError:
-                args, _, _, defaults = inspect.getargspec(conn.solver.__call__)
-            args = args[-len(defaults):]
-            if rng is None and 'rng' in args:
-                rng = defaults[args.index('rng')]
-            if E is None and 'E' in args:
-                E = defaults[args.index('E')]
+            if rng is None:
+                rng = np.random
 
             try:
                 key = self._get_cache_key(conn.solver,


### PR DESCRIPTION
**Motivation and context:**
As noted in #1358 trying to inspect the default arguments has two problems:

* It prevents the usage of the ``(*args, **kwargs)`` idiom to write a wrapper for solvers.
* The solvers don't specify the actual RNG being used as default argument, but `None` and retrieve `np.random` later. So the RNG state was not saved anyways when relying on the default arguments (but I believe the builder always sets the `rng` argument, so that this bug did not ocurr in practice).

Instead of inspecting the defaults, `E` is assumed to be always `None` by default (any other default would seem quite weird to me) and `rng` is set to `np.random` if `None`.

By setting the RNG explicitly, all cached solvers will depend on the RNG state. This means that decoders are only reused if the RNG state matches even though the solver might be independent of the RNG. Unfortunately, there is no way to know whether the solver will use the RNG and this issue did exist before.

Fixes #1358.

**Interactions with other PRs:**
none

**How has this been tested?**
Unit tests still pass. I did not test the original issue reported in #1358, but as the failing code was completely removed, it should be resolved. Not sure if we should add a regression test. It seems weird to write a test that tests that the code isn't doing certain things and it seems unlikely that #1358 is reintroduced. I also did not add a test for the hashing of the RNG state because it seems to be quite awkward to test (without gaining much). But I could probably be swayed to add tests.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.