### PR TITLE
Fill in default values automatically in documentation

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -33,7 +33,7 @@ setup_py:
     - matplotlib>=1.4
     - nbsphinx
     - numpydoc>=0.6
-    - nengo_sphinx_theme>=0.8
+    - nengo_sphinx_theme>=0.12.0
   optional_req:
     - scipy>=0.13
     - scikit-learn
@@ -129,6 +129,8 @@ docs_conf_py:
     scipy: 'https://docs.scipy.org/doc/scipy/reference'
     sklearn: 'https://scikit-learn.org/dev'
   analytics_id: UA-41658423-2
+  extensions:
+    - nengo_sphinx_theme.ext.resolvedefaults
 
 travis_yml:
   python: 3.6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "nbsphinx",
     "nengo_sphinx_theme",
     "numpydoc",
+    "nengo_sphinx_theme.ext.resolvedefaults",
 ]
 
 # -- sphinx.ext.autodoc

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -234,16 +234,16 @@ class Process(FrozenObject):
 
     Parameters
     ----------
-    default_size_in : int (Default: 0)
+    default_size_in : int
         Sets the default size in for nodes using this process.
-    default_size_out : int (Default: 1)
+    default_size_out : int
         Sets the default size out for nodes running this process. Also,
         if ``d`` is not specified in `~.Process.run` or `~.Process.run_steps`,
         this will be used.
-    default_dt : float (Default: 0.001 (1 millisecond))
+    default_dt : float
         If ``dt`` is not specified in `~.Process.run`, `~.Process.run_steps`,
         `~.Process.ntrange`, or `~.Process.trange`, this will be used.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed. Ensures random factors will be the same each run.
 
     Attributes
@@ -284,13 +284,13 @@ class Process(FrozenObject):
         ----------
         x : ndarray
             The input signal given to the process.
-        d : int, optional (Default: None)
+        d : int, optional
             Output dimensionality. If None, ``default_size_out`` will be used.
-        dt : float, optional (Default: None)
+        dt : float, optional
             Simulation timestep. If None, ``default_dt`` will be used.
-        rng : `numpy.random.RandomState` (Default: ``numpy.random``)
+        rng : `numpy.random.RandomState`
             Random number generator used for stochstic processes.
-        copy : bool, optional (Default: True)
+        copy : bool, optional
             If True, a new output array will be created for output.
             If False, the input signal ``x`` will be overwritten.
         """
@@ -343,11 +343,11 @@ class Process(FrozenObject):
         ----------
         t : float
             The length of time to run.
-        d : int, optional (Default: None)
+        d : int, optional
             Output dimensionality. If None, ``default_size_out`` will be used.
-        dt : float, optional (Default: None)
+        dt : float, optional
             Simulation timestep. If None, ``default_dt`` will be used.
-        rng : `numpy.random.RandomState` (Default: ``numpy.random``)
+        rng : `numpy.random.RandomState`
             Random number generator used for stochstic processes.
         """
         dt = self.default_dt if dt is None else dt
@@ -364,11 +364,11 @@ class Process(FrozenObject):
         ----------
         n_steps : int
             The number of steps to run.
-        d : int, optional (Default: None)
+        d : int, optional
             Output dimensionality. If None, ``default_size_out`` will be used.
-        dt : float, optional (Default: None)
+        dt : float, optional
             Simulation timestep. If None, ``default_dt`` will be used.
-        rng : `numpy.random.RandomState` (Default: ``numpy.random``)
+        rng : `numpy.random.RandomState`
             Random number generator used for stochstic processes.
         """
         shape_in = as_shape(0)
@@ -388,7 +388,7 @@ class Process(FrozenObject):
         ----------
         n_steps : int
             The given number of steps.
-        dt : float, optional (Default: None)
+        dt : float, optional
             Simulation timestep. If None, ``default_dt`` will be used.
         """
         dt = self.default_dt if dt is None else dt
@@ -401,7 +401,7 @@ class Process(FrozenObject):
         ----------
         t : float
             The given length of time.
