### PR TITLE
Progress bar bug fixes and improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,14 @@ Release History
 2.7.1 (unreleased)
 ==================
 
+**Deprecated**
 
+- The ``nengo.ipynb`` IPython extension and the ``IPython2ProgressBar``
+  have been deprecated and replaced by the ``IPython5ProgressBar``.
+  This progress bar will be automatically activated in IPython and
+  Jupyter notebooks from IPython version 5.0 onwards.
+  (`#1087 <https://github.com/nengo/nengo/issues/1087>`_,
+  `#1375 <https://github.com/nengo/nengo/pull/1375>`_)
 
 2.7.0 (March 7, 2018)
 =====================
@@ -71,7 +78,6 @@ Release History
   (`#1406 <https://github.com/nengo/nengo/pull/1406>`_)
 - Fixed the ``--seed-offset`` option of the test suite.
   (`#1409 <https://github.com/nengo/nengo/pull/1409>`_)
-
 
 2.6.0 (October 6, 2017)
 =======================
@@ -401,7 +407,7 @@ Release History
   (`#982 <https://github.com/nengo/nengo/pull/982>`_)
 
 **Bug fixes**
-
+n
 - The DecoderCache is used as context manager instead of relying on the
   ``__del__`` method for cleanup. This should solve problems with the
   cache's file lock not being removed. It might be necessary to

--- a/examples/advanced/functions_and_tuning_curves.ipynb
+++ b/examples/advanced/functions_and_tuning_curves.ipynb
@@ -33,7 +33,6 @@
       "\n",
       "import nengo\n",
       "\n",
-      "%load_ext nengo.ipynb\n",
       "%matplotlib inline"
      ],
      "language": "python",

--- a/examples/advanced/inhibitory_gating.ipynb
+++ b/examples/advanced/inhibitory_gating.ipynb
@@ -22,8 +22,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/advanced/izhikevich.ipynb
+++ b/examples/advanced/izhikevich.ipynb
@@ -34,7 +34,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.utils.matplotlib import rasterplot"
      ],
      "language": "python",

--- a/examples/advanced/matrix_multiplication.ipynb
+++ b/examples/advanced/matrix_multiplication.ipynb
@@ -26,8 +26,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/advanced/nef_summary.ipynb
+++ b/examples/advanced/nef_summary.ipynb
@@ -16,7 +16,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Uniform\n",
       "from nengo.utils.ensemble import tuning_curves\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/advanced/processes.ipynb
+++ b/examples/advanced/processes.ipynb
@@ -44,8 +44,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/2d_representation.ipynb
+++ b/examples/basic/2d_representation.ipynb
@@ -33,7 +33,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "\n",
       "model = nengo.Network(label='2D Representation')\n",
       "with model:\n",

--- a/examples/basic/addition.ipynb
+++ b/examples/basic/addition.ipynb
@@ -28,8 +28,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/combining.ipynb
+++ b/examples/basic/combining.ipynb
@@ -23,8 +23,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/communication_channel.ipynb
+++ b/examples/basic/communication_channel.ipynb
@@ -35,8 +35,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/many_neurons.ipynb
+++ b/examples/basic/many_neurons.ipynb
@@ -28,8 +28,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/multiplication.ipynb
+++ b/examples/basic/multiplication.ipynb
@@ -29,8 +29,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/single_neuron.ipynb
+++ b/examples/basic/single_neuron.ipynb
@@ -23,8 +23,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/squaring.ipynb
+++ b/examples/basic/squaring.ipynb
@@ -29,8 +29,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/basic/two_neurons.ipynb
+++ b/examples/basic/two_neurons.ipynb
@@ -28,8 +28,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/controlled_integrator.ipynb
+++ b/examples/dynamics/controlled_integrator.ipynb
@@ -46,8 +46,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/controlled_integrator2.ipynb
+++ b/examples/dynamics/controlled_integrator2.ipynb
@@ -23,8 +23,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/controlled_oscillator.ipynb
+++ b/examples/dynamics/controlled_oscillator.ipynb
@@ -63,8 +63,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/integrator.ipynb
+++ b/examples/dynamics/integrator.ipynb
@@ -27,8 +27,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/lorenz_attractor.ipynb
+++ b/examples/dynamics/lorenz_attractor.ipynb
@@ -38,8 +38,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/dynamics/oscillator.ipynb
+++ b/examples/dynamics/oscillator.ipynb
@@ -22,8 +22,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/learning/learn_associations.ipynb
+++ b/examples/learning/learn_associations.ipynb
@@ -53,8 +53,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/learning/learn_communication_channel.ipynb
+++ b/examples/learning/learn_communication_channel.ipynb
@@ -39,7 +39,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",

