### PR TITLE
Rich display progress bar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,15 @@ Release History
 2.6.1 (unreleased)
 ==================
 
+**Deprecated**
+
+- The ``nengo.ipynb`` IPython extension and the ``IPython2ProgressBar``
+  have been deprecated. ``IPython5ProgressBar`` can be used instead (supporting
+  IPython>=5) and will be automatically activated in IPython kernels (e.g.,
+  in Jupyter notebooks).
+  (`#1375 <https://github.com/nengo/nengo/pull/1375>`_,
+  `#1087 <https://github.com/nengo/nengo/issues/1087>`_)
+
 **Fixed**
 
 - Better error message for invalid return values in ``nengo.Node`` functions.

--- a/examples/advanced/functions_and_tuning_curves.ipynb
+++ b/examples/advanced/functions_and_tuning_curves.ipynb
@@ -33,7 +33,6 @@
       "\n",
       "import nengo\n",
       "\n",
-      "%load_ext nengo.ipynb\n",
       "%matplotlib inline"
      ],
      "language": "python",

--- a/examples/advanced/inhibitory_gating.ipynb
+++ b/examples/advanced/inhibitory_gating.ipynb
@@ -22,8 +22,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/advanced/izhikevich.ipynb
+++ b/examples/advanced/izhikevich.ipynb
@@ -34,7 +34,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.utils.matplotlib import rasterplot"
      ],
      "language": "python",

--- a/examples/advanced/matrix_multiplication.ipynb
+++ b/examples/advanced/matrix_multiplication.ipynb
@@ -26,8 +26,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/advanced/nef_summary.ipynb
+++ b/examples/advanced/nef_summary.ipynb
@@ -16,7 +16,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Uniform\n",
       "from nengo.utils.ensemble import tuning_curves\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/advanced/processes.ipynb
+++ b/examples/advanced/processes.ipynb
@@ -44,8 +44,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/2d_representation.ipynb
+++ b/examples/basic/2d_representation.ipynb
@@ -33,7 +33,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "\n",
       "model = nengo.Network(label='2D Representation')\n",
       "with model:\n",

--- a/examples/basic/addition.ipynb
+++ b/examples/basic/addition.ipynb
@@ -28,8 +28,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/combining.ipynb
+++ b/examples/basic/combining.ipynb
@@ -23,8 +23,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/communication_channel.ipynb
+++ b/examples/basic/communication_channel.ipynb
@@ -35,8 +35,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/many_neurons.ipynb
+++ b/examples/basic/many_neurons.ipynb
@@ -28,8 +28,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/multiplication.ipynb
+++ b/examples/basic/multiplication.ipynb
@@ -29,8 +29,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/single_neuron.ipynb
+++ b/examples/basic/single_neuron.ipynb
@@ -23,8 +23,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/squaring.ipynb
+++ b/examples/basic/squaring.ipynb
@@ -29,8 +29,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/two_neurons.ipynb
+++ b/examples/basic/two_neurons.ipynb
@@ -28,8 +28,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/controlled_integrator.ipynb
+++ b/examples/dynamics/controlled_integrator.ipynb
@@ -46,8 +46,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/controlled_integrator2.ipynb
+++ b/examples/dynamics/controlled_integrator2.ipynb
@@ -23,8 +23,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/controlled_oscillator.ipynb
+++ b/examples/dynamics/controlled_oscillator.ipynb
@@ -63,8 +63,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/integrator.ipynb
+++ b/examples/dynamics/integrator.ipynb
@@ -27,8 +27,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/lorenz_attractor.ipynb
+++ b/examples/dynamics/lorenz_attractor.ipynb
@@ -38,8 +38,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/oscillator.ipynb
+++ b/examples/dynamics/oscillator.ipynb
@@ -22,8 +22,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/learning/learn_associations.ipynb
+++ b/examples/learning/learn_associations.ipynb
@@ -53,8 +53,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/learning/learn_communication_channel.ipynb
+++ b/examples/learning/learn_communication_channel.ipynb
@@ -39,7 +39,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",

--- a/examples/learning/learn_product.ipynb
+++ b/examples/learning/learn_product.ipynb
@@ -33,7 +33,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",

--- a/examples/learning/learn_square.ipynb
+++ b/examples/learning/learn_square.ipynb
@@ -29,8 +29,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/learning/learn_unsupervised.ipynb
+++ b/examples/learning/learn_unsupervised.ipynb
@@ -35,8 +35,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/networks/basal_ganglia.ipynb
+++ b/examples/networks/basal_ganglia.ipynb
@@ -32,8 +32,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/networks/ensemble_array.ipynb
+++ b/examples/networks/ensemble_array.ipynb
@@ -26,8 +26,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/networks/integrator_network.ipynb
+++ b/examples/networks/integrator_network.ipynb
@@ -27,8 +27,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/spa/associative_memory.ipynb
+++ b/examples/spa/associative_memory.ipynb
@@ -35,8 +35,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "from nengo import spa\n",
-      "%load_ext nengo.ipynb"
+      "from nengo import spa"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/spa/convolution.ipynb
+++ b/examples/spa/convolution.ipynb
@@ -25,7 +25,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa\n",
       "from nengo.spa import Vocabulary\n",
       "\n",