-        dt : float, optional (Default: None)
+        dt : float, optional
             Simulation timestep. If None, ``default_dt`` will be used.
         """
         dt = self.default_dt if dt is None else dt

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -14,11 +14,11 @@ class Model:
 
     Parameters
     ----------
-    dt : float, optional (Default: 0.001)
+    dt : float, optional
         The length of a simulator timestep, in seconds.
-    label : str, optional (Default: None)
+    label : str, optional
         A name or description to differentiate models.
-    decoder_cache : DecoderCache, optional (Default: ``NoDecoderCache()``)
+    decoder_cache : DecoderCache, optional
         Interface to a cache for expensive parts of the build process.
 
     Attributes

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -37,7 +37,7 @@ class SimPES(Operator):
         If not None, multiply the error signal by these post-synaptic
         encoders (in the case that we want to learn a neuron-to-neuron
         weight matrix instead of decoder weights).
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -54,7 +54,7 @@ class SimPES(Operator):
         If not None, multiply the error signal by these post-synaptic
         encoders (in the case that we want to learn a neuron-to-neuron
         weight matrix instead of decoder weights).
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Notes
@@ -143,7 +143,7 @@ class SimBCM(Operator):
         The synaptic weight change to be applied, :math:`\Delta \omega_{ij}`.
     learning_rate : float
         The scalar learning rate, :math:`\kappa`.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -241,7 +241,7 @@ class SimOja(Operator):
         The scalar learning rate, :math:`\kappa`.
     beta : float
         The scalar forgetting rate, :math:`\beta`.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -340,7 +340,7 @@ class SimVoja(Operator):
         either 0 or 1 to turn learning off or on, respectively.
     learning_rate : float
         The scalar learning rate.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes

--- a/nengo/builder/neurons.py
+++ b/nengo/builder/neurons.py
@@ -18,9 +18,9 @@ class SimNeurons(Operator):
         The input current.
     output : Signal
         The neuron output signal that will be set.
-    states : list, optional (Default: None)
+    states : list, optional
         A list of additional neuron state signals set by ``step_math``.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -68,7 +68,7 @@ class Operator:
 
     Parameters
     ----------
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -200,7 +200,7 @@ class TimeUpdate(Operator):
         The signal associated with the integer step counter.
     time : Signal
         The signal associated with the time (a float, in seconds).
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -255,9 +255,9 @@ class Reset(Operator):
     ----------
     dst : Signal
         The Signal to reset.
-    value : float, optional (Default: 0)
+    value : float, optional
         The constant value to which ``dst`` is set.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -318,13 +318,13 @@ class Copy(Operator):
         The signal that will be assigned to (set).
     src : Signal
         The signal that will be copied (read).
-    dst_slice : slice or list, optional (Default: None)
+    dst_slice : slice or list, optional
         Slice or list of indices associated with ``dst``.
-    src_slice : slice or list, optional (Default: None)
+    src_slice : slice or list, optional
         Slice or list of indices associated with ``src``
-    inc : bool, optional (Default: False)
+    inc : bool, optional
         Whether this should be an increment rather than a copy.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -430,7 +430,7 @@ class ElementwiseInc(Operator):
         The second signal to be multiplied.
     Y : Signal
         The signal to be incremented.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -539,7 +539,7 @@ class DotInc(Operator):
         The second signal to be multiplied (a vector).
     Y : Signal
         The signal to be incremented.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -632,7 +632,7 @@ class BsrDotInc(DotInc):
         Column index pointers, see `scipy.sparse.bsr_matrix` for details.
     reshape : bool
         Whether to reshape the result.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -704,7 +704,7 @@ class SimPyFunc(Operator):
     x : Signal or None
         An input signal to pass to ``fn``.
         If None, an input signal will not be passed to ``fn``.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes

--- a/nengo/builder/processes.py
+++ b/nengo/builder/processes.py
@@ -18,10 +18,10 @@ class SimProcess(Operator):
         Output from the process, or None if no output.
     t : Signal
         The signal associated with the time (a float, in seconds).
-    mode : str, optional (Default: ``'set'``)
+    mode : str, optional
         Denotes what type of update this operator performs.
         Must be one of ``'update'``, ``'inc'`` or ``'set'``.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -118,11 +118,11 @@ def build_process(model, process, sig_in=None, sig_out=None, inc=False):
         The model to build into.
     process : Process
         Process to build.
-    sig_in : Signal, optional (Default: None)
+    sig_in : Signal, optional
         The input signal, or None if no input signal.
-    sig_out : Signal, optional (Default: None)
+    sig_out : Signal, optional
         The output signal, or None if no output signal.
-    inc : bool, optional (Default: False)
+    inc : bool, optional
         Whether `.SimProcess` should be made with
         ``mode='inc'` (True) or ``mode='set'`` (False).
 
@@ -148,7 +148,7 @@ def build_synapse(model, synapse, sig_in, sig_out=None):
         Synapse to build.
     sig_in : Signal
         The input signal.
-    sig_out : Signal, optional (Default: None)
+    sig_out : Signal, optional
         The output signal. If None, a new output signal will be
         created and returned.
 

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -19,17 +19,17 @@ class Signal:
     initial_value : array_like
         The initial value of the signal. Much of the metadata tracked by the
         Signal is based on this array as well (e.g., dtype).
-    name : str, optional (Default: None)
+    name : str, optional
         Name of the signal. Primarily used for debugging.
         If None, the memory location of the Signal will be used.
-    base : Signal, optional (Default: None)
+    base : Signal, optional
         The base signal, if this signal is a view on another signal.
         Linking the two signals with the ``base`` argument is necessary
         to ensure that their live data is also linked.
-    readonly : bool, optional (Default: False)
+    readonly : bool, optional
         Whether this signal and its related live data should be marked as
         readonly. Writing to these arrays will raise an exception.
-    offset : int, optional (Default: 0)
+    offset : int, optional
         For a signal view this gives the offset of the view from the base
         ``initial_value`` in bytes. This might differ from the offset
         of the NumPy array view provided as ``initial_value`` if the base

--- a/nengo/builder/transforms.py
+++ b/nengo/builder/transforms.py
@@ -78,7 +78,7 @@ class ConvInc(Operator):
         Output signal to be incremented.
     conv : `~nengo.transforms.Convolution`
         The Convolution object being applied.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Attributes
@@ -91,7 +91,7 @@ class ConvInc(Operator):
         Output signal to be incremented.
     conv : `~nengo.transforms.Convolution`
         The Convolution object being applied.
-    tag : str, optional (Default: None)
+    tag : str, optional
         A label associated with the operator, for debugging purposes.
 
     Notes

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -292,8 +292,7 @@ class Connection(NengoObject):
     post : Ensemble or Neurons or Node or Probe
         The destination object for the connection.
 
-    synapse : Synapse or None, optional \
-              (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+    synapse : Synapse or None, optional
         Synapse model to use for filtering (see `~nengo.synapses.Synapse`).
         If *None*, no synapse will be used and information will be transmitted
         without any delay (if supported by the backend---some backends may
@@ -303,39 +302,36 @@ class Connection(NengoObject):
         *None* if components are connected in a cycle. Furthermore, a synaptic
         filter with a zero time constant is different from a *None* synapse
         as a synaptic filter will always add a delay of at least one time step.
-    function : callable or (n_eval_points, size_mid) array_like, \
-               optional (Default: None)
+    function : callable or (n_eval_points, size_mid) array_like, optional
         Function to compute across the connection. Note that ``pre`` must be
         an ensemble to apply a function across the connection.
         If an array is passed, the function is implicitly defined by the
         points in the array and the provided ``eval_points``, which have a
         one-to-one correspondence.
-    transform : (size_out, size_mid) array_like, optional \
-                (Default: ``np.array(1.0)``)
+    transform : (size_out, size_mid) array_like, optional
         Linear transform mapping the pre output to the post input.
         This transform is in terms of the sliced size; if either pre
         or post is a slice, the transform must be shaped according to
         the sliced dimensionality. Additionally, the function is applied
         before the transform, so if a function is computed across the
         connection, the transform must be of shape ``(size_out, size_mid)``.
-    solver : Solver, optional (Default: ``nengo.solvers.LstsqL2()``)
+    solver : Solver, optional
         Solver instance to compute decoders or weights
         (see `~nengo.solvers.Solver`). If ``solver.weights`` is True, a full
         connection weight matrix is computed instead of decoders.
     learning_rule_type : LearningRuleType or iterable of LearningRuleType, \
-                         optional (Default: None)
+                         optional
         Modifies the decoders or connection weights during simulation.
-    eval_points : (n_eval_points, size_in) array_like or int, optional \
-                  (Default: None)
+    eval_points : (n_eval_points, size_in) array_like or int, optional
         Points at which to evaluate ``function`` when computing decoders,
         spanning the interval (-pre.radius, pre.radius) in each dimension.
         If None, will use the eval_points associated with ``pre``.
-    scale_eval_points : bool, optional (Default: True)
+    scale_eval_points : bool, optional
         Indicates whether the evaluation points should be scaled
         by the radius of the pre Ensemble.
-    label : str, optional (Default: None)
+    label : str, optional
         A descriptive label for the connection.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
 
     Attributes

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -27,7 +27,7 @@ class Distribution(FrozenObject):
         ----------
         n : int
             Number samples to take.
-        d : int or None, optional (Default: None)
+        d : int or None, optional
             The number of dimensions to return. If this is an int, the return
             value will be of shape ``(n, d)``. If None, the return
             value will be of shape ``(n,)``.
@@ -97,7 +97,7 @@ class Uniform(Distribution):
         The closed lower bound of the uniform distribution; samples >= low
     high : Number
         The open upper bound of the uniform distribution; samples < high
-    integer : boolean, optional (Default: False)
+    integer : boolean, optional
         If true, sample from a uniform distribution of integers. In this case,
         low and high should be integers.
     """
@@ -176,10 +176,10 @@ class Exponential(Distribution):
     scale : float
         The scale parameter (inverse of the rate parameter lambda). Larger
         values make the distribution narrower (sharper peak).
-    shift : float, optional (Default: 0)
+    shift : float, optional
         Amount to shift the distribution by. There will be no values smaller
         than this shift when sampling from the distribution.
-    high : float, optional (Default: np.inf)
+    high : float, optional
         All values larger than or equal to this value will be clipped to
         slightly less than this value.
     """
@@ -209,11 +209,11 @@ class UniformHypersphere(Distribution):
 
     Parameters
     ----------
-    surface : bool, optional (Default: False)
+    surface : bool, optional
         Whether sample points should be distributed uniformly
         over the surface of the hyperphere (True),
         or within the hypersphere (False).
-    min_magnitude : Number, optional (Default: 0)
+    min_magnitude : Number, optional
         Lower bound on the returned vector magnitudes (such that they are in
         the range ``[min_magnitude, 1]``). Must be in the range [0, 1).
         Ignored if ``surface`` is ``True``.
@@ -260,7 +260,7 @@ class Choice(Distribution):
         The options (choices) to choose between. The choice is always done
         along the first axis, so if ``options`` is a matrix, the options are
         the rows of that matrix.
-    weights : (N,) array_like, optional (Default: None)
+    weights : (N,) array_like, optional
         Weights controlling the probability of selecting each option. Will
         automatically be normalized. If None, weights be uniformly distributed.
     """
@@ -359,7 +359,7 @@ class SqrtBeta(Distribution):
     ----------
     n: int
         Number of subvectors.
-    m: int, optional (Default: 1)
+    m: int, optional
         Length of each subvector.
 
     See also
@@ -446,7 +446,7 @@ class SubvectorLength(SqrtBeta):
     ----------
     dimensions : int
         Dimensionality of the complete unit vector.
-    subdimensions : int, optional (Default: 1)
+    subdimensions : int, optional
         Dimensionality of the subvector.
 
     See also
@@ -568,9 +568,9 @@ def get_samples(dist_or_samples, n, d=None, rng=np.random):
         Source of the samples to be returned.
     n : int
         Number samples to take.
-    d : int or None, optional (Default: None)
+    d : int or None, optional
         The number of dimensions to return.
-    rng : RandomState, optional (Default: np.random)
+    rng : RandomState, optional
         Random number generator.
 
     Returns

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -15,51 +15,46 @@ class Ensemble(NengoObject):
     dimensions : int
         The number of representational dimensions.
 
-    radius : int, optional (Default: 1.0)
+    radius : int, optional
         The representational radius of the ensemble.
-    encoders : Distribution or (n_neurons, dimensions) array_like, optional \
-               (Default: UniformHypersphere(surface=True))
+    encoders : Distribution or (n_neurons, dimensions) array_like, optional
         The encoders used to transform from representational space
         to neuron space. Each row is a neuron's encoder; each column is a
         representational dimension.