--- a/examples/learning/learn_product.ipynb
+++ b/examples/learning/learn_product.ipynb
@@ -33,7 +33,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",

--- a/examples/learning/learn_square.ipynb
+++ b/examples/learning/learn_square.ipynb
@@ -29,8 +29,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/learning/learn_unsupervised.ipynb
+++ b/examples/learning/learn_unsupervised.ipynb
@@ -35,8 +35,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/networks/basal_ganglia.ipynb
+++ b/examples/networks/basal_ganglia.ipynb
@@ -32,8 +32,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/networks/ensemble_array.ipynb
+++ b/examples/networks/ensemble_array.ipynb
@@ -26,8 +26,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/networks/integrator_network.ipynb
+++ b/examples/networks/integrator_network.ipynb
@@ -27,8 +27,7 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/spa/associative_memory.ipynb
+++ b/examples/spa/associative_memory.ipynb
@@ -35,8 +35,7 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "from nengo import spa\n",
-      "%load_ext nengo.ipynb"
+      "from nengo import spa"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/spa/convolution.ipynb
+++ b/examples/spa/convolution.ipynb
@@ -25,7 +25,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa\n",
       "from nengo.spa import Vocabulary\n",
       "\n",

--- a/examples/spa/question.ipynb
+++ b/examples/spa/question.ipynb
@@ -26,7 +26,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/question_control.ipynb
+++ b/examples/spa/question_control.ipynb
@@ -27,7 +27,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/question_memory.ipynb
+++ b/examples/spa/question_memory.ipynb
@@ -26,7 +26,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_parser.ipynb
+++ b/examples/spa/spa_parser.ipynb
@@ -34,7 +34,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_sequence.ipynb
+++ b/examples/spa/spa_sequence.ipynb
@@ -33,7 +33,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/spa/spa_sequence_routed.ipynb
+++ b/examples/spa/spa_sequence_routed.ipynb
@@ -31,7 +31,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo import spa"
      ],
      "language": "python",

--- a/examples/usage/config.ipynb
+++ b/examples/usage/config.ipynb
@@ -38,7 +38,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.utils.ipython import hide_input\n",
       "hide_input()"
      ],

--- a/examples/usage/delay_node.ipynb
+++ b/examples/usage/delay_node.ipynb
@@ -27,7 +27,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.processes import WhiteSignal"
      ],
      "language": "python",

--- a/examples/usage/exceptions.ipynb
+++ b/examples/usage/exceptions.ipynb
@@ -31,7 +31,6 @@
       "import warnings\n",
       "import nengo\n",
       "import nengo.spa\n",
-      "%load_ext nengo.ipynb\n",
       "\n",
       "def print_exc(func):\n",
       "    try:\n",

--- a/examples/usage/network_design.ipynb
+++ b/examples/usage/network_design.ipynb
@@ -51,7 +51,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Choice\n",
       "from nengo.processes import Piecewise\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/usage/network_design_advanced.ipynb
+++ b/examples/usage/network_design_advanced.ipynb
@@ -41,7 +41,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.dists import Choice\n",
       "from nengo.processes import Piecewise\n",
       "from nengo.utils.ipython import hide_input\n",

--- a/examples/usage/rectified_linear.ipynb
+++ b/examples/usage/rectified_linear.ipynb
@@ -62,7 +62,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "\n",
       "\n",
       "class RectifiedLinear(nengo.neurons.NeuronType):  # Neuron types must subclass `nengo.Neurons`\n",

