### PR TITLE
Install SciPy when building docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
       export CONDA_DEPS="";
       export PIP_DEPS="flake8 pylint";
     elif [[ "$DOCS" == "true" ]]; then
-      export CONDA_DEPS="matplotlib";
+      export CONDA_DEPS="matplotlib scipy";
       export PIP_DEPS="ipython[all]==2.4.1 sphinx ghp-import -e git+https://github.com/tbekolay/guzzle_sphinx_theme.git@use_smartypants#egg=guzzle_sphinx_theme";
     fi
   - if [[ -n "$NUMPY" && "$STATIC" == "false" ]]; then

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -286,7 +286,7 @@ class PiecewiseDataParam(DictParam):
             if callable(value):
                 try:
                     value = np.ravel(value(time))
-                except:
+                except Exception:
                     raise ValidationError("callable object for time step %.3f "
                                           "should return a numerical constant"
                                           % time, attr='data', obj=instance)

--- a/nengo/spa/pointer.py
+++ b/nengo/spa/pointer.py
@@ -21,7 +21,7 @@ class SemanticPointer(object):
         else:
             try:
                 len(data)
-            except:
+            except Exception:
                 raise ValidationError(
                     "Must specify either the data or the length for a "
                     "SemanticPointer.", attr='data', obj=self)


### PR DESCRIPTION
**Motivation and context:**
At the moment, a lot of our more complex notebooks ([e.g.](https://www.nengo.ai/nengo/examples/associative_memory.html)) render with a warning because SciPy isn't installed when building this docs. This PR installs SciPy when building the docs through TravisCI.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [na] I have run the test suite locally and all tests passed.
