### PR TITLE
Use pylint (not pyflakes) to check for long lines.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,8 +5,14 @@ enable = anomalous-backslash-in-string,
          bad-super-call,
          bare-except,
          dangerous-default-value,
+         line-too-long,
          super-init-not-called,
          unused-import,
+
+
+[FORMAT]
+
+max-line-length = 79
 
 
 [REPORTS]

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -715,7 +715,7 @@ class DecoderCache(object):
         h.update(np.ascontiguousarray(targets).data)
 
         # rng format doc:
-        # noqa <https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.RandomState.get_state.html#numpy.random.RandomState.get_state>
+        # https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.RandomState.get_state.html
         state = rng.get_state()
         h.update(state[0].encode())  # string 'MT19937'
         h.update(state[1].data)  # 1-D array of 624 unsigned integer keys

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -8,7 +8,7 @@ error checking on those parameters.
 
 A good writeup on descriptors (which has an example similar to Parameter)
 can be found at
-https://nbviewer.ipython.org/urls/gist.github.com/ChrisBeaumont/5758381/raw/descriptor_writeup.ipynb  # noqa
+https://nbviewer.ipython.org/urls/gist.github.com/ChrisBeaumont/5758381/raw/descriptor_writeup.ipynb
 
 """
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ ignore =
 
 [flake8]
 exclude = __init__.py, compat.py
-# F401 is checked by pylint
-ignore = E123,E133,E226,E241,E242,E731,F401,W503
+# E501, F401 are checked by pylint
+ignore = E123,E133,E226,E241,E242,E501,E731,F401,W503
 max-complexity = 10
 
 [upload_docs]


### PR DESCRIPTION
**Motivation and context:**
pylint allows to specify a regex for lines that are allowed to exceed the maximum line length. That way we can allow lines with URLs to be longer without the added noise of a noqa comment.

**Interactions with other PRs:**
#1347 could do without an awkward `#noqa` in a docstring given these changes.

**How has this been tested?**
`tox -e static` passed

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.