### PR TITLE
Handle module names w/o tests in get_filename.

### DIFF
--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -68,7 +68,8 @@ class Recorder(object):
 
     def get_filename(self, ext=''):
         modparts = self.module_name.split('.')[1:]
-        modparts.remove('tests')
+        if 'tests' in modparts:
+            modparts.remove('tests')
         return "%s.%s.%s" % ('.'.join(modparts), self.function_name, ext)
 
     def get_filepath(self, ext=''):


### PR DESCRIPTION
**Motivation and context:**
When running the nengo_spa tests with the `--plots` argument the module
name does not contain 'tests' for some reason. That makes the tests
fail without this change.

**Interactions with other PRs:**
none

**How has this been tested?**
nengo_spa tests run succesfully with this change and the `--plots` argument.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [ ] I have included a changelog entry. **(do we need one for this change?)**
- [n/a] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
