### PR TITLE
Fix bugs with Piecewise process output shape

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,8 @@ Release History
 - Added a ``Piecewise`` process, which replaces the now deprecated
   ``piecewise`` function.
   (`#1036 <https://github.com/nengo/nengo/issues/1036>`_,
-  `#1100 <https://github.com/nengo/nengo/pull/1100>`_)
+  `#1100 <https://github.com/nengo/nengo/pull/1100>`_,
+  `#1362 <https://github.com/nengo/nengo/pull/1362>`_)
 
 **Changed**
 

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -392,9 +392,9 @@ class TestPiecewise(object):
         with pytest.raises(ValidationError):
             Piecewise(data)
 
-        data = {0.05: [1], 0.1: 0}
-        with pytest.raises(ValidationError):
-            Piecewise(data)
+        # check that scalars and length 1 arrays can be used interchangeably
+        # (no validation error)
+        Piecewise({0.05: [1], 0.1: 0})
 
     def test_invalid_interpolation_type(self):
         data = {0.05: 1, 0.1: 0}
@@ -458,3 +458,14 @@ class TestPiecewise(object):
         test_and_plot('quadratic')
         test_and_plot('cubic')
         plt.legend(loc="lower left")
+
+    @pytest.mark.parametrize("value", (1, [1, 1]))
+    def test_shape_out(self, value):
+        process = Piecewise({1: value})
+        f = process.make_step(shape_in=(process.default_size_in,),
+                              shape_out=(process.default_size_out,),
+                              dt=process.default_dt,
+                              rng=None)
+
+        assert np.array_equal(f(0), np.zeros(process.default_size_out))
+        assert np.array_equal(f(2), np.ones(process.default_size_out))


### PR DESCRIPTION
**Motivation and context:**
This fixes two related bugs with the Piecewise process:

1. `Piecewise({1: [1, 1, 1]})` would return `0.0` for times < 1 (rather than `[0, 0, 0]`).
2. `Piecewise({1: 1})` would return an array with shape `()` for times < 1 and shape `(1,)` for times >= 1, 
    because `ravel` upsizes its inputs to at least 1d.  This doesn't really produce any errors, but it's 
    probably good to be consistent.  I thought about adding some logic to check if the output shape 
    should be `()` or `(1,)`, but then figured that it was probably easier/more consistent to just always have 
    the output of the process be an array, instead of a scalar.

I wasn't sure whether to add a changelog entry or not.  Technically a bugfix, but it comes so closely on the heels of the feature release that it seems unnecessary (anyone looking at the changelog would probably be seeing both things for the first time).

**How has this been tested?**

Added a new test, see `test_shape_out`

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