-    intercepts : Distribution or (n_neurons,) array_like, optional \
-                 (Default: ``nengo.dists.Uniform(-1.0, 1.0)``)
+    intercepts : Distribution or (n_neurons,) array_like, optional
         The point along each neuron's encoder where its activity is zero. If
         ``e`` is the neuron's encoder, then the activity will be zero when
         ``dot(x, e) <= c``, where ``c`` is the given intercept.
-    max_rates : Distribution or (n_neurons,) array_like, optional \
-                (Default: ``nengo.dists.Uniform(200, 400)``)
+    max_rates : Distribution or (n_neurons,) array_like, optional
         The activity of each neuron when the input signal ``x`` is magnitude 1
         and aligned with that neuron's encoder ``e``;
         i.e., when ``dot(x, e) = 1``.
-    eval_points : Distribution or (n_eval_points, dims) array_like, optional \
-                  (Default: ``nengo.dists.UniformHypersphere()``)
+    eval_points : Distribution or (n_eval_points, dims) array_like, optional
         The evaluation points used for decoder solving, spanning the interval
         (-radius, radius) in each dimension, or a distribution from which
         to choose evaluation points.
-    n_eval_points : int, optional (Default: None)
+    n_eval_points : int, optional
         The number of evaluation points to be drawn from the ``eval_points``
         distribution. If None, then a heuristic is used to determine
         the number of evaluation points.
-    neuron_type : `~nengo.neurons.NeuronType`, optional \
-                  (Default: ``nengo.LIF()``)
+    neuron_type : `~nengo.neurons.NeuronType`, optional
         The model that simulates all neurons in the ensemble
         (see `~nengo.neurons.NeuronType`).
-    gain : Distribution or (n_neurons,) array_like (Default: None)
+    gain : Distribution or (n_neurons,) array_like
         The gains associated with each neuron in the ensemble. If None, then
         the gain will be solved for using ``max_rates`` and ``intercepts``.
-    bias : Distribution or (n_neurons,) array_like (Default: None)
+    bias : Distribution or (n_neurons,) array_like
         The biases associated with each neuron in the ensemble. If None, then
         the gain will be solved for using ``max_rates`` and ``intercepts``.
-    noise : Process, optional (Default: None)
+    noise : Process, optional
         Random noise injected directly into each neuron in the ensemble
         as current. A sample is drawn for each individual neuron on
         every simulation step.
-    normalize_encoders : bool, optional (Default: True)
+    normalize_encoders : bool, optional
         Indicates whether the encoders should be normalized.
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
 
     Attributes

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -60,9 +60,9 @@ class LearningRuleType(FrozenObject, SupportDefaultsMixin):
 
     Parameters
     ----------
-    learning_rate : float, optional (Default: 1e-6)
+    learning_rate : float, optional
         A scalar indicating the rate at which ``modifies`` will be adjusted.
-    size_in : int, str, optional (Default: 0)
+    size_in : int, str, optional
         Dimensionality of the error signal (see above).
 
     Attributes
@@ -129,10 +129,9 @@ class PES(LearningRuleType):
 
     Parameters
     ----------
-    learning_rate : float, optional (Default: 1e-4)
+    learning_rate : float, optional
         A scalar indicating the rate at which weights will be adjusted.