--- a/examples/spa/question.ipynb
+++ b/examples/spa/question.ipynb
@@ -26,7 +26,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/question_control.ipynb
+++ b/examples/spa/question_control.ipynb
@@ -27,7 +27,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/question_memory.ipynb
+++ b/examples/spa/question_memory.ipynb
@@ -26,7 +26,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_parser.ipynb
+++ b/examples/spa/spa_parser.ipynb
@@ -34,7 +34,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_sequence.ipynb
+++ b/examples/spa/spa_sequence.ipynb
@@ -33,7 +33,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_sequence_routed.ipynb
+++ b/examples/spa/spa_sequence_routed.ipynb
@@ -31,7 +31,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/usage/config.ipynb
+++ b/examples/usage/config.ipynb
@@ -38,7 +38,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.utils.ipython import hide_input\n",
       "hide_input()"
      ],

--- a/examples/usage/delay_node.ipynb
+++ b/examples/usage/delay_node.ipynb
@@ -27,7 +27,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",

--- a/examples/usage/exceptions.ipynb
+++ b/examples/usage/exceptions.ipynb
@@ -30,7 +30,6 @@
       "import traceback\n",
       "import nengo\n",
       "import nengo.spa\n",
-      "%load_ext nengo.ipynb\n",
       "\n",
       "def print_exc(func):\n",
       "    try:\n",

--- a/examples/usage/network_design.ipynb
+++ b/examples/usage/network_design.ipynb
@@ -51,7 +51,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Choice\n",
       "from nengo.processes import Piecewise\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/usage/network_design_advanced.ipynb
+++ b/examples/usage/network_design_advanced.ipynb
@@ -41,7 +41,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Choice\n",
       "from nengo.processes import Piecewise\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/usage/rectified_linear.ipynb
+++ b/examples/usage/rectified_linear.ipynb
@@ -62,7 +62,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "\n",
       "\n",
       "class RectifiedLinear(nengo.neurons.NeuronType):  # Neuron types must subclass `nengo.Neurons`\n",

--- a/examples/usage/strings.ipynb
+++ b/examples/usage/strings.ipynb
@@ -23,8 +23,7 @@
      "collapsed": false,
      "input": [
       "import numpy as np\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/usage/tuning_curves.ipynb
+++ b/examples/usage/tuning_curves.ipynb
@@ -46,7 +46,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.utils.ensemble import tuning_curves"
      ],
      "language": "python",

--- a/nengo/ipynb.py
+++ b/nengo/ipynb.py
@@ -45,6 +45,12 @@ except ImportError:
 
 
 def load_ipython_extension(ipython):