--- a/examples/usage/strings.ipynb
+++ b/examples/usage/strings.ipynb
@@ -23,8 +23,7 @@
      "collapsed": false,
      "input": [
       "import numpy as np\n",
-      "import nengo\n",
-      "%load_ext nengo.ipynb"
+      "import nengo"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/usage/tuning_curves.ipynb
+++ b/examples/usage/tuning_curves.ipynb
@@ -46,7 +46,6 @@
       "%matplotlib inline\n",
       "\n",
       "import nengo\n",
-      "%load_ext nengo.ipynb\n",
       "from nengo.utils.ensemble import tuning_curves"
      ],
      "language": "python",

--- a/nengo-data/nengorc
+++ b/nengo-data/nengorc
@@ -67,10 +67,3 @@
 # (e.g., 'nengo.utils.progress.ProgressBar'), which Nengo will attempt
 # to load. (str)
 #progress_bar = auto
-
-# Set the progress updating scheme. The default of 'auto' will use a
-# heuristic to select the appropriate updater.
-# Any other string will be interpreted as a module and class name
-# (e.g., 'nengo.utils.progress.UpdateEveryT'), which Nengo will attempt
-# to load. (str)
-#updater = auto

--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -10,14 +10,14 @@ from nengo.ensemble import Ensemble
 from nengo.network import Network
 from nengo.node import Node
 from nengo.probe import Probe
-from nengo.utils.progress import ProgressTracker
+from nengo.utils.progress import Progress
 
 logger = logging.getLogger(__name__)
 nullcontext = contextlib.contextmanager(lambda: (yield))
 
 
 @Builder.register(Network)  # noqa: C901