-    pre_synapse : `.Synapse`, optional \
-                  (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+    pre_synapse : `.Synapse`, optional
         Synapse model used to filter the pre-synaptic activities.
 
     Attributes
@@ -190,16 +189,14 @@ class BCM(LearningRuleType):
 
     Parameters
     ----------
-    learning_rate : float, optional (Default: 1e-9)
+    learning_rate : float, optional
         A scalar indicating the rate at which weights will be adjusted.
-    pre_synapse : `.Synapse`, optional \
-                  (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+    pre_synapse : `.Synapse`, optional
         Synapse model used to filter the pre-synaptic activities.
-    post_synapse : `.Synapse`, optional (Default: ``None``)
+    post_synapse : `.Synapse`, optional
         Synapse model used to filter the post-synaptic activities.
         If None, ``post_synapse`` will be the same as ``pre_synapse``.
-    theta_synapse : `.Synapse`, optional \
-                    (Default: ``nengo.synapses.Lowpass(tau=1.0)``)
+    theta_synapse : `.Synapse`, optional
         Synapse model used to filter the theta signal.
 
     Attributes
@@ -280,15 +277,14 @@ class Oja(LearningRuleType):
 
     Parameters
     ----------
-    learning_rate : float, optional (Default: 1e-6)
+    learning_rate : float, optional
         A scalar indicating the rate at which weights will be adjusted.
-    pre_synapse : `.Synapse`, optional \
-                  (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+    pre_synapse : `.Synapse`, optional
         Synapse model used to filter the pre-synaptic activities.
-    post_synapse : `.Synapse`, optional (Default: ``None``)
+    post_synapse : `.Synapse`, optional
         Synapse model used to filter the post-synaptic activities.
         If None, ``post_synapse`` will be the same as ``pre_synapse``.
-    beta : float, optional (Default: 1.0)
+    beta : float, optional
         A scalar weight on the forgetting term.
 
     Attributes
@@ -354,10 +350,11 @@ class Voja(LearningRuleType):
 
     Parameters
     ----------
-    learning_rate : float, optional (Default: 1e-2)
+    post_tau : float, optional
+        Filter constant on activities of neurons in post population.
+    learning_rate : float, optional
         A scalar indicating the rate at which encoders will be adjusted.
-    post_synapse : `.Synapse`, optional \
-                   (Default: ``nengo.synapses.Lowpass(tau=0.005)``)
+    post_synapse : `.Synapse`, optional
         Synapse model used to filter the post-synaptic activities.
 
     Attributes

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -48,12 +48,12 @@ class Network:
 
     Parameters
     ----------
-    label : str, optional (Default: None)
+    label : str, optional
         Name of the network.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed that will be fed to the random number generator.
         Setting the seed makes the network's build process deterministic.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this network will be added to the current container.
         If None, this network will be added to the network at the top of the
         ``Network.context`` stack unless the stack is empty.

--- a/nengo/networks/actionselection.py
+++ b/nengo/networks/actionselection.py
@@ -92,21 +92,21 @@ class BasalGanglia(nengo.Network):
     ----------
     dimensions : int
         Number of dimensions (i.e., actions).
-    n_neurons_per_ensemble : int, optional (Default: 100)
+    n_neurons_per_ensemble : int, optional
         Number of neurons in each ensemble in the network.
-    output_weight : float, optional (Default: -3.)
+    output_weight : float, optional
         A scaling factor on the output of the basal ganglia
         (specifically on the connection out of the GPi).
-    input_bias : float, optional (Default: 0.)
+    input_bias : float, optional
         An amount by which to bias all dimensions of the input node.
         Biasing the input node is important for ensuring that all input
         dimensions are positive and easily comparable.
-    ampa_config : config, optional (Default: None)
+    ampa_config : config, optional
         Configuration for connections corresponding to biological connections
         to AMPA receptors (i.e., connections from STN to to GPi and GPe).
         If None, a default configuration using a 2 ms lowpass synapse
         will be used.
-    gaba_config : config, optional (Default: None)
+    gaba_config : config, optional
         Configuration for connections corresponding to biological connections
         to GABA receptors (i.e., connections from StrD1 to GPi, StrD2 to GPe,
         and GPe to GPi and STN). If None, a default configuration using an
@@ -267,11 +267,11 @@ class Thalamus(nengo.Network):
     ----------
     dimensions : int
         Number of dimensions (i.e., actions).
-    n_neurons_per_ensemble : int, optional (Default: 50)
+    n_neurons_per_ensemble : int, optional
         Number of neurons in each ensemble in the network.
-    mutual_inhib : float, optional (Default: 1.)
+    mutual_inhib : float, optional
         Strength of the mutual inhibition between actions.
-    threshold : float, optional (Default: 0.)
+    threshold : float, optional
         The threshold below which values will not be represented.
     **kwargs
         Keyword arguments passed through to ``nengo.Network``

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -21,26 +21,26 @@ class AssociativeMemory(nengo.Network):
     ----------
     input_vectors: array_like
         The list of vectors to be compared against.
-    output_vectors: array_like, optional (Default: None)
+    output_vectors: array_like, optional
         The list of vectors to be produced for each match. If None, the
         associative memory will be autoassociative (cleanup memory).
-    n_neurons: int, optional (Default: 50)
+    n_neurons: int, optional
         The number of neurons for each of the ensemble (where each ensemble
         represents each item in the input_vectors list).
-    threshold: float, optional (Default: 0.3)
+    threshold: float, optional
         The association activation threshold.
-    input_scales: float or array_like, optional (Default: 1.0)
+    input_scales: float or array_like, optional
         Scaling factor to apply on each of the input vectors. Note that it
         is possible to scale each vector independently.
-    inhibitable: bool, optional (Default: False)
+    inhibitable: bool, optional
         Flag to indicate if the entire associative memory module is
         inhibitable (entire thing can be shut off). The input gain into
         the inhibitory connection is 1.5.
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if the network will be added to the current container.
         If None, will be true if currently within a Network.
     """
@@ -199,7 +199,7 @@ class AssociativeMemory(nengo.Network):
             of the attribute for the associative memory network.
         input_vectors: array_like
             The list of vectors to be compared against.
-        input_scales: float or array_like, optional (Default: 1.0)
+        input_scales: float or array_like, optional
             Scaling factor to apply on each of the input vectors. Note that it
             is possible to scale each vector independently.
         """
@@ -279,12 +279,12 @@ class AssociativeMemory(nengo.Network):
         output_vector: array_like
             The vector to be produced if the input value matches none of
             the vectors in the input vector list.
-        output_name: str, optional (Default: 'output')
+        output_name: str, optional
             The name of the input to which the default output vector
             should be applied.
-        n_neurons: int, optional (Default: 50)
+        n_neurons: int, optional
             Number of neurons to use for the default output vector ensemble.
-        min_activation_value: float, optional (Default: 0.5)
+        min_activation_value: float, optional
             Minimum activation value (i.e. threshold) to use to disable
             the default output vector.
         """
@@ -320,9 +320,9 @@ class AssociativeMemory(nengo.Network):
 
         Parameters
         ----------
-        inhibit_scale: float, optional (Default: 1.5)
+        inhibit_scale: float, optional
             Mutual inhibition scaling factor.
-        inhibit_synapse: float, optional (Default: 0.005)
+        inhibit_synapse: float, optional
             Mutual inhibition synapse time constant.
         """
         if not self.is_wta:
@@ -342,9 +342,9 @@ class AssociativeMemory(nengo.Network):
 
         Parameters
         ----------
-        n_neurons: int, optional (Default: 50)
+        n_neurons: int, optional
             Number of neurons to use for the default output vector ensemble.
-        inhibit_scale: float, optional (Default: 10)
+        inhibit_scale: float, optional
             Mutual inhibition scaling factor.
         """
         if self.thresh_ens is not None:

--- a/nengo/networks/circularconvolution.py
+++ b/nengo/networks/circularconvolution.py
@@ -110,12 +110,12 @@ class CircularConvolution(nengo.Network):
     dimensions : int
         The number of dimensions of the input and output vectors.
 
-    invert_a, invert_b : bool, optional (Default: False, False)
+    invert_a, invert_b : bool, optional
         Whether to reverse the order of elements in either
         the first input (``invert_a``) or the second input (``invert_b``).
         Flipping the second input will make the network perform circular
         correlation instead of circular convolution.
-    input_magnitude : float, optional (Default: 1.0)
+    input_magnitude : float, optional
         The expected magnitude of the vectors to be convolved.
         This value is used to determine the radius of the ensembles
         computing the element-wise product.

--- a/nengo/networks/ensemblearray.py
+++ b/nengo/networks/ensemblearray.py
@@ -34,9 +34,9 @@ class EnsembleArray(nengo.Network):
     n_ensembles : int
         The number of sub-ensembles to create.
 
-    ens_dimensions : int, optional (Default: 1)
+    ens_dimensions : int, optional
         The dimensionality of each sub-ensemble.
-    neuron_nodes : bool, optional (Default: False)
+    neuron_nodes : bool, optional
         Whether to create a node that provides access to each individual
         neuron, typically for the purpose of inhibiting the entire
         EnsembleArray.
@@ -44,12 +44,12 @@ class EnsembleArray(nengo.Network):
         .. note:: Deprecated in Nengo 2.1.0.
                   Call `~.EnsembleArray.add_neuron_input` or
                   `~.EnsembleArray.add_neuron_output` instead.
-    label : str, optional (Default: None)
+    label : str, optional
         A name to assign this EnsembleArray.
         Used for visualization and debugging.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed that will be used in the build step.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this network will be added to the current container.
         If None, this network will be added to the network at the top of the
         ``Network.context`` stack unless the stack is empty.
@@ -222,7 +222,7 @@ class EnsembleArray(nengo.Network):
             The function to compute across the connection from sub-ensembles
             to the new output node. If function is an iterable, it must be
             an iterable consisting of one function for each sub-ensemble.
-        synapse : Synapse, optional (Default: None)
+        synapse : Synapse, optional
             The synapse model with which to filter the connections from
             sub-ensembles to the new output node. This is kept separate from
             the other ``conn_kwargs`` because this defaults to None rather

--- a/nengo/networks/product.py
+++ b/nengo/networks/product.py
@@ -40,7 +40,7 @@ class Product(nengo.Network):
     dimensions : int
         Number of dimensions in each of the vectors to be multiplied.
 
-    input_magnitude : float, optional (Default: 1.)
+    input_magnitude : float, optional
         The expected magnitude of the vectors to be multiplied.
         This value is used to determine the radius of the ensembles
         computing the element-wise product.

--- a/nengo/networks/workingmemory.py
+++ b/nengo/networks/workingmemory.py
@@ -15,14 +15,14 @@ class InputGatedMemory(nengo.Network):
     dimensions : int
         Dimensionality of the vector.
 
-    feedback : float, optional (Default: 1.0)
+    feedback : float, optional
         Strength of the recurrent connection from the memory to itself.
-    difference_gain : float, optional (Default: 1.0)
+    difference_gain : float, optional
         Strength of the connection from the difference ensembles to the
         memory ensembles.
-    recurrent_synapse : float, optional (Default: 0.1)
+    recurrent_synapse : float, optional
 
-    difference_synapse : Synapse (Default: None)
+    difference_synapse : Synapse
         If None, ...
     **kwargs
         Keyword arguments passed through to ``nengo.Network``

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -664,14 +664,14 @@ class Izhikevich(NeuronType):
 
     Parameters
     ----------
-    tau_recovery : float, optional (Default: 0.02)
+    tau_recovery : float, optional
         (Originally 'a') Time scale of the recovery variable.
-    coupling : float, optional (Default: 0.2)
+    coupling : float, optional
         (Originally 'b') How sensitive recovery is to subthreshold
         fluctuations of voltage.
-    reset_voltage : float, optional (Default: -65.)
+    reset_voltage : float, optional
         (Originally 'c') The voltage to reset to after a spike, in millivolts.
-    reset_recovery : float, optional (Default: 8.)
+    reset_recovery : float, optional
         (Originally 'd') The recovery value to reset to after a spike.
 
     References

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -139,14 +139,14 @@ class Node(NengoObject):
     output : callable, array_like, or None
         Function that transforms the Node inputs into outputs,
         a constant output value, or None to transmit signals unchanged.
-    size_in : int, optional (Default: 0)
+    size_in : int, optional
         The number of dimensions of the input data parameter.
-    size_out : int, optional (Default: None)
+    size_out : int, optional
         The size of the output signal. If None, it will be determined
         based on the values of ``output`` and ``size_in``.
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the node. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
         Note: no aspects of the node are random, so currently setting
         this seed has no effect.

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -60,11 +60,11 @@ class Parameter:
 
     Attributes
     ----------
-    coerce_defaults : bool (Default: True)
+    coerce_defaults : bool
         If True, validate values for this parameter when they are set in a
         `.Config` object. Setting a parameter directly on an object will
         always be validated.
-    equatable : bool (Default: False)
+    equatable : bool
         If True, parameter values can be compared for equality
         (``a==b``); otherwise equality checks will just compare object
         identity (``a is b``).

--- a/nengo/presets.py
+++ b/nengo/presets.py
@@ -25,11 +25,11 @@ def ThresholdingEnsembles(threshold, intercept_width=0.15, radius=1.):
     ----------
     threshold : float
         Point at which ensembles should start firing.
-    intercept_width : float, optional (Default: 0.15)
+    intercept_width : float, optional
         Controls how widely distributed the intercepts are. Smaller values
         give more clustering at the threshold, larger values give a more
         uniform distribution.
-    radius : float, optional (Default: 1.)
+    radius : float, optional
         Ensemble radius.
 
     Returns

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -76,21 +76,21 @@ class Probe(NengoObject):
     target : Ensemble, Neurons, Node, or Connection
         The object to probe.
 
-    attr : str, optional (Default: None)
+    attr : str, optional
         The signal to probe. Refer to the target's ``probeable`` list for
         details. If None, the first element in the ``probeable`` list
         will be used.
-    sample_every : float, optional (Default: None)
+    sample_every : float, optional
         Sampling period in seconds. If None, the ``dt`` of the simluation
         will be used.
-    synapse : Synapse, optional (Default: None)
+    synapse : Synapse, optional
         A synaptic model to filter the probed signal.
-    solver : Solver, optional (Default: ``ConnectionDefault``)
+    solver : Solver, optional
         `~nengo.solvers.Solver` to compute decoders
         for probes that require them.
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the probe. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
 
     Attributes

--- a/nengo/processes.py
+++ b/nengo/processes.py
@@ -17,14 +17,14 @@ class WhiteNoise(Process):
 
     Parameters
     ----------
-    dist : Distribution, optional (Default: ``Gaussian(mean=0, std=1)``)
+    dist : Distribution, optional
         The distribution from which to draw samples.
-    scale : bool, optional (Default: True)
+    scale : bool, optional
         Whether to scale the white noise for integration. Integrating white
         noise requires using a time constant of ``sqrt(dt)`` instead of ``dt``
         on the noise term [1]_, to ensure the magnitude of the integrated
         noise does not change with ``dt``.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed. Ensures noise will be the same each run.
 
     References
@@ -69,16 +69,16 @@ class FilteredNoise(Process):
 
     Parameters
     ----------
-    synapse : Synapse, optional (Default: ``Lowpass(tau=0.005)``)
+    synapse : Synapse, optional
         The synapse to use to filter the noise.
-    dist : Distribution, optional (Default: ``Gaussian(mean=0, std=1)``)
+    dist : Distribution, optional
         The distribution used to generate the white noise.
-    scale : bool, optional (Default: True)
+    scale : bool, optional
         Whether to scale the white noise for integration, making the output
         signal invariant to ``dt``.
-    synapse_kwargs : dict, optional (Default: None)
+    synapse_kwargs : dict, optional
         Arguments to pass to ``synapse.make_step``.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed. Ensures noise will be the same each run.
     """
 
@@ -126,9 +126,9 @@ class BrownNoise(FilteredNoise):
 
     Parameters
     ----------
-    dist : Distribution, optional (Default: ``Gaussian(mean=0, std=1)``)
+    dist : Distribution, optional
         The distribution used to generate the white noise.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed. Ensures noise will be the same each run.
     """
 
@@ -161,12 +161,12 @@ class WhiteSignal(Process):
         The cut-off frequency of the low-pass filter, in Hz.
         Must not exceed the Nyquist frequency for the simulation
         timestep, which is ``0.5 / dt``.
-    rms : float, optional (Default: 0.5)
+    rms : float, optional
         The root mean square power of the filtered signal
-    y0 : float, optional (Default: None)
+    y0 : float, optional
         Align the phase of each output dimension to begin at the value
         that is closest (in absolute value) to y0.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed. Ensures noise will be the same each run.
     """
 
@@ -347,7 +347,7 @@ class Piecewise(Process):
         at those times. Times must be numbers (ints or floats), while values
         can be numbers, lists of numbers, numpy arrays of numbers,
         or callables that return any of those options.
-    interpolation : str, optional (Default: 'zero')
+    interpolation : str, optional
         One of 'linear', 'nearest', 'slinear', 'quadratic', 'cubic', or 'zero'.
         Specifies how to interpolate between times with specified value.
         'zero' creates a plain piecewise function whose values begin at

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -84,26 +84,25 @@ class Simulator:
     network : Network or None
         A network object to be built and then simulated. If None,
         then a `.Model` with the build model must be provided instead.
-    dt : float, optional (Default: 0.001)
+    dt : float, optional
         The length of a simulator timestep, in seconds.
-    seed : int, optional (Default: None)
+    seed : int, optional
         A seed for all stochastic operators used in this simulator.
         Will be set to ``network.seed + 1`` if not given.
-    model : Model, optional (Default: None)
+    model : Model, optional
         A `.Model` that contains build artifacts to be simulated.
         Usually the simulator will build this model for you; however, if you
         want to build the network manually, or you want to inject build
         artifacts in the model before building the network, then you can
         pass in a `.Model` instance.
-    progress_bar : bool or ProgressBar, optional \
-                   (Default: True)
+    progress_bar : bool or ProgressBar, optional
         Progress bar for displaying build and simulation progress.
 
         If ``True``, the default progress bar will be used.
         If ``False``, the progress bar will be disabled.
         For more control over the progress bar, pass in a ``ProgressBar``
         instance.
-    optimize : bool, optional (Default: True)
+    optimize : bool, optional
         If ``True``, the builder will run an additional optimization step
         that can speed up simulations significantly at the cost of slower
         builds. If running models for very small amounts of time,
@@ -287,7 +286,7 @@ class Simulator:
         ----------
         time_in_seconds : float
             Amount of time to run the simulation for. Must be positive.
-        progress_bar : bool or ProgressBar, optional (Default: True)
+        progress_bar : bool or ProgressBar, optional
             Progress bar for displaying the progress of the simulation run.
 
             If True, the default progress bar will be used.
@@ -316,7 +315,7 @@ class Simulator:
         ----------
         steps : int
             Number of steps to run the simulation for.
-        progress_bar : bool or ProgressBar, optional (Default: True)
+        progress_bar : bool or ProgressBar, optional
             Progress bar for displaying the progress of the simulation run.
 
             If True, the default progress bar will be used.
@@ -355,7 +354,7 @@ class Simulator:
 
         Parameters
         ----------
-        sample_every : float, optional (Default: None)
+        sample_every : float, optional
             The sampling period of the probe to create a range for.
             If None, a time value for every ``dt`` will be produced.
         """

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -44,7 +44,7 @@ class Solver(FrozenObject, metaclass=DocstringInheritor):
         Y : (n_eval_points, dimensions) array_like
             Matrix of the target decoded values for each of the D dimensions,
             at each of the evaluation points.
-        rng : `numpy.random.RandomState`, optional (Default: ``numpy.random``)
+        rng : `numpy.random.RandomState`, optional
             A random number generator to use as required.
 
         Returns
@@ -72,9 +72,9 @@ class Lstsq(Solver):
 
     Parameters
     ----------
-    weights : bool, optional (Default: False)
+    weights : bool, optional
         If False, solve for decoders. If True, solve for weights.
-    rcond : float, optional (Default: 0.01)
+    rcond : float, optional
         Cut-off ratio for small singular values (see `numpy.linalg.lstsq`).
 
     Attributes
@@ -112,11 +112,11 @@ class _LstsqNoiseSolver(Solver):
         """
         Parameters
         ----------
-        weights : bool, optional (Default: False)
+        weights : bool, optional
             If False, solve for decoders. If True, solve for weights.
-        noise : float, optional (Default: 0.1)
+        noise : float, optional
             Amount of noise, as a fraction of the neuron activity.
-        solver : `.LeastSquaresSolver`, optional (Default: ``Cholesky()``)
+        solver : `.LeastSquaresSolver`, optional
             Subsolver to use for solving the least squares problem.
 
         Attributes
@@ -166,11 +166,11 @@ class _LstsqL2Solver(Solver):
         """
         Parameters
         ----------
-        weights : bool, optional (Default: False)
+        weights : bool, optional
             If False, solve for decoders. If True, solve for weights.
-        reg : float, optional (Default: 0.1)
+        reg : float, optional
             Amount of regularization, as a fraction of the neuron activity.
-        solver : `.LeastSquaresSolver`, optional (Default: ``Cholesky()``)
+        solver : `.LeastSquaresSolver`, optional
             Subsolver to use for solving the least squares problem.
 
         Attributes
@@ -234,11 +234,11 @@ class LstsqL1(Solver):
 
         Parameters
         ----------
-        weights : bool, optional (Default: False)
+        weights : bool, optional
             If False, solve for decoders. If True, solve for weights.
-        l1 : float, optional (Default: 1e-4)
+        l1 : float, optional
             Amount of L1 regularization.
-        l2 : float, optional (Default: 1e-6)
+        l2 : float, optional
             Amount of L2 regularization.
         max_iter : int, optional
             Maximum number of iterations for the underlying elastic net.
@@ -306,13 +306,13 @@ class LstsqDrop(Solver):
         """
         Parameters
         ----------
-        weights : bool, optional (Default: False)
+        weights : bool, optional
             If False, solve for decoders. If True, solve for weights.
-        drop : float, optional (Default: 0.25)
+        drop : float, optional
             Fraction of decoders or weights to set to zero.
-        solver1 : Solver, optional (Default: ``LstsqL2(reg=0.001)``)
+        solver1 : Solver, optional
             Solver for finding the initial decoders.
-        solver2 : Solver, optional (Default: ``LstsqL2(reg=0.1)``)
+        solver2 : Solver, optional
             Used for re-solving for the decoders after dropout.
 
         Attributes
@@ -375,7 +375,7 @@ class Nnls(Solver):
 
         Parameters
         ----------
-        weights : bool, optional (Default: False)
+        weights : bool, optional
             If False, solve for decoders. If True, solve for weights.
 
         Attributes
@@ -423,9 +423,9 @@ class NnlsL2(Nnls):
 
         Parameters
         ----------
-        weights : bool, optional (Default: False)
+        weights : bool, optional
             If False, solve for decoders. If True, solve for weights.
-        reg : float, optional (Default: 0.1)
+        reg : float, optional
             Amount of regularization, as a fraction of the neuron activity.
 
         Attributes
@@ -485,13 +485,13 @@ class NoSolver(Solver):
 
     Parameters
     ----------
-    values : (n_neurons, size_out) array_like, optional (Default: None)
+    values : (n_neurons, size_out) array_like, optional
         The array of decoders to use.
         ``size_out`` is the dimensionality of the decoded signal (determined
         by the connection function).
         If ``None``, which is the default, the solver will return an
         appropriately sized array of zeros.
-    weights : bool, optional (Default: False)
+    weights : bool, optional
         If False, connection will use factored weights (decoders from this
         solver, transform, and encoders).
         If True, connection will use a full weight matrix (created by
@@ -499,13 +499,13 @@ class NoSolver(Solver):
 
     Attributes
     ----------
-    values : (n_neurons, size_out) array_like, optional (Default: None)
+    values : (n_neurons, size_out) array_like, optional
         The array of decoders to use.
         ``size_out`` is the dimensionality of the decoded signal (determined
         by the connection function).
         If ``None``, which is the default, the solver will return an
         appropriately sized array of zeros.
-    weights : bool, optional (Default: False)
+    weights : bool, optional
         If False, connection will use factored weights (decoders from this
         solver, transform, and encoders).
         If True, connection will use a full weight matrix (created by

--- a/nengo/spa/assoc_mem.py
+++ b/nengo/spa/assoc_mem.py
@@ -12,38 +12,38 @@ class AssociativeMemory(Module):
     ----------
     input_vocab: Vocabulary
         The vocabulary to match.
-    output_vocab: Vocabulary, optional (Default: None)
+    output_vocab: Vocabulary, optional
         The vocabulary to be produced for each match. If
         None, the associative memory will act like an autoassociative memory
         (cleanup memory).
-    input_keys : list, optional (Default: None)
+    input_keys : list, optional
         A list of strings that correspond to the input vectors.
-    output_keys : list, optional (Default: None)
+    output_keys : list, optional
         A list of strings that correspond to the output vectors.
-    default_output_key: str, optional (Default: None)
+    default_output_key: str, optional
         The semantic pointer string to be produced if the input value matches
         none of vectors in the input vector list.
-    threshold: float, optional (Default: 0.3)
+    threshold: float, optional
         The association activation threshold.
-    inhibitable: bool, optional (Default: False)
+    inhibitable: bool, optional
         Flag to indicate if the entire associative memory module is
         inhibitable (i.e., the entire module can be inhibited).
-    wta_output: bool, optional (Default: False)
+    wta_output: bool, optional
         Flag to indicate if output of the associative memory should contain
         more than one vector. If True, only one vector's output will be
         produced; i.e. produce a winner-take-all (WTA) output.
         If False, combinations of vectors will be produced.
-    wta_inhibit_scale: float, optional (Default: 3.0)
+    wta_inhibit_scale: float, optional
         Scaling factor on the winner-take-all (WTA) inhibitory connections.
-    wta_synapse: float, optional (Default: 0.005)
+    wta_synapse: float, optional
         Synapse to use for the winner-take-all (wta) inhibitory connections.
-    threshold_output: bool, optional (Default: False)
+    threshold_output: bool, optional
         Adds a threholded output if True.
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/basalganglia.py
+++ b/nengo/spa/basalganglia.py
@@ -16,13 +16,13 @@ class BasalGanglia(nengo.networks.BasalGanglia, Module):
     ----------
     actions : Actions
         The actions to choose between.
-    input_synapse : float, optional (Default: 0.002)
+    input_synapse : float, optional
         The synaptic filter on all input connections.
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/bind.py
+++ b/nengo/spa/bind.py
@@ -14,26 +14,26 @@ class Bind(Module):
     ----------
     dimensions : int
         Number of dimensions for the two vectors to be compared.
-    vocab : Vocabulary, optional (Default: None)
+    vocab : Vocabulary, optional
         The vocabulary to use to interpret the vectors. If None,
         the default vocabulary for the given dimensionality is used.
-    n_neurons : int, optional (Default: 200)
+    n_neurons : int, optional
         Number of neurons to use in each product computation.
-    invert_a, invert_b : bool, optional (Default: False, False)
+    invert_a, invert_b : bool, optional
         Whether to reverse the order of elements in either
         the first input (``invert_a``) or the second input (``invert_b``).
         Flipping the second input will make the network perform circular
         correlation instead of circular convolution.
-    input_magnitude : float, optional (Default: 1.0)
+    input_magnitude : float, optional
         The expected magnitude of the vectors to be convolved.
         This value is used to determine the radius of the ensembles
         computing the element-wise product.
 
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/buffer.py
+++ b/nengo/spa/buffer.py
@@ -19,23 +19,23 @@ class Buffer(Module):
     ----------
     dimensions : int
         Number of dimensions for the vector.
-    subdimensions : int, optional (Default: 16)
+    subdimensions : int, optional
         Size of the individual ensembles making up the vector.
         Must divide ``dimensions`` evenly.
-    neurons_per_dimensions : int, optional (Default: 50)
+    neurons_per_dimensions : int, optional
         Number of neurons in an ensemble will be
         ``neurons_per_dimensions * subdimensions``.
-    vocab : Vocabulary, optional (Default: None)
+    vocab : Vocabulary, optional
         The vocabulary to use to interpret the vector. If None,
         the default vocabulary for the given dimensionality is used.
-    direct : bool, optional (Default: False)
+    direct : bool, optional
         Whether or not to use direct mode for the neurons.
 
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/compare.py
+++ b/nengo/spa/compare.py
@@ -11,21 +11,21 @@ class Compare(Module):
     ----------
     dimensions : int
         Number of dimensions for the two vectors to be compared.
-    vocab : Vocabulary, optional (Default: None)
+    vocab : Vocabulary, optional
         The vocabulary to use to interpret the vector. If None,
         the default vocabulary for the given dimensionality is used.
-    neurons_per_multiply : int, optional (Default: 200)
+    neurons_per_multiply : int, optional
         Number of neurons to use in each product computation.
-    input_magnitude : float, optional (Default: 1.0)
+    input_magnitude : float, optional
         The expected magnitude of the vectors to be multiplied.
         This value is used to determine the radius of the ensembles
         computing the element-wise product.
 
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/cortical.py
+++ b/nengo/spa/cortical.py
@@ -13,16 +13,16 @@ class Cortical(Module):
     ----------
     actions : Actions
         The actions to implement.
-    synapse : float, optional (Default: 0.01)
+    synapse : float, optional
         The synaptic filter to use for the connections.
-    neurons_cconv : int, optional (Default: 200)
+    neurons_cconv : int, optional
         Number of neurons per circular convolution dimension.
 
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/input.py
+++ b/nengo/spa/input.py
@@ -37,11 +37,11 @@ class Input(Module):
 
     Parameters
     ----------
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/memory.py
+++ b/nengo/spa/memory.py
@@ -16,28 +16,28 @@ class Memory(Buffer):
     ----------
     dimensions : int
         Number of dimensions for the vector.
-    subdimensions : int, optional (Default: 16)
+    subdimensions : int, optional
         Size of the individual ensembles making up the vector.
         Must divide ``dimensions`` evenly.
-    neurons_per_dimensions : int, optional (Default: 50)
+    neurons_per_dimensions : int, optional
         Number of neurons in an ensemble will be
         ``neurons_per_dimensions * subdimensions``.
-    synapse : float, optional (Default: 0.01)
+    synapse : float, optional
         Synaptic filter to use on recurrent connection.
-    vocab : Vocabulary, optional (Default: None)
+    vocab : Vocabulary, optional
         The vocabulary to use to interpret the vector. If None,
         the default vocabulary for the given dimensionality is used.
-    tau : float or None, optional (Default: None)
+    tau : float or None, optional
         Effective time constant of the integrator. If None, it should
         have an infinite time constant.
-    direct : bool, optional (Default: False)
+    direct : bool, optional
         Whether or not to use direct mode for the neurons.
 
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -238,7 +238,7 @@ class SPA(nengo.Network):
             Collection of simulation data returned by sim.run() function call.
         probe: Probe
             Probe with desired data.
-        vocab : Vocabulary, optional (Default: None)
+        vocab : Vocabulary, optional
             The vocabulary to compare with. If None, uses the vocabulary
             associated with ``probe.target``.
         """

--- a/nengo/spa/state.py
+++ b/nengo/spa/state.py
@@ -16,33 +16,33 @@ class State(Module):
     ----------
     dimensions : int
         Number of dimensions for the vector.
-    subdimensions : int, optional (Default: 16)
+    subdimensions : int, optional
         The dimension of the individual ensembles making up the vector.
         Must divide ``dimensions`` evenly. The number of sub-ensembles
         will be ``dimensions // subdimensions``.
-    neurons_per_dimension : int, optional (Default: 50)
+    neurons_per_dimension : int, optional
         Number of neurons per dimension. Each ensemble will have
         ``neurons_per_dimension * subdimensions`` neurons, for a total of
         ``neurons_per_dimension * dimensions`` neurons.
-    feedback : float, optional (Default: 0.0)
+    feedback : float, optional
         Gain of feedback connection. Set to 1.0 for perfect memory,
         or 0.0 for no memory. Values in between will create a decaying memory.
-    feedback_synapse : float, optional (Default: 0.1)
+    feedback_synapse : float, optional
         The synapse on the feedback connection.
-    vocab : Vocabulary, optional (Default: None)
+    vocab : Vocabulary, optional
         The vocabulary to use to interpret the vector. If None,
         the default vocabulary for the given dimensionality is used.
-    tau : float or None, optional (Default: None)
+    tau : float or None, optional
         Effective time constant of the integrator. If None, it should
         have an infinite time constant.
-    direct : bool, optional (Default: False)
+    direct : bool, optional
         Whether or not to use direct mode for the neurons.
 
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/thalamus.py
+++ b/nengo/spa/thalamus.py
@@ -16,40 +16,40 @@ class Thalamus(nengo.networks.Thalamus, Module):
     ----------
     bg : spa.BasalGanglia
         The associated basal ganglia that defines the action to implement.
-    neurons_action : int, optional (Default: 50)
+    neurons_action : int, optional
         Number of neurons per action to represent the selection.
-    threshold_action : float, optional (Default: 0.2)
+    threshold_action : float, optional
         Minimum value for action representation.
-    mutual_inhibit : float, optional (Default: 1.0)
+    mutual_inhibit : float, optional
         Strength of inhibition between actions.
-    route_inhibit : float, optional (Default: 3.0)
+    route_inhibit : float, optional
         Strength of inhibition for unchosen actions.
-    synapse_inhibit : float, optional (Default: 0.008)
+    synapse_inhibit : float, optional
         Synaptic filter to apply for inhibition between actions.
-    synapse_bg : float, optional (Default: 0.008)
+    synapse_bg : float, optional
         Synaptic filter for connection between basal ganglia and thalamus.
-    synapse_direct : float, optional (Default: 0.01)
+    synapse_direct : float, optional
         Synaptic filter for direct outputs.
-    neurons_channel_dim : int, optional (Default: 50)
+    neurons_channel_dim : int, optional
         Number of neurons per routing channel dimension.
-    subdim_channel : int, optional (Default: 16)
+    subdim_channel : int, optional
         Number of subdimensions used in routing channel.
-    synapse_channel : float, optional (Default: 0.01)
+    synapse_channel : float, optional
         Synaptic filter for channel inputs and outputs.
-    neurons_cconv : int, optional (Default: 200)
+    neurons_cconv : int, optional
         Number of neurons per circular convolution dimension.
-    neurons_gate : int, optional (Default: 40)
+    neurons_gate : int, optional
         Number of neurons per gate.
-    threshold_gate : float, optional (Default: 0.3)
+    threshold_gate : float, optional
         Minimum value for gating neurons.
-    synapse_to-gate : float, optional (Default: 0.002)
+    synapse_to-gate : float, optional
         Synaptic filter for controlling a gate.
 
-    label : str, optional (Default: None)
+    label : str, optional
         A name for the ensemble. Used for debugging and visualization.
-    seed : int, optional (Default: None)
+    seed : int, optional
         The seed used for random number generation.
-    add_to_container : bool, optional (Default: None)
+    add_to_container : bool, optional
         Determines if this Network will be added to the current container.
         If None, will be true if currently within a Network.
     """

--- a/nengo/spa/utils.py
+++ b/nengo/spa/utils.py
@@ -36,7 +36,7 @@ def similarity(data, vocab, normalize=False):
     vocab: Vocabulary or array_like
         Vocabulary (or list of vectors) to use to calculate
         the similarity values.
-    normalize : bool, optional (Default: False)
+    normalize : bool, optional
         Whether to normalize all vectors, to compute the cosine similarity.
     """
     from nengo.spa.vocab import Vocabulary

--- a/nengo/spa/vocab.py
+++ b/nengo/spa/vocab.py
@@ -20,25 +20,25 @@ class Vocabulary:
     -----------
     dimensions : int
         Number of dimensions for each semantic pointer.
-    randomize : bool, optional (Default: True)
+    randomize : bool, optional
         Whether to randomly generate pointers. If False, the semantic
         pointers will be ``[1, 0, 0, ...], [0, 1, 0, ...], [0, 0, 1, ...]``
         and so on.
-    unitary : bool or list, optional (Default: False)
+    unitary : bool or list, optional
         If True, all generated pointers will be unitary. If a list of
         strings, any pointer whose name is in the list will be forced to be
         unitary when created.
-    max_similarity : float, optional (Default: 0.1)
+    max_similarity : float, optional
         When randomly generating pointers, ensure that the cosine of the
         angle between the new pointer and all existing pointers is less
         than this amount. If the system is unable to find such a pointer
         after 100 tries, a warning message is printed.
-    include_pairs : bool, optional (Default: False)
+    include_pairs : bool, optional
         Whether to keep track of all pairs of pointers as well. This
         is helpful for determining if a vector is similar to ``A*B`` (in
         addition to being similar to ``A`` or ``B``), but exponentially
         increases the processing time.
-    rng : `numpy.random.RandomState`, optional (Default: None)
+    rng : `numpy.random.RandomState`, optional
         The random number generator to use to create new vectors.
 
     Attributes
@@ -259,18 +259,18 @@ class Vocabulary:
         ----------
         v : SemanticPointer or ndarray
             The vector to convert into text.
-        minimum_count : int, optional (Default: 1)
+        minimum_count : int, optional
             Always return at least this many terms in the text.
-        maximum_count : int, optional (Default: None)
+        maximum_count : int, optional
             Never return more than this many terms in the text.
             If None, all terms will be returned.
-        threshold : float, optional (Default: 0.1)
+        threshold : float, optional
             How small a similarity for a term to be ignored.
-        join : str, optional (Default: ';')
+        join : str, optional
             The text separator to use between terms.
-        terms : list, optional (Default: None)
+        terms : list, optional
             Only consider terms in this list of strings.
-        normalize : bool, optional (Default: False)
+        normalize : bool, optional
             Whether to normalize the vector before computing similarity.
         """
         if isinstance(v, pointer.SemanticPointer):
@@ -342,7 +342,7 @@ class Vocabulary:
         ----------
         other : Vocabulary
             The other vocabulary to translate into.
-        keys : list, optional (Default: None)
+        keys : list, optional
             If None, any term that exists in just one of the Vocabularies
             will be created in the other Vocabulary and included. Otherwise,
             the transformation will only consider terms in this list. Any
@@ -424,7 +424,7 @@ class Vocabulary:
         ----------
         keys : list
             List of semantic pointer names to be added to the vocabulary.
-        unitary : bool or list, optional (Default: False)
+        unitary : bool or list, optional
             If True, all generated pointers will be unitary. If a list of
             strings, any pointer whose name is on the list will be forced to
             be unitary when created.

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -29,25 +29,25 @@ class Synapse(Process):
 
     Parameters
     ----------
-    default_size_in : int, optional (Default: 1)
+    default_size_in : int, optional
         The size_in used if not specified.
-    default_size_out : int (Default: None)
+    default_size_out : int
         The size_out used if not specified.
         If None, will be the same as default_size_in.
-    default_dt : float (Default: 0.001 (1 millisecond))
+    default_dt : float
         The simulation timestep used if not specified.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed. Ensures random factors will be the same each run.
 
     Attributes
     ----------
-    default_dt : float (Default: 0.001 (1 millisecond))
+    default_dt : float
         The simulation timestep used if not specified.
-    default_size_in : int (Default: 0)
+    default_size_in : int
         The size_in used if not specified.
-    default_size_out : int (Default: 1)
+    default_size_out : int
         The size_out used if not specified.
-    seed : int, optional (Default: None)
+    seed : int, optional
         Random number seed. Ensures random factors will be the same each run.
     """
 
@@ -67,17 +67,17 @@ class Synapse(Process):
         ----------
         x : array_like
             The signal to filter.
-        dt : float, optional (Default: None)
+        dt : float, optional
             The timestep of the input signal.
             If None, ``default_dt`` will be used.
-        axis : int, optional (Default: 0)
+        axis : int, optional
             The axis along which to filter.
-        y0 : array_like, optional (Default: None)
+        y0 : array_like, optional
             The starting state of the filter output. If None, the initial
             value of the input signal along the axis filtered will be used.
-        copy : bool, optional (Default: True)
+        copy : bool, optional
             Whether to copy the input data, or simply work in-place.
-        filtfilt : bool, optional (Default: False)
+        filtfilt : bool, optional
             If True, runs the process forward then backward on the signal,
             for zero-phase filtering (like Matlab's ``filtfilt``).
         """
@@ -130,10 +130,10 @@ class Synapse(Process):
             The timestep of the simulation.
         rng : `numpy.random.RandomState`
             Random number generator.
-        y0 : array_like, optional (Default: None)
+        y0 : array_like, optional
             The starting state of the filter output. If None, each dimension
             of the state will start at zero.
-        dtype : `numpy.dtype` (Default: np.float64)
+        dtype : `numpy.dtype`
             Type of data used by the synapse model. This is important for
             ensuring that certain synapses avoid or force integer division.
         """
@@ -152,7 +152,7 @@ class LinearFilter(Synapse):
         Numerator coefficients of transfer function.
     den : array_like
         Denominator coefficients of transfer function.
-    analog : boolean, optional (Default: True)
+    analog : boolean, optional
         Whether the synapse coefficients are analog (i.e. continuous-time),
         or discrete. Analog coefficients will be converted to discrete for
         simulation using the simulator ``dt``.

--- a/nengo/transforms.py
+++ b/nengo/transforms.py
@@ -62,7 +62,7 @@ class Dense(Transform):
     ----------
     shape : tuple of int
         The shape of the dense matrix: ``(size_out, size_in)``.
-    init : `.Distribution` or array_like, optional (Default: 1.0)
+    init : `.Distribution` or array_like, optional
         A Distribution used to initialize the transform matrix, or a concrete
         instantiation for the matrix. If the matrix is square we also allow a
         scalar (equivalent to ``np.eye(n) * init``) or a vector (equivalent to
@@ -136,25 +136,24 @@ class Convolution(Transform):
         Shape of the input signal to the convolution; e.g.,
         ``(height, width, channels)`` for a 2D convolution with
         ``channels_last=True``.
-    kernel_size : tuple of int, optional (Default: (3, 3))
+    kernel_size : tuple of int, optional
         Size of the convolutional kernels (1 element for a 1D convolution,
         2 for a 2D convolution, etc.).
-    strides : tuple of int, optional (Default: (1, 1))
+    strides : tuple of int, optional
         Stride of the convolution (1 element for a 1D convolution, 2 for
         a 2D convolution, etc.).
-    padding : ``"same"`` or ``"valid"``, optional (Default: "valid")
+    padding : ``"same"`` or ``"valid"``, optional
         Padding method for input signal. "Valid" means no padding, and
         convolution will only be applied to the fully-overlapping areas of the
         input signal (meaning the output will be smaller). "Same" means that
         the input signal is zero-padded so that the output is the same shape
         as the input.
-    channels_last : bool, optional (Default: True)
+    channels_last : bool, optional
         If ``True`` (default), the channels are the last dimension in the input
         signal (e.g., a 28x28 image with 3 channels would have shape
         ``(28, 28, 3)``).  ``False`` means that channels are the first
         dimension (e.g., ``(3, 28, 28)``).
-    init : `.Distribution` or `~numpy:numpy.ndarray`, optional \
-           (Default: Uniform(-1, 1))
+    init : `.Distribution` or `~numpy:numpy.ndarray`, optional
         A predefined kernel with shape
         ``kernel_size + (input_channels, n_filters)``, or a ``Distribution``
         that will be used to initialize the kernel.
@@ -271,7 +270,7 @@ class ChannelShape:
     ----------
     shape : tuple of int
         Signal shape
-    channels_last : bool, optional (Default: True)
+    channels_last : bool, optional
         If True (default), the last item in ``shape`` represents the channels,
         and the rest are spatial dimensions. Otherwise, the first item in
         ``shape`` is the channel dimension.

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -295,13 +295,13 @@ class RandomizedSVD(LeastSquaresSolver):
 
     Parameters
     ----------
-    n_components : int, optional (Default: 60)
+    n_components : int, optional
         The number of SVD components to compute. A small survey of activity
         matrices suggests that the first 60 components capture almost all
         the variance.
-    n_oversamples : int, optional (Default: 10)
+    n_oversamples : int, optional
         The number of additional samples on the range of A.
-    n_iter : int, optional (Default: 0)
+    n_iter : int, optional
         The number of power iterations to perform (can help with noisy data).
 
     See also

--- a/nengo/utils/matplotlib.py
+++ b/nengo/utils/matplotlib.py
@@ -104,9 +104,9 @@ def rasterplot(time, spikes, ax=None, use_eventplot=False, **kwargs):  # noqa
         Time data from the simulation
     spikes : array
         The spike data with columns for each neuron and 1s indicating spikes
-    ax : matplotlib.axes.Axes, optional (Default: None)
+    ax : matplotlib.axes.Axes, optional
         The figure axes to plot into. If None, we will use current axes.
-    use_eventplot : boolean, optional (Default: False)
+    use_eventplot : boolean, optional
         Whether to use the new Matplotlib `eventplot` routine. It is slower
         and makes larger image files, so we do not use it by default.
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ docs_req = [
     "matplotlib>=1.4",
     "nbsphinx",
     "numpydoc>=0.6",
-    "nengo_sphinx_theme>=0.8",
+    "nengo_sphinx_theme>=0.12.0",
 ]
 optional_req = [
     "scipy>=0.13",


### PR DESCRIPTION
**Motivation and context:**
This PR adds a Sphinx extension that automatically fills in the defaults in the function signatures for parameters. At this point I'm mostly looking for general feedback, there might be some details that would need some discussion and some things that should be done before this PR gets merged (if it gets merged).

The advantages of this approach:

* One has to write less boilerplate within the documentation.
* Inconsistencies between the actual parameter values and documentation are avoided.
* It would allow us to replace `numpydoc` with `sphinx.ext.napoleon` [as mentioned here](https://github.com/nengo/nengo/pull/1349#issuecomment-323463317) which would cut down on an external dependency. Also `sphinx.ext.napoleon` resolves a bug with numfig that I encountered in Nengo SPA.
* The default value gets documented in the function signature as it is usually done in Python docs.
* The default is not documented in the field that is supposed to be for the data type.

Potential disadvantages:

* The default value might be overwritten by a config. That is not evident from the function signature (but also not that evident from our current notation).
* The extension relies on the argument having the same name as the parameter. This allows for wrong values being documented as defaults if an argument and parameter names do not match up. Though that would likely be confusing code that should be avoided ...

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
Currently based on #1349, but doesn't really depend on it and could probably easily be rebased onto master.

**How has this been tested?**
build the documentation and looked and the function signatures

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [x] The default of the `function` argument of `nengo.Connection` cannot be resolved at the moment.
- [x] Go through the documentation and remove manually documented defaults.