+    # Not a deprecation warning as this are hidden by default and we want to
+    # make sure the user sees this message.
+    warnings.warn(
+        "Loading the nengo.ipynb notebook extension will break with current "
+        "Jupyter notebook versions and is deprecated. All features provided "
+        "by the old extension are automatically activated for IPython>=5.")
     if has_ipynb_widgets() and rc.get('progress', 'progress_bar') == 'auto':
         IPythonProgressWidget.load_frontend(ipython)
         rc.set('progress', 'progress_bar', '.'.join((
@@ -136,6 +142,9 @@ class IPythonProgressWidget(DOMWidget):
     @classmethod
     def load_frontend(cls, ipython):
         """Loads the JavaScript front-end code required by then widget."""
+        warnings.warn(
+            "The IPythonProgressWidget is deprecated and will break current "
+            "Jupyter notebook versions.", DeprecationWarning)
         if notebook_version[0] < 4:
             ipython.run_cell_magic('javascript', '', cls.LEGACY_FRONTEND)
         elif ipywidgets.version_info[0] < 5:
@@ -156,6 +165,10 @@ class IPython2ProgressBar(ProgressBar):
     supports_fast_ipynb_updates = True
 
     def __init__(self, task):
+        warnings.warn(
+            "IPython2ProgressBar is deprecated and will be removed. "
+            "Use nengo.progress.IPython5ProgressBar for IPython>=5.",
+            DeprecationWarning)
         super(IPython2ProgressBar, self).__init__(task)
         self._escaped_task = escape(task)
         self._widget = IPythonProgressWidget()

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -114,18 +114,3 @@ def test_no_outputs(nb_file):
 
     for cell in iter_cells(nb_file):
         assert cell.outputs == [], "Cell outputs not cleared"
-
-
-@pytest.mark.example
-@pytest.mark.parametrize('nb_file', all_examples)
-def test_loads_ipynb_ext(nb_file):
-    pytest.importorskip("IPython", minversion="1.0")
-
-    no_sim = True
-    for cell in iter_cells(nb_file):
-        if "%load_ext nengo.ipynb" in cell.source:
-            break
-        if "nengo.Simulator(" in cell.source:
-            no_sim = False
-    else:
-        assert no_sim, "nengo.ipynb extension not loaded"

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -104,6 +104,7 @@ else:
 
 assert pickle
 assert configparser
+assert escape
 assert replace
 assert zip_longest
 

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -12,10 +12,12 @@ PY2 = sys.version_info[0] == 2
 
 # If something's changed from Python 2 to 3, we handle that here
 if PY2:
+    from cgi import escape as cgi_escape
     import cPickle as pickle
     import ConfigParser as configparser
     from itertools import izip_longest as zip_longest
     from StringIO import StringIO
+    escape = lambda s, quote=True: cgi_escape(s, quote=quote)
     string_types = (str, unicode)
     int_types = (int, long)
     range = xrange
@@ -77,6 +79,7 @@ if PY2:
 else:
     import pickle
     import configparser
+    from html import escape
     from io import StringIO
     from itertools import zip_longest
     from os import replace

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -78,6 +78,14 @@ except ImportError:
 assert get_ipython
 
 
+def check_ipy_version(min_version):
+    try:
+        import IPython
+        return IPython.version_info >= min_version
+    except ImportError:
+        return False
+
+
 def has_ipynb_widgets():
     """Determines whether IPython widgets are available.
 

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -226,6 +226,15 @@ class TerminalProgressBar(ProgressBar):
 
 
 class HtmlProgressBar(ProgressBar):
+    """A progress bar using a HTML representation.
+
+    This HTML representation can be used in Jupyter notebook environments
+    and is provided by the *_repr_html_* method that will be automatically
+    used by IPython interpreters.
+
+    If the kernel frontend does not support HTML (e.g., in Jupyter qtconsole),
+    a warning message will be issued as the ASCII representation.
+    """
     supports_fast_ipynb_updates = True
 
     def __init__(self, task):
@@ -293,6 +302,16 @@ class HtmlProgressBar(ProgressBar):
 
 
 class IPython5ProgressBar(ProgressBar):
+    """ProgressBar for IPython>=5 environments.
+
+    Provides a HTML representation, except for in a pure terminal IPython
+    (i.e. not an IPython kernel that was connected to via ZMQ), where a
+    ASCII progress bar will be used.
+
+    Note that some Jupyter environments (like qtconsole) will try to use the
+    HTML version, but do not support HTML and will show a warning instead of
+    an actual progress bar.
+    """
     supports_fast_ipynb_updates = True
 
     def __init__(self, task):

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -286,8 +286,8 @@ class HtmlProgressBar(ProgressBar):
                 &nbsp;
               </div>
             </div>'''.format(
-                text=text, prev_progress=self._prev_progress * 100.,
-                progress=self._progress.progress * 100.)
+            text=text, prev_progress=self._prev_progress * 100.,
+            progress=self._progress.progress * 100.)
         self._prev_progress = self._progress.progress
         return html
 

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -276,7 +276,8 @@ class HtmlProgressBar(ProgressBar):
               </div>
               <div style="
                   background-color: #bdd2e6;
-                  animation: progress 0.1s 1;">
+                  animation: progress 0.1s 1;
+                  width: {progress}%;">
                 <style type="text/css" scoped="scoped">
                     @keyframes progress {{
                         0% {{ width: {prev_progress}%; }}


### PR DESCRIPTION
**Motivation and context:**
`%load_ext nengo.ipynb` and the IPython progress bar currently break in in recent Jupyter notebook/IPython versions (potentially completely crashing the notebook frontend). Also, the implementation based on widgets has proven to be not very robust as the widget API has been evolving quickly.

This PR implements a new `IPython5ProgressBar` compatible with IPython 5 and newer. The HTML code is based on the old `IPython2ProgressBar`, but instead of using widgets, the IPython rich display system is used which allows updates to displays since IPython 5. As we do not require to capture any user interaction that is completely sufficient. It also allows us to display the HTML progress bar in notebooks without `%load_ext nengo.ipynb`.

The notebook extension `nengo.ipynb` is deprecated with this PR as well as the `IPython2ProgressBar` and loading it will issue a warning. At some point `%load_ext nengo.ipynb` should become a no-op or deleted (but that would break backwards compatibility).

**Interactions with other PRs:**
none

**How has this been tested?**
Tested the following scenarios:
* Progress bar in Jupyter notebook
* Progress bar when executing with `ipython` on the terminal
* Progress bar when executing with `python` on the terminal

Still to test:
* [x] What happens in `ipython qtconsole`?

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