-def build_network(model, network, progress_bar=False):
+def build_network(model, network, progress=None):
     """Builds a `.Network` object into a model.
 
     The network builder does this by mapping each high-level object to its
@@ -40,17 +40,10 @@ def build_network(model, network, progress_bar=False):
         The model to build into.
     network : Network
         The network to build.
-    progress_bar : bool or `.ProgressBar` or `.ProgressUpdater`, optional \
-                   (Default: False)
-        Progress bar for displaying build progress.
+    progress : `nengo.utils.progress.Progress`, optional
+        Object used to track the build progress.
 
-        If True, the default progress bar will be used.
-        If False, the progress bar will be disabled.
-        For more control over the progress bar, pass in a `.ProgressBar`
-        or `.ProgressUpdater` instance.
-
-        Note that this will only affect top-level networks. Subnetworks
-        cannot have progress bars displayed.
+        Note that this will only affect top-level networks.
 
     Notes
     -----
@@ -68,15 +61,17 @@ def build_network(model, network, progress_bar=False):
         model.seeds[network] = get_seed(network, np.random)
         model.seeded[network] = getattr(network, 'seed', None) is not None
         max_steps = len(network.all_objects) + 1  # +1 for top level network
-        progress = ProgressTracker(max_steps, progress_bar, task="Building")
 
-        def build_callback(obj):
-            if isinstance(obj, tuple(network.objects)):
-                progress.step()
-        model.build_callback = build_callback
-    else:
-        # create noop context manager
-        progress = contextlib.contextmanager(lambda: (yield))()
+        if progress is not None:
+            progress.max_steps = max_steps
+
+            def build_callback(obj):
+                if isinstance(obj, tuple(network.objects)):
+                    progress.step()
+            model.build_callback = build_callback
+
+    if progress is None:
+        progress = Progress()  # dummy progress
 
     # Set config
     old_config = model.config

--- a/nengo/ipynb.py
+++ b/nengo/ipynb.py
@@ -44,7 +44,16 @@ else:
 
 
 def load_ipython_extension(ipython):
-    if has_ipynb_widgets() and rc.get('progress', 'progress_bar') == 'auto':
+    if IPython.version_info[0] >= 5:
+        warnings.warn(
+            "Loading the nengo.ipynb notebook extension is no longer "
+            "required. Progress bars are automatically activated for IPython "
+            "version 5 and later.")
+    elif has_ipynb_widgets() and rc.get('progress', 'progress_bar') == 'auto':
+        warnings.warn(
+            "The nengo.ipynb notebook extension is deprecated. Please upgrade "
+            "to IPython version 5 or later.")
+
         IPythonProgressWidget.load_frontend(ipython)
         rc.set('progress', 'progress_bar', '.'.join((
             __name__, IPython2ProgressBar.__name__)))
@@ -135,6 +144,9 @@ class IPythonProgressWidget(DOMWidget):
     @classmethod
     def load_frontend(cls, ipython):
         """Loads the JavaScript front-end code required by then widget."""
+        warnings.warn(
+            "IPythonProgressWidget is deprecated. Please upgrade to "
+            "IPython version 5 or later.", DeprecationWarning)
         if notebook_version[0] < 4:
             ipython.run_cell_magic('javascript', '', cls.LEGACY_FRONTEND)
         elif ipywidgets.version_info[0] < 5:
@@ -155,6 +167,9 @@ class IPython2ProgressBar(ProgressBar):
     supports_fast_ipynb_updates = True
 
     def __init__(self, task):
+        warnings.warn(
+            "IPython2ProgressBar is deprecated. Please upgrade to IPython "
+            "version 5 or later.", DeprecationWarning)
         super(IPython2ProgressBar, self).__init__(task)
         self._escaped_task = escape(task)
         self._widget = IPythonProgressWidget()

--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -76,7 +76,7 @@ RC_DEFAULTS = {
         'path': nengo.utils.paths.decoder_cache_dir,
     },
     'progress': {
-        'updater': 'auto',
+        'updater': 'auto',  # Deprecated
         'progress_bar': 'auto',
     },
     'exceptions': {

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -159,11 +159,13 @@ class Simulator(object):
                 self.model.build(network,
                                  progress=pt.next_stage("Building", "Build"))
 
-        # Order the steps (they are made in `Simulator.reset`)
-        self.dg = operator_dependency_graph(self.model.operators)
+            # Order the steps (they are made in `Simulator.reset`)
+            self.dg = operator_dependency_graph(self.model.operators)
 
-        if optimize:
-            opmerge_optimize(self.model, self.dg)
+            if optimize:
+                with pt.next_stage(
+                        'Building (running optimizer)', 'Optimization'):
+                    opmerge_optimize(self.model, self.dg)
 
         self._step_order = [op for op in toposort(self.dg)
                             if hasattr(op, 'make_step')]

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -115,18 +115,3 @@ def test_no_outputs(nb_file):
 
     for cell in iter_cells(nb_file):
         assert cell.outputs == [], "Cell outputs not cleared"
-
-
-@pytest.mark.example
-@pytest.mark.parametrize('nb_file', all_examples)
-def test_loads_ipynb_ext(nb_file):
-    pytest.importorskip("IPython", minversion="1.0")
-
-    no_sim = True
-    for cell in iter_cells(nb_file):
-        if "%load_ext nengo.ipynb" in cell.source:
-            break
-        if "nengo.Simulator(" in cell.source:
-            no_sim = False
-    else:
-        assert no_sim, "nengo.ipynb extension not loaded"

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -12,11 +12,13 @@ PY2 = sys.version_info[0] == 2
 
 # If something's changed from Python 2 to 3, we handle that here
 if PY2:
+    from cgi import escape as cgi_escape
     import cPickle as pickle
     import ConfigParser as configparser
     from inspect import getargspec as getfullargspec
     from itertools import izip_longest as zip_longest
     from StringIO import StringIO
+    escape = lambda s, quote=True: cgi_escape(s, quote=quote)
     string_types = (str, unicode)
     int_types = (int, long)
     range = xrange
@@ -78,6 +80,7 @@ if PY2:
 else:
     import pickle
     import configparser
+    from html import escape
     from inspect import getfullargspec
     from io import StringIO
     from itertools import zip_longest

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -80,6 +80,14 @@ except ImportError:
 assert get_ipython
 
 
+def check_ipy_version(min_version):
+    try:
+        import IPython
+        return IPython.version_info >= min_version
+    except ImportError:
+        return False
+
+
 def has_ipynb_widgets():
     """Determines whether IPython widgets are available.
 

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -70,6 +70,19 @@ class TestProgress(object):
             with Progress(-1):
                 pass
 
