### PR TITLE
Add warning for invalid Node return types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,8 +22,10 @@ Release History
 2.6.1 (unreleased)
 ==================
 
+**Fixed**
 
-
+- Better error message for invalid return values in ``nengo.Node`` functions.
+  (`#1317 <https://github.com/nengo/nengo/pull/1317>`_)
 
 2.6.0 (October 6, 2017)
 =======================

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -760,16 +760,20 @@ class SimPyFunc(Operator):
         def step_simpyfunc():
             args = (np.copy(x),) if x is not None else ()
             y = fn(t.item(), *args) if t is not None else fn(*args)
+
             if output is not None:
-                # required since Numpy turns None into NaN
-                if y is None or not np.all(np.isfinite(y)):
-                    raise SimulationError(
-                        "Function %r returned non-finite value" %
-                        function_name(self.fn))
                 try:
+                    # required since Numpy turns None into NaN
+                    if y is None or not np.all(np.isfinite(y)):
+                        raise SimulationError(
+                            "Function %r returned non-finite value" %
+                            function_name(self.fn))
+
                     output[...] = y
-                except ValueError:
-                    raise SimulationError("Function %r returned invalid value "
-                                          "%r" % (function_name(self.fn), y))
+
+                except (TypeError, ValueError):
+                    raise SimulationError("Function %r returned a value "
+                                          "%r of invalid type %r" %
+                                          (function_name(self.fn), y, type(y)))
 
         return step_simpyfunc

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -381,26 +381,14 @@ def test_node_with_unusual_strided_view(Simulator, seed):
         pass
 
 
-def test_non_finite_values(Simulator):
+@pytest.mark.parametrize("badval", [np.inf, np.nan, "string"])
+def test_invalid_values(Simulator, badval):
     with nengo.Network() as model:
         with pytest.raises(ValidationError):
-            node = nengo.Node(np.inf)
+            node = nengo.Node(badval)
 
     with nengo.Network() as model:
-        with pytest.raises(ValidationError):
-            node = nengo.Node(np.nan)
-
-    with nengo.Network() as model:
-        node = nengo.Node(lambda t: np.inf)
-        ens = nengo.Ensemble(10, 1)
-        nengo.Connection(node, ens)
-
-    with Simulator(model) as sim:
-        with pytest.raises(SimulationError):
-            sim.run(0.01)
-
-    with nengo.Network() as model:
-        node = nengo.Node(lambda t: np.nan)
+        node = nengo.Node(lambda t: badval)
         ens = nengo.Ensemble(10, 1)
         nengo.Connection(node, ens)
 


### PR DESCRIPTION
**Motivation and context:**
Solves #1370. Not sure if this needs a changelog entry or not.

**How has this been tested?**
Ran the code in #1370 and it returned a legible error. Also ran all tests. Didn't add a unit test, because `operators.py` isn't tested?

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have included a changelog entry.
- [x] I have run the test suite locally and all tests passed.