### PR TITLE
Disable default validation for some parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,12 @@ Release History
   which scale the output amplitude.
   (`#1325 <https://github.com/nengo/nengo/pull/1325>`_)
 
+**Changed**
+
+- Default values can no longer be set for
+  ``Ensemble.n_neurons`` or ``Ensemble.dimensions``.
+  (`#1372 <https://github.com/nengo/nengo/pull/1372>`__)
+
 **Fixed**
 
 - Better error message for invalid return values in ``nengo.Node`` functions.
@@ -39,6 +45,9 @@ Release History
 - Fixed an issue in which the cache would not release its index lock
   on abnormal termination of the Nengo process.
   (`#1364 <https://github.com/nengo/nengo/pull/1364>`_)
+- Fixed validation checks that prevented the default
+  from being set on certain parameters.
+  (`#1372 <https://github.com/nengo/nengo/pull/1372>`__)
 
 2.6.0 (October 6, 2017)
 =======================

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -33,6 +33,8 @@ class PrePostParam(NengoObjectParam):
 class ConnectionLearningRuleTypeParam(LearningRuleTypeParam):
     """Connection-specific validation for learning rules."""
 
+    coerce_defaults = False
+
     def check_rule(self, conn, rule):
         super(ConnectionLearningRuleTypeParam, self).check_rule(conn, rule)
 
@@ -94,6 +96,8 @@ class ConnectionLearningRuleTypeParam(LearningRuleTypeParam):
 class ConnectionSolverParam(SolverParam):
     """Connection-specific validation for decoder solvers."""
 
+    coerce_defaults = False
+
     def coerce(self, conn, solver):
         solver = super(ConnectionSolverParam, self).coerce(conn, solver)
         if solver is not None:
@@ -111,6 +115,8 @@ class ConnectionSolverParam(SolverParam):
 
 
 class EvalPointsParam(DistOrArrayParam):
+    coerce_defaults = False
+
     def coerce(self, conn, distorarray):
         """Eval points are only valid when pre is an ensemble."""
         if distorarray is not None and not isinstance(conn.pre, Ensemble):
@@ -122,6 +128,8 @@ class EvalPointsParam(DistOrArrayParam):
 
 class ConnectionFunctionParam(Parameter):
     """Connection-specific validation for functions."""
+
+    coerce_defaults = False
 
     def check_array(self, conn, ndarray):
         if not isinstance(conn.eval_points, np.ndarray):
@@ -217,6 +225,8 @@ class ConnectionFunctionParam(Parameter):
 
 class TransformParam(DistOrArrayParam):
     """The transform additionally validates size_out."""
+
+    coerce_defaults = False
 
     def __init__(self, name, default, optional=False, readonly=False):
         super(TransformParam, self).__init__(

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -108,8 +108,8 @@ class Ensemble(NengoObject):
 
     probeable = ('decoded_output', 'input', 'scaled_encoders')
 
-    n_neurons = IntParam('n_neurons', default=None, low=1)
-    dimensions = IntParam('dimensions', default=None, low=1)
+    n_neurons = IntParam('n_neurons', low=1)
+    dimensions = IntParam('dimensions', low=1)
     radius = NumberParam('radius', default=1.0, low=1e-10)
     encoders = DistOrArrayParam('encoders',
                                 default=UniformHypersphere(surface=True),

--- a/nengo/presets.py
+++ b/nengo/presets.py
@@ -17,7 +17,6 @@ def ThresholdingEnsembles(threshold, intercept_width=0.15, radius=1.):
       exponential distribution (shape parameter of ``intercept_width``).
       This clusters intercepts near the threshold for better approximation.
     - Sets encoders to 1.
-    - Sets dimensions to 1.
     - Sets evaluation points to be uniformly distributed between
       ``threshold`` and ``radius``.
     - Sets the radius.
@@ -39,7 +38,6 @@ def ThresholdingEnsembles(threshold, intercept_width=0.15, radius=1.):
         Configuration with presets.
     """
     config = nengo.Config(nengo.Ensemble)
-    config[nengo.Ensemble].dimensions = 1
     config[nengo.Ensemble].radius = radius
     config[nengo.Ensemble].intercepts = nengo.dists.Exponential(
         intercept_width, threshold, radius)

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -25,6 +25,8 @@ class TargetParam(NengoObjectParam):
 
 
 class AttributeParam(StringParam):
+    coerce_defaults = False
+
     def coerce(self, probe, attr):
         value = super(AttributeParam, self).coerce(probe, attr)
         if attr in ('decoders', 'transform'):
@@ -109,10 +111,10 @@ class Probe(NengoObject):
     """
 
     target = TargetParam('target', nonzero_size_out=True)
-    attr = AttributeParam('attr', default=None)
+    attr = AttributeParam('attr', default=None, optional=True)
     sample_every = NumberParam(
         'sample_every', default=None, optional=True, low=1e-10)
-    synapse = SynapseParam('synapse', default=None)
+    synapse = SynapseParam('synapse', default=None, optional=True)
     solver = ProbeSolverParam('solver', default=ConnectionDefault)
 
     _param_init_order = ['target']


### PR DESCRIPTION
Some parameters rely on attributes of their parent object to perform the validation, so the validation cannot be performed until the attribute value is set on that object.  Previously, attempting to set the default value for one of these parameters (e.g. `net.config[nengo.Connection].transform = 2`) would result in an error (because it would try to perform the validation and fail).  This PR disables the validation for the defaults on those parameters.  Note that the validation will still be performed when the attribute is set on an object instance (e.g., `my_conn.transform = 2` or `self.transform = Default`).

Also adjusted some parameters that were set to non-optional with a value of None (or vice versa), which were revealed by the new test.

**How has this been tested?**
Added a new test, see `test_params.py:test_coerce_defaults`

**How long should this take to review?**
- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