+    def test_unknown_number_of_steps(self, monkeypatch):
+        t = 1.
+        monkeypatch.setattr(time, 'time', lambda: t)
+
+        with Progress(None) as p:
+            p.step()
+            t = 10.
+            assert p.progress == 0.
+            assert p.eta() == -1
+
+        assert p.n_steps == 1
+        assert p.elapsed_seconds() == 9.
+
 
 class TestAutoProgressBar(object):
     class ProgressMock(object):

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -3,15 +3,13 @@ import time
 import pytest
 
 from nengo.exceptions import ValidationError
-from nengo.utils.progress import (
-    AutoProgressBar, UpdateEveryN, UpdateEveryT, UpdateN, Progress,
-    ProgressBar, ProgressTracker)
+from nengo.utils.progress import AutoProgressBar, Progress, ProgressBar
 
 
 class ProgressBarMock(ProgressBar):
-    def __init__(self, task="Testing"):
+    def __init__(self):
+        super(ProgressBarMock, self).__init__()
         self.n_update_calls = 0
-        super(ProgressBarMock, self).__init__(task)
 
     def update(self, progress):
         self.n_update_calls += 1
@@ -19,7 +17,7 @@ class ProgressBarMock(ProgressBar):
 
 class TestProgress(object):
     def test_progress_calculation(self):
-        with Progress(10) as p:
+        with Progress(max_steps=10) as p:
             assert p.progress == 0.
             for _ in range(5):
                 p.step()
@@ -28,19 +26,19 @@ class TestProgress(object):
             assert p.progress == 1.
 
     def test_finished_property(self):
-        with Progress(10) as p:
+        with Progress(max_steps=10) as p:
             assert not p.finished
             p.step(5)
             assert not p.finished
         assert p.finished
 
     def test_success_property(self):
-        with Progress(10) as p:
+        with Progress(max_steps=10) as p:
             assert p.success is None
         assert p.success
 
         try:
-            with Progress(10) as p2:
+            with Progress(max_steps=10) as p2:
                 raise Exception()
         except Exception:
             pass
@@ -50,31 +48,31 @@ class TestProgress(object):
         t = 1.
         monkeypatch.setattr(time, 'time', lambda: t)
 
-        with Progress(10) as p:
+        with Progress(max_steps=10) as p:
             t = 10.
 
         assert p.elapsed_seconds() == 9.
 
     def test_eta(self):
-        with Progress(10) as p:
+        with Progress(max_steps=10) as p:
             assert p.eta() == -1  # no estimate available yet
             p.step()
             assert p.eta() >= 0.
 
     def test_max_steps(self):
         with pytest.raises(ValidationError):
-            with Progress(0):
+            with Progress(max_steps=0):
                 pass
 
         with pytest.raises(ValidationError):
-            with Progress(-1):
+            with Progress(max_steps=-1):
                 pass
 
     def test_unknown_number_of_steps(self, monkeypatch):
         t = 1.
         monkeypatch.setattr(time, 'time', lambda: t)
 
-        with Progress(None) as p:
+        with Progress() as p:
             p.step()
             t = 10.
             assert p.progress == 0.
@@ -86,10 +84,10 @@ class TestProgress(object):
 
 class TestAutoProgressBar(object):
     class ProgressMock(object):
-        def __init__(self, eta, start_time=1234.5):
+        def __init__(self, eta, time_start=1234.5):
             self.eta = lambda: eta
             self.elapsed_seconds = lambda: 0
-            self.start_time = start_time
+            self.time_start = time_start
             self.finished = False
 
     def test_progress_not_shown_if_eta_below_threshold(self):
@@ -122,56 +120,3 @@ class TestAutoProgressBar(object):
         progress_mock.finished = True
         auto_progress.update(progress_mock)
         assert progress_bar.n_update_calls >= 1
