### PR TITLE
Use Simulator fixture in appropriate unit tests

### DIFF
--- a/nengo/spa/tests/test_assoc_mem.py
+++ b/nengo/spa/tests/test_assoc_mem.py
@@ -63,7 +63,7 @@ def test_am_spa_keys_as_expressions(Simulator, plt, seed, rng):
         in_p = nengo.Probe(model.am.input)
         out_p = nengo.Probe(model.am.output, synapse=0.03)
 
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim.run(0.2)
 
     # Specify t ranges

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -1015,7 +1015,7 @@ def test_zero_activities_error(Simulator):
         nengo.Connection(a, nengo.Node(size_in=1))
 
     with pytest.raises(BuildError):
-        with nengo.Simulator(model):
+        with Simulator(model):
             pass
 
 
@@ -1027,7 +1027,7 @@ def test_function_returns_none_error(Simulator):
                          function=lambda x: x if x < 0.5 else None)
 
     with pytest.raises(BuildError):
-        with nengo.Simulator(model):
+        with Simulator(model):
             pass
 
 

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -406,5 +406,5 @@ def test_raises_exception_for_invalid_intercepts(Simulator, intercept):
         nengo.Ensemble(1, 1, intercepts=[intercept])
 
     with pytest.raises(BuildError):
-        with nengo.Simulator(model):
+        with Simulator(model):
             pass

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -265,7 +265,7 @@ def test_probe_cache(Simulator):
         u = nengo.Node(nengo.processes.WhiteNoise())
         up = nengo.Probe(u)
 
-    with nengo.Simulator(model, seed=0) as sim:
+    with Simulator(model, seed=0) as sim:
         sim.run_steps(10)
         ua = np.array(sim.data[up])
 


### PR DESCRIPTION
**Motivation and context:**
Some of our unit tests were using `nengo.Simulator` instead of the `Simulator` fixture.  Doesn't make any difference for core `nengo`, but it means that those tests weren't working properly for other backends.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