-
-
-class TestUpdateN(object):
-    def test_at_most_n_updates_are_performed(self):
-        progress_bar = ProgressBarMock()
-        updater = UpdateN(progress_bar, max_updates=3)
-
-        with ProgressTracker(100, updater, "Testing") as p:
-            for _ in range(100):
-                p.step()
-
-        assert progress_bar.n_update_calls > 0
-        assert progress_bar.n_update_calls <= 3
-
-
-class TestUpdateEveryN(object):
-    def test_updates_every_n_steps(self):
-        progress_bar = ProgressBarMock()
-        updater = UpdateEveryN(progress_bar, every_n=5)
-
-        with ProgressTracker(100, updater, "Testing") as p:
-            progress_bar.n_update_calls = 0
-            for _ in range(5):
-                p.step()
-            assert progress_bar.n_update_calls == 1
-
-            p.step(2)
-            assert progress_bar.n_update_calls == 1
-            p.step(3)
-            assert progress_bar.n_update_calls == 2
-
-
-class TestUpdateEveryT(object):
-    def test_updates_after_interval_has_passed(self, monkeypatch):
-        progress_bar = ProgressBarMock()
-        updater = UpdateEveryT(progress_bar, every_t=2.)
-        t = 1.
-        monkeypatch.setattr(time, 'time', lambda: t)
-
-        with ProgressTracker(100, updater, "Testing") as p:
-            p.step()  # Update is allowed to happen on first step.
-
-            progress_bar.n_update_calls = 0
-            p.step()
-            assert progress_bar.n_update_calls == 0
-
-            t = 2.
-            p.step()
-            assert progress_bar.n_update_calls == 0
-
-            t = 4.
-            p.step()
-            assert progress_bar.n_update_calls == 1


### PR DESCRIPTION
**Motivation and context:**
This introduces a number of bug fixes improvements to the progress bars.

* Despite #1340, the build progress bar was not working correctly for nested networks.
* The updating frequency in Jupyter notebooks was lower than it should have been (due to the `AutoProgressBar` not reporting the capabilities of the delegate properly).
* Allows progress bar with an unknown number of steps.
* Implements special displays for unknown number of steps for the terminal and IPython progress bars (see below).
* Uses the same space for all build related progress bars and displays the total time for all sub steps in the end. (The ETA for single steps are just for that step.)

![tty](https://user-images.githubusercontent.com/850157/32705043-8b17bf82-c7dd-11e7-9f5e-52548ebf4e0f.gif)
![nov-12-2017 19-10-41](https://user-images.githubusercontent.com/850157/32705044-8e0ac694-c7dd-11e7-874c-7bb0082504f6.gif)

Open questions:

* Remove/deprecate `AutoProgressBar`? The intention of it is to not display the progress bar for short running builds or simulations (of less than one second) to not needlessly clutter up the output. This might have made more sense when there was only a single progress bar (before the build progress bar was introduced). Maybe it makes more sense to always display the progress bars now?
* The build displays progress bars for the actual building and the optimizing as these are the longest running substeps, but there are a few more steps that a progress bar might sense for:
  * Initializing the cache (acquiring the index lock might take 10 seconds before a timeout, though with #1364 this should occur more rarely).
  * Constructing the operator dependency graph.
  * Topo-sorting the dependency graph
  * Initializing the signals

The downside of introducing progress bars for these steps is that a callback needs to introduced into the code (because updating of the progress bars is synchronous, we could make it asynchronous, but that would require to spawn threads which might not be a good idea in a library).

**Interactions with other PRs:**
This PR is based on #1375 and rewrites some of that code again to do updates per JavaScript (to avoid messing with the CSS animations).

**How has this been tested?**
Manually on a bigger model. Also added a unit test to test some aspects of the `Simulator` progress bar (it fails for the buggy implementation of the build progress, but passes for the fixed version).

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Lengthy (more than 150 lines changed or changes are complicated)

**Where should a reviewer start?**
Might make sense to go through commit by commit, though for the `HtmlProgressBar` implementation it might save time to just look at the final implementation.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.