### PR TITLE
Pytest warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - STATIC="false"
     - DOCS="false"
     - CONDA_DEPS="matplotlib jupyter"
-    - PIP_DEPS="pytest pytest-xdist"
+    - PIP_DEPS="pytest"
 
 matrix:
   include:
@@ -76,7 +76,7 @@ script:
           sphinx-build -W docs docs/_build;
         fi
       else
-        py.test nengo -n 2 -v --duration 20;
+        py.test nengo -v --duration 20;
       fi
     fi
 

--- a/examples/advanced/izhikevich.ipynb
+++ b/examples/advanced/izhikevich.ipynb
@@ -304,9 +304,22 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "with nengo.Network(seed=0) as model:\n",
+      "    u = nengo.Node(lambda t: np.sin(2 * np.pi * t))\n",
+      "    ens = nengo.Ensemble(30, dimensions=1, neuron_type=nengo.Izhikevich())\n",
+      "    nengo.Connection(u, ens)\n",
+      "    out_p = nengo.Probe(ens, synapse=0.03)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 16
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
       "from nengo.utils.ensemble import tuning_curves\n",
-      "ens.neuron_type = nengo.Izhikevich()\n",
-      "ens.n_neurons = 30\n",
       "with nengo.Simulator(model) as sim:\n",
       "    plt.figure()\n",
       "    plt.plot(*tuning_curves(ens, sim));"

--- a/examples/dynamics/controlled_oscillator.ipynb
+++ b/examples/dynamics/controlled_oscillator.ipynb
@@ -194,7 +194,7 @@
       "plt.figure()\n",
       "plt.plot(sim.trange(), sim.data[oscillator_probe])\n",
       "plt.xlabel('Time (s)')\n",
-      "plt.legend(['$x_0$', '$x_1$', '$\\omega$']);"
+      "plt.legend(['$x_0$', '$x_1$', r'$\\omega$']);"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/learning/learn_associations.ipynb
+++ b/examples/learning/learn_associations.ipynb
@@ -299,7 +299,7 @@
       "    plt.xlim(-1.5, 1.5)\n",
       "    plt.ylim(-1.5, 2)\n",
       "    plt.legend()\n",
-      "    plt.axes().set_aspect('equal')\n",
+      "    plt.gca().set_aspect('equal')\n",
       "\n",
       "\n",
       "plot_2d(\"Before\", sim.data[p_encoders][0].copy() / scale)\n",

--- a/examples/usage/exceptions.ipynb
+++ b/examples/usage/exceptions.ipynb
@@ -28,13 +28,16 @@
      "collapsed": false,
      "input": [
       "import traceback\n",
+      "import warnings\n",
       "import nengo\n",
       "import nengo.spa\n",
       "%load_ext nengo.ipynb\n",
       "\n",
       "def print_exc(func):\n",
       "    try:\n",
-      "        func()\n",
+      "        with warnings.catch_warnings():\n",
+      "            warnings.simplefilter('ignore')\n",
+      "            func()\n",
       "    except:\n",
       "        traceback.print_exc()"
      ],

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -265,10 +265,22 @@ def seed(request):
 
 
 def pytest_generate_tests(metafunc):
+    marks = [
+        getattr(pytest.mark, m.name)(*m.args, **m.kwargs)
+        for m in getattr(metafunc.function, 'pytestmark', [])]
+
+    def mark_nl(nl):
+        if nl is Sigmoid:
+            nl = pytest.param(nl, marks=[pytest.mark.filterwarnings(
+                'ignore:overflow encountered in exp')] + marks)
+        return nl
+
     if "nl" in metafunc.funcargnames:
-        metafunc.parametrize("nl", TestConfig.neuron_types)
+        metafunc.parametrize(
+            "nl", [mark_nl(nl) for nl in TestConfig.neuron_types])
     if "nl_nodirect" in metafunc.funcargnames:
-        nodirect = [n for n in TestConfig.neuron_types if n is not Direct]
+        nodirect = [mark_nl(n) for n in TestConfig.neuron_types
+                    if n is not Direct]
         metafunc.parametrize("nl_nodirect", nodirect)
 
 

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -111,12 +111,12 @@ def recorder_dirname(request, name):
 
     simulator, nl = TestConfig.RefSimulator, None
     if 'Simulator' in request.funcargnames:
-        simulator = request.getfuncargvalue('Simulator')
+        simulator = request.getfixturevalue('Simulator')
     # 'nl' stands for the non-linearity used in the neuron equation
     if 'nl' in request.funcargnames:
-        nl = request.getfuncargvalue('nl')
+        nl = request.getfixturevalue('nl')
     elif 'nl_nodirect' in request.funcargnames:
-        nl = request.getfuncargvalue('nl_nodirect')
+        nl = request.getfixturevalue('nl_nodirect')
 
     dirname = "%s.%s" % (simulator.__module__, name)
     if nl is not None:
@@ -137,7 +137,7 @@ def parametrize_function_name(request, function_name):
         argnames = request.keywords['parametrize'].args[::2]
         argnames = [x.strip() for names in argnames for x in names.split(',')]
         for name in argnames:
-            value = request.getfuncargvalue(name)
+            value = request.getfixturevalue(name)
             if inspect.isclass(value):
                 value = value.__name__
             suffixes.append('{}={}'.format(name, value))

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import re
 from fnmatch import fnmatch
+import warnings
 
 import matplotlib
 import numpy as np
@@ -49,6 +50,7 @@ class TestConfig(object):
 
 def pytest_configure(config):
     matplotlib.use('agg')
+    warnings.simplefilter('always')
 
     if config.getoption('simulator'):
         TestConfig.Simulator = load_class(config.getoption('simulator')[0])

--- a/nengo/networks/tests/test_product.py
+++ b/nengo/networks/tests/test_product.py
@@ -10,8 +10,7 @@ from nengo.utils.numpy import rmse, maxint
 def test_sine_waves(Simulator, plt, seed):
     radius = 2
     dim = 5
-    product = nengo.networks.Product(
-        200, dim, radius, net=nengo.Network(seed=seed))
+    product = nengo.networks.Product(200, dim, radius, seed=seed)
 
     func_a = lambda t: np.sqrt(radius)*np.sin(np.arange(1, dim+1)*2*np.pi*t)
     func_b = lambda t: np.sqrt(radius)*np.sin(np.arange(dim, 0, -1)*2*np.pi*t)
@@ -47,8 +46,7 @@ def test_direct_mode_with_single_neuron(Simulator, plt, seed):
     config = nengo.Config(nengo.Ensemble)
     config[nengo.Ensemble].neuron_type = nengo.Direct()
     with config:
-        product = nengo.networks.Product(
-            1, dim, radius, net=nengo.Network(seed=seed))
+        product = nengo.networks.Product(1, dim, radius, seed=seed)
 
     func_a = lambda t: np.sqrt(radius)*np.sin(np.arange(1, dim+1)*2*np.pi*t)
     func_b = lambda t: np.sqrt(radius)*np.sin(np.arange(dim, 0, -1)*2*np.pi*t)
@@ -132,7 +130,8 @@ def test_compare_product_benchmark(analytics_data, logger):
     stats = pytest.importorskip('scipy.stats')
     data1, data2 = (d['error'] for d in analytics_data)
     improvement = np.mean(data1) - np.mean(data2)
-    p = np.ceil(1000. * 2. * stats.mannwhitneyu(data1, data2)[1]) / 1000.
+    p = np.ceil(1000. * 2. * stats.mannwhitneyu(
+        data1, data2, alternative='two-sided')[1]) / 1000.
     logger.info("Multiplication improvement by %f (%.0f%%, p < %.3f)",
                 improvement, (1. - np.mean(data2) / np.mean(data1)) * 100., p)
     assert improvement >= 0. or p >= 0.05

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -142,7 +142,7 @@ class Simulator(object):
     def __init__(
             self, network,
             dt=0.001, seed=None, model=None, progress_bar=True, optimize=True):
-        self.closed = False
+        self.closed = True  # Start closed in case constructor raises exception
         self.progress_bar = progress_bar
 
         if model is None:
@@ -181,6 +181,8 @@ class Simulator(object):
                 seed = network.seed + 1
             else:
                 seed = np.random.randint(npext.maxint)
+
+        self.closed = False
         self.reset(seed=seed)
 
     def __del__(self):

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -249,7 +249,7 @@ class LstsqL1(Solver):
     l1 = NumberParam('l1', low=0)
     l2 = NumberParam('l2', low=0)
 
-    def __init__(self, weights=False, l1=1e-4, l2=1e-6):
+    def __init__(self, weights=False, l1=1e-4, l2=1e-6, max_iter=1000):
         """
         .. note:: Requires `scikit-learn <http://scikit-learn.org/stable/>`_.
 
@@ -261,6 +261,8 @@ class LstsqL1(Solver):
             Amount of L1 regularization.
         l2 : float, optional (Default: 1e-6)
             Amount of L2 regularization.
+        max_iter : int, optional
+            Maximum number of iterations for the underlying elastic net.
 
         Attributes
         ----------
@@ -270,12 +272,15 @@ class LstsqL1(Solver):
             Amount of L2 regularization.
         weights : bool
             If False, solve for decoders. If True, solve for weights.
+        max_iter : int
+            Maximum number of iterations for the underlying elastic net.
         """
         import sklearn.linear_model  # noqa F401, import to check existence
         assert sklearn.linear_model
         super(LstsqL1, self).__init__(weights=weights)
         self.l1 = l1
         self.l2 = l2
+        self.max_iter = max_iter
 
     def __call__(self, A, Y, rng=np.random, E=None):
         import sklearn.linear_model
@@ -294,7 +299,8 @@ class LstsqL1(Solver):
 
         # --- solve least-squares A * X = Y
         model = sklearn.linear_model.ElasticNet(
-            alpha=alpha, l1_ratio=l1_ratio, fit_intercept=False, max_iter=1000)
+            alpha=alpha, l1_ratio=l1_ratio, fit_intercept=False,
+            max_iter=self.max_iter)
         model.fit(A, Y)
         X = model.coef_.T
         X.shape = (A.shape[1], Y.shape[1]) if Y.ndim > 1 else (A.shape[1],)

--- a/nengo/spa/action_build.py
+++ b/nengo/spa/action_build.py
@@ -35,7 +35,7 @@ def convolution(module, target_name, effect, n_neurons_cconv, synapse):
             n_neurons_cconv, s1_vocab.dimensions,
             invert_a=False,
             invert_b=False,
-            net=nengo.Network(label='cconv_%s' % str(effect)))
+            label='cconv_%s' % str(effect))
 
     with module.spa:
         # compute the requested transform

--- a/nengo/spa/tests/test_actions.py
+++ b/nengo/spa/tests/test_actions.py
@@ -104,6 +104,7 @@ def test_action():
                    'motor=A, motor2=B', name='test_action')
 
 
+@pytest.mark.filterwarnings('ignore:The actions currently being added')
 def test_actions():
     a = Actions(
         'dot(state, A) --> state=B',

--- a/nengo/spa/tests/test_spa.py
+++ b/nengo/spa/tests/test_spa.py
@@ -3,7 +3,6 @@ import pytest
 import nengo
 from nengo import spa
 from nengo.exceptions import SpaModuleError
-from nengo.utils.testing import warns
 
 
 def test_spa_verification(seed):
@@ -110,7 +109,7 @@ def test_spa_vocab():
     # warning on vocabs with duplicate dimensions
     vc = spa.Vocabulary(16)
     vc.parse("SOCKS")
-    with warns(UserWarning):
+    with pytest.warns(UserWarning):
         model = spa.SPA(vocabs=[va, vb, vc])
     assert model._default_vocabs[16].keys == ["SOCKS"]
     assert model._default_vocabs[32].keys == ["SHOES"]

--- a/nengo/spa/tests/test_vocabulary.py
+++ b/nengo/spa/tests/test_vocabulary.py
@@ -5,7 +5,6 @@ import pytest
 
 from nengo.exceptions import SpaParseError, ValidationError
 from nengo.spa import Vocabulary
-from nengo.utils.testing import warns
 
 
 def test_add(rng):
@@ -176,7 +175,7 @@ def test_create_pointer_warning(rng):
     v = Vocabulary(2, rng=rng)
 
     # five pointers shouldn't fit
-    with warns(UserWarning):
+    with pytest.warns(UserWarning):
         v.parse('A')
         v.parse('B')
         v.parse('C')

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -14,7 +14,6 @@ from nengo.cache import (CacheIndex, DecoderCache, Fingerprint,
 from nengo.exceptions import CacheIOWarning, FingerprintError
 from nengo.solvers import LstsqL2
 from nengo.utils.compat import int_types
-from nengo.utils.testing import warns
 
 
 class SolverMock(object):
@@ -578,7 +577,7 @@ def test_warns_out_of_context(tmpdir):
 
     solver_mock = SolverMock()
     solver = cache.wrap_solver(solver_mock)
-    with warns(UserWarning):
+    with pytest.warns(UserWarning):
         solver(**get_solver_test_args())
     assert SolverMock.n_calls[solver_mock] == 1
 
@@ -645,7 +644,7 @@ def test_writeablecacheindex_warning(monkeypatch, tmpdir):
         raise CalledProcessError(-1, "move")
 
     monkeypatch.setattr(nengo.cache, "replace", raise_error)
-    with warns(CacheIOWarning):
+    with pytest.warns(CacheIOWarning):
         with WriteableCacheIndex(cache_dir=str(tmpdir)):
             pass
 

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -383,7 +383,10 @@ with model:
 
     without_cache = {
         'rc': 'rc.set("decoder_cache", "enabled", "False")',
-        'stmt': 'sim = nengo.Simulator(model)'
+        'stmt': '''
+with nengo.Simulator(model):
+    pass
+'''
     }
 
     with_cache_miss_ro = {
@@ -494,8 +497,9 @@ with nengo.Simulator(model):
             diff = [np.median(b) - np.median(a)
                     for a, b in zip(clean_d1, clean_d2)]
 
-            p_values = np.array([2. * stats.mannwhitneyu(a, b)[1]
-                                 for a, b in zip(clean_d1, clean_d2)])
+            p_values = np.array(
+                [2. * stats.mannwhitneyu(a, b, alternative='two-sided')[1]
+                 for a, b in zip(clean_d1, clean_d2)])
             overall_p = 1. - np.prod(1. - p_values)
             if overall_p < .05:
                 logger.info("  %s: Significant change (p <= %.3f). See plots.",
@@ -559,7 +563,8 @@ cache = nengo.cache.DecoderCache()
 
         diff = np.median(clean_d2) - np.median(clean_d1)
 
-        p_value = 2. * stats.mannwhitneyu(clean_d1, clean_d2)[1]
+        p_value = 2. * stats.mannwhitneyu(
+            clean_d1, clean_d2, alternative='two-sided')[1]
         if p_value < .05:
             logger.info("Significant change of %d seconds (p <= %.3f).",
                         diff, np.ceil(p_value * 1000.) / 1000.)

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -280,7 +280,8 @@ def test_dist_transform(Simulator, seed):
 
     assert isinstance(conn1.transform, nengo.dists.Gaussian)
 
-    sim = Simulator(net)
+    with Simulator(net) as sim:
+        pass
 
     w = sim.data[conn1].weights
     assert np.allclose(np.mean(w), 0.5, atol=0.01)
@@ -299,7 +300,8 @@ def test_dist_transform(Simulator, seed):
         b = nengo.Node(size_in=101)
         conn = nengo.Connection(a, b)
 
-    sim = Simulator(net)
+    with Simulator(net) as sim:
+        pass
     assert np.allclose(w, sim.data[conn].weights)
 
 

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -654,6 +654,7 @@ def test_list_indexing(Simulator, plt, seed):
     assert np.allclose(d_data[t > 0.15], [1, 1], atol=0.1)
 
 
+@pytest.mark.filterwarnings('ignore:boolean index did not match')
 def test_boolean_indexing(Simulator, rng, plt):
     D = 10
     mu = np.arange(D) % 2 == 0
@@ -1007,6 +1008,9 @@ def test_function_names():
         assert str(array_conn).endswith("computing 'ndarray'>")
 
 
+@pytest.mark.filterwarnings('ignore:divide by zero')
+@pytest.mark.filterwarnings('ignore:invalid value')
+@pytest.mark.filterwarnings('ignore:Non-finite values detected')
 def test_zero_activities_error(Simulator):
     with nengo.Network() as model:
         a = nengo.Ensemble(10, 1)

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -165,7 +165,8 @@ def test_copies_structure():
 
 
 def test_network_copy_builds(RefSimulator):
-    RefSimulator(make_network().copy())
+    with RefSimulator(make_network().copy()):
+        pass
 
 
 def test_copy_obj_view():

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -8,7 +8,6 @@ from nengo import spa
 from nengo.exceptions import NetworkContextError, NotAddedToNetworkWarning
 from nengo.params import IntParam, iter_params
 from nengo.utils.compat import is_array_like, pickle
-from nengo.utils.testing import warns
 
 
 def assert_is_copy(cp, original):
@@ -271,7 +270,7 @@ class TestCopy(object):
         original = make_f()
         copy(original)  # Fine because not in a network
         with nengo.Network():
-            with warns(NotAddedToNetworkWarning):
+            with pytest.warns(NotAddedToNetworkWarning):
                 copy(original)
 
 
@@ -290,7 +289,7 @@ class TestPickle(object):
         original = make_f()
         pkl = pickle.dumps(original)
         with nengo.Network():
-            with warns(NotAddedToNetworkWarning):
+            with pytest.warns(NotAddedToNetworkWarning):
                 pickle.loads(pkl)
 
 

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -3,7 +3,6 @@ import pytest
 
 import nengo.dists as dists
 import nengo.utils.numpy as npext
-from nengo.utils.testing import warns
 from nengo.exceptions import ValidationError
 
 
@@ -97,7 +96,7 @@ def test_hypersphere_dimension_fail(rng):
 
 
 def test_hypersphere_warns(rng):
-    with warns(UserWarning):
+    with pytest.warns(UserWarning):
         dists.UniformHypersphere(surface=True, min_magnitude=0.1)
 
 

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -6,14 +6,14 @@ import nengo.utils.numpy as npext
 from nengo.dists import Choice, Gaussian, UniformHypersphere
 from nengo.exceptions import BuildError
 from nengo.processes import WhiteNoise, FilteredNoise
-from nengo.utils.testing import warns, allclose
+from nengo.utils.testing import allclose
 
 
 def test_missing_attribute():
     with nengo.Network():
         a = nengo.Ensemble(10, 1)
 
-        with warns(SyntaxWarning):
+        with pytest.warns(SyntaxWarning):
             a.dne = 9
 
 
@@ -208,7 +208,7 @@ def test_eval_points_number_warning(Simulator, seed):
     with model:
         A = nengo.Ensemble(5, 1, n_eval_points=10, eval_points=[[0.1], [0.2]])
 
-    with warns(UserWarning):
+    with pytest.warns(UserWarning):
         # n_eval_points doesn't match actual passed eval_points, which warns
         with Simulator(model) as sim:
             pass

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -401,6 +401,7 @@ def test_no_norm_encoders(Simulator):
 
 
 @pytest.mark.parametrize('intercept', [1.0, 1.1])
+@pytest.mark.filterwarnings('ignore:divide by zero')
 def test_raises_exception_for_invalid_intercepts(Simulator, intercept):
     with nengo.Network() as model:
         nengo.Ensemble(1, 1, intercepts=[intercept])

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -287,7 +287,8 @@ def test_invalid_rates(Simulator):
                        neuron_type=nengo.LIF(tau_ref=0.01))
 
     with pytest.raises(ValueError):
-        Simulator(model)
+        with Simulator(model):
+            pass
 
 
 def test_gain_bias(Simulator):
@@ -296,7 +297,7 @@ def test_gain_bias(Simulator):
     D = 2
 
     gain = np.random.uniform(low=0.2, high=5, size=N)
-    bias = np.random.uniform(low=0.2, high=1, size=N)
+    bias = np.random.uniform(low=1.2, high=2, size=N)
 
     model = nengo.Network()
     with model:

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -69,6 +69,7 @@ def assert_noexceptions(nb_file, tmpdir):
 
 @pytest.mark.example
 @pytest.mark.parametrize('nb_file', fast_examples)
+@pytest.mark.filterwarnings("ignore:Creating new attribute 'memory_location'")
 def test_fast_noexceptions(nb_file, tmpdir):
     """Ensure that no cells raise an exception."""
     assert_noexceptions(nb_file, tmpdir)

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -288,21 +288,19 @@ def test_dt_dependence(Simulator, plt, learning_rule, seed, rng):
     # differ due to lowered presynaptic firing rate
     dts = (0.0001, 0.001)
     colors = ('b', 'g', 'r')
+    ax1 = plt.subplot(2, 1, 1)
+    ax2 = plt.subplot(2, 1, 2)
     for c, dt in zip(colors, dts):
         with Simulator(m, dt=dt) as sim:
             sim.run(0.1)
         trans_data.append(sim.data[m.weights_p])
-        plt.subplot(2, 1, 1)
-        plt.plot(sim.trange(dt=0.01), sim.data[m.weights_p][..., 0], c=c)
-        plt.subplot(2, 1, 2)
-        plt.plot(sim.trange(), sim.data[m.activity_p], c=c)
+        ax1.plot(sim.trange(dt=0.01), sim.data[m.weights_p][..., 0], c=c)
+        ax2.plot(sim.trange(), sim.data[m.activity_p], c=c)
 
-    plt.subplot(2, 1, 1)
-    plt.xlim(right=sim.trange()[-1])
-    plt.ylabel("Connection weight")
-    plt.subplot(2, 1, 2)
-    plt.xlim(right=sim.trange()[-1])
-    plt.ylabel("Presynaptic activity")
+    ax1.set_xlim(right=sim.trange()[-1])
+    ax1.set_ylabel("Connection weight")
+    ax2.set_xlim(right=sim.trange()[-1])
+    ax2.set_ylabel("Presynaptic activity")
 
     assert np.allclose(trans_data[0], trans_data[1], atol=3e-3)
     assert not np.allclose(sim.data[m.weights_p][0], sim.data[m.weights_p][-1])

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -340,24 +340,22 @@ def test_dt_dependence(Simulator, nl_nodirect, plt, seed, rng):
     out_data = []
     dts = (0.0001, 0.001)
     colors = ('b', 'g', 'r')
+    ax1 = plt.subplot(2, 1, 1)
+    ax2 = plt.subplot(2, 1, 2)
     for c, dt in zip(colors, dts):
         with Simulator(m, dt=dt, seed=seed+1) as sim:
             sim.run(0.1)
         t = sim.trange(dt=0.001)
         activity_data.append(sim.data[activity_p])
         out_data.append(sim.data[out_p])
-        plt.subplot(2, 1, 1)
-        plt.plot(t, sim.data[out_p], c=c)
-        plt.subplot(2, 1, 2)
+        ax1.plot(t, sim.data[out_p], c=c)
         # Just plot 5 neurons
-        plt.plot(t, sim.data[activity_p][..., :5], c=c)
+        ax2.plot(t, sim.data[activity_p][..., :5], c=c)
 
-    plt.subplot(2, 1, 1)
-    plt.xlim(right=t[-1])
-    plt.ylabel("Decoded output")
-    plt.subplot(2, 1, 2)
-    plt.xlim(right=t[-1])
-    plt.ylabel("Neural activity")
+    ax1.set_xlim(right=t[-1])
+    ax1.set_ylabel("Decoded output")
+    ax2.set_xlim(right=t[-1])
+    ax2.set_ylabel("Neural activity")
 
     assert rmse(activity_data[0], activity_data[1]) < ((1. / dt) * 0.01)
     assert np.allclose(out_data[0], out_data[1], atol=0.05)

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -308,6 +308,7 @@ def test_sigmoid_response_curves(Simulator, max_rate, intercept):
 
 @pytest.mark.parametrize("max_rate,intercept", [
     (300., 1.1), (300., 1.0), (100., 0.9), (100, 1.0)])
+@pytest.mark.filterwarnings('ignore:divide by zero')
 def test_sigmoid_invalid(Simulator, max_rate, intercept):
     """Check that invalid sigmoid ensembles raise an error."""
     with nengo.Network() as m:
@@ -473,6 +474,7 @@ def test_frozen():
         d.coupling = 8
 
 
+@pytest.mark.filterwarnings('ignore:divide by zero')
 def test_direct_mode_nonfinite_value(Simulator):
     with nengo.Network() as model:
         e1 = nengo.Ensemble(10, 1, neuron_type=Direct())

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -3,7 +3,6 @@ import pytest
 
 import nengo
 from nengo.exceptions import SimulationError, ValidationError
-from nengo.utils.testing import warns
 
 
 def test_time(Simulator):
@@ -257,7 +256,7 @@ def test_set_output(Simulator):
 
     with nengo.Network() as model:
         # if output is None, size_out == size_in
-        with warns(UserWarning):
+        with pytest.warns(UserWarning):
             # warns since size_in != size_out and output is None
             passthrough = nengo.Node(None, size_in=20, size_out=30)
         assert passthrough.output is None

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -325,6 +325,7 @@ def test_iter_params_does_not_list_obsolete_params():
     assert set(params.iter_params(Test())) == {'p1', 'p2'}
 
 
+@pytest.mark.filterwarnings("ignore:'Node.size_out' is being overwritten")
 def test_configure_all_nengo_parameters():
 
     # make up a non-default value for the parameter

--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -247,7 +247,7 @@ def test_update_timing(Simulator):
     with nengo.Network() as net:
         inp = nengo.Node([1])
         ens = nengo.Ensemble(10, 1, encoders=np.ones((10, 1)),
-                             gain=np.ones(10), bias=np.zeros(10))
+                             gain=np.ones(10), bias=np.ones(10))
         nengo.Connection(inp, ens, synapse=None)
 
         sig_p = nengo.Probe(ens.neurons, 'input', synapse=0)
@@ -256,4 +256,4 @@ def test_update_timing(Simulator):
         sim.run(0.003)
 
     assert np.allclose(sim.data[sig_p][0], 0)
-    assert np.allclose(sim.data[sig_p][1:], 1)
+    assert np.allclose(sim.data[sig_p][1:], 2)

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -12,7 +12,6 @@ from nengo.exceptions import ValidationError
 from nengo.processes import (BrownNoise, FilteredNoise, Piecewise,
                              PresentInput, WhiteNoise, WhiteSignal)
 from nengo.synapses import Lowpass
-from nengo.utils.testing import warns
 
 
 class DistributionMock(Distribution):
@@ -405,7 +404,7 @@ class TestPiecewise(object):
         # Emulate not having scipy in case we have scipy
         monkeypatch.setitem(sys.modules, "scipy.interpolate", None)
 
-        with warns(UserWarning):
+        with pytest.warns(UserWarning):
             process = Piecewise({0.05: 1, 0.1: 0}, interpolation='linear')
         assert process.interpolation == 'zero'
 
@@ -523,6 +522,6 @@ class TestPiecewise(object):
         def func(t):
             return t
 
-        with warns(UserWarning):
+        with pytest.warns(UserWarning):
             process = Piecewise({0.05: 0, 0.1: func}, interpolation='linear')
         assert process.interpolation == 'zero'

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -440,15 +440,16 @@ class TestPiecewise(object):
             0.1: [-0.5, -0.25]
         }
 
+        ax1 = plt.subplot(2, 1, 1)
+        ax2 = plt.subplot(2, 1, 2)
+
         def test_and_plot(interp):
             t, f = self.run_sim(data, interp, Simulator)
             assert np.allclose(f[t == 0.05], [1., 0.5])
             assert np.allclose(f[t == 0.075], [-1., -0.5])
             assert np.allclose(f[t == 0.1], [-0.5, -0.25])
-            plt.subplot(2, 1, 1)
-            plt.plot(t, f.T[0], label=interp)
-            plt.subplot(2, 1, 2)
-            plt.plot(t, f.T[1], label=interp)
+            ax1.plot(t, f.T[0], label=interp)
+            ax2.plot(t, f.T[1], label=interp)
 
         test_and_plot('zero')
         test_and_plot('linear')

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -10,7 +10,6 @@ from nengo.builder.operator import DotInc
 from nengo.builder.signal import Signal
 from nengo.exceptions import ObsoleteError, SimulatorClosed, ValidationError
 from nengo.utils.compat import ResourceWarning
-from nengo.utils.testing import warns
 
 
 def test_steps(RefSimulator):
@@ -126,7 +125,7 @@ def test_warn_on_opensim_del(Simulator):
         nengo.Ensemble(10, 1)
 
     sim = Simulator(net)
-    with warns(ResourceWarning):
+    with pytest.warns(ResourceWarning):
         sim.__del__()
     sim.close()
 
@@ -281,7 +280,7 @@ def test_invalid_run_time(Simulator):
     with Simulator(net) as sim:
         with pytest.raises(ValidationError):
             sim.run(-0.0001)
-        with warns(UserWarning):
+        with pytest.warns(UserWarning):
             sim.run(0)
         sim.run(0.0006)  # Rounds up to 0.001
         assert sim.n_steps == 1

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -146,7 +146,7 @@ def test_subsolvers(Solver, seed, rng, tol=1e-2):
 
 @pytest.mark.parametrize('Solver', [
     Factory(LstsqL2, solver=Factory(lstsq.RandomizedSVD)),
-    LstsqL1])
+    Factory(LstsqL1, max_iter=2000)])
 def test_decoder_solver_extra(Solver, plt, rng):
     pytest.importorskip('sklearn')
     test_decoder_solver(Solver, plt, rng)
@@ -250,6 +250,7 @@ def test_subsolvers_L2(rng, logger):
 
 
 @pytest.mark.noassertions
+@pytest.mark.filterwarnings('ignore:Objective did not converge.')
 def test_subsolvers_L1(rng, logger):
     pytest.importorskip('sklearn')
 
@@ -261,13 +262,15 @@ def test_subsolvers_L1(rng, logger):
     logger.info('duration: %0.3f', t.duration)
 
 
+@pytest.mark.slow
 def test_compare_solvers(Simulator, plt, seed):
     pytest.importorskip('sklearn')
 
     N = 70
     decoder_solvers = [
-        Lstsq(), LstsqNoise(), LstsqL2(), LstsqL2nz(), LstsqL1()]
-    weight_solvers = [LstsqL1(weights=True), LstsqDrop(weights=True)]
+        Lstsq(), LstsqNoise(), LstsqL2(), LstsqL2nz(), LstsqL1(max_iter=5000)]
+    weight_solvers = [
+        LstsqL1(weights=True, max_iter=5000), LstsqDrop(weights=True)]
 
     tfinal = 4
 

--- a/nengo/utils/compat.py
+++ b/nengo/utils/compat.py
@@ -14,6 +14,7 @@ PY2 = sys.version_info[0] == 2
 if PY2:
     import cPickle as pickle
     import ConfigParser as configparser
+    from inspect import getargspec as getfullargspec
     from itertools import izip_longest as zip_longest
     from StringIO import StringIO
     string_types = (str, unicode)
@@ -77,6 +78,7 @@ if PY2:
 else:
     import pickle
     import configparser
+    from inspect import getfullargspec
     from io import StringIO
     from itertools import zip_longest
     from os import replace
@@ -101,6 +103,7 @@ else:
 
 assert pickle
 assert configparser
+assert getfullargspec
 assert replace
 assert zip_longest
 

--- a/nengo/utils/logging.py
+++ b/nengo/utils/logging.py
@@ -32,6 +32,11 @@ def log(level='warning', path=None):
     path : string (optional)
         Path of a file to append log messages to. If ``None`` (default),
         messages are logged to the console.
+
+    Returns
+    -------
+    logging handler
+        The logging handler setup by this function.
     """
     if level.upper() not in ('CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'):
         raise ValueError("Invalid logging level")
@@ -55,6 +60,7 @@ def log(level='warning', path=None):
         logging.root.addHandler(handler)
     handler.setLevel(level)
     logging.captureWarnings(True)
+    return handler
 
 
 class CaptureLogHandler(logging.StreamHandler):

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import collections
 import inspect
 import itertools
 import logging
@@ -9,7 +8,6 @@ import re
 import sys
 import threading
 import time
-import warnings
 
 import numpy as np
 
@@ -187,59 +185,6 @@ class Logger(Recorder):
                 fp.write(self.handler.stream.getvalue())
             self.handler.close()
             del self.handler
-
-
-RecordedWarning = collections.namedtuple(
-    'RecordedWarning', ['message', 'category', 'filename', 'lineno', 'module'])
-
-
-class WarningCatcher(object):
-
-    def __init__(self):
-        self.recorded = []
-
-    def warn_explicit(self, message, category, filename, lineno,
-                      module=None, registry=None, mod_globals=None):
-        self.recorded.append(RecordedWarning(
-            message, category, filename, lineno, module))
-        self.old_warn_explicit(
-            message, category, filename, lineno, module, registry, mod_globals)
-
-    def warn(self, message, category=None, stacklevel=1):
-        if isinstance(message, Warning):
-            category = type(message)
-        category = UserWarning if category is None else category
-        # warnings.warn uses sys._getframe and other mechanisms to get
-        # the filename, lineno, and module. We won't bother for now.
-        self.recorded.append(RecordedWarning(
-            message, category, None, None, None))
-        # We increase stacklevel by 1 to account for this function being
-        # in the stack trace.
-        self.old_warn(message, category, stacklevel + 1)
-
-    def __enter__(self):
-        self.old_warn_explicit = warnings.warn_explicit
-        self.old_warn = warnings.warn
-        warnings.warn_explicit = self.warn_explicit
-        warnings.warn = self.warn
-        return self
-
-    def __exit__(self, type, value, traceback):
-        warnings.warn_explicit = self.old_warn_explicit
-        warnings.warn = self.old_warn
-
-
-class warns(WarningCatcher):
-    def __init__(self, warning_type):
-        import pytest
-        self._pytest = pytest
-        self.warning_type = warning_type
-        super(warns, self).__init__()
-
-    def __exit__(self, type, value, traceback):
-        if not any(r.category is self.warning_type for r in self.recorded):
-            self._pytest.fail("DID NOT WARN")
-        super(warns, self).__exit__(type, value, traceback)
 
 
 def allclose(t, targets, signals,  # noqa: C901

--- a/nengo/utils/tests/test_connection.py
+++ b/nengo/utils/tests/test_connection.py
@@ -10,6 +10,7 @@ from nengo.utils.numpy import rms
 
 @pytest.mark.parametrize("dimensions", [1, 4])
 @pytest.mark.parametrize("radius", [1, 2.0])
+@pytest.mark.filterwarnings("ignore:'targets' can be passed directly")
 def test_target_function(Simulator, nl_nodirect, plt, dimensions, radius,
                          seed, rng):
     eval_points = UniformHypersphere().sample(1000, dimensions, rng=rng)

--- a/nengo/utils/tests/test_functions_piecewise.py
+++ b/nengo/utils/tests/test_functions_piecewise.py
@@ -5,6 +5,7 @@ from nengo.exceptions import ValidationError
 from nengo.utils.functions import piecewise
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_basic():
     f = piecewise({0.5: 1, 1.0: 0})
     assert np.allclose(f(-10), [0])
@@ -17,6 +18,7 @@ def test_basic():
     assert np.allclose(f(100), [0])
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_lists():
     f = piecewise({0.5: [1, 0], 1.0: [0, 1]})
     assert np.allclose(f(-10), [0, 0])
@@ -29,24 +31,28 @@ def test_lists():
     assert np.allclose(f(100), [0, 1])
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_invalid_key():
     with pytest.raises(ValidationError):
         f = piecewise({0.5: 1, 1: 0, 'a': 0.2})
         assert f
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_invalid_length():
     with pytest.raises(ValidationError):
         f = piecewise({0.5: [1, 0], 1.0: [1, 0, 0]})
         assert f
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_invalid_function_length():
     with pytest.raises(ValidationError):
         f = piecewise({0.5: 0, 1.0: lambda t: [t, t ** 2]})
         assert f
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_function():
     f = piecewise({0: np.sin, 0.5: np.cos})
     assert np.allclose(f(0), [np.sin(0)])
@@ -57,6 +63,7 @@ def test_function():
     assert np.allclose(f(1.0), [np.cos(1.0)])
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_function_list():
 
     def func1(t):

--- a/nengo/utils/tests/test_lock.py
+++ b/nengo/utils/tests/test_lock.py
@@ -5,7 +5,14 @@ import time
 
 import pytest
 
+from nengo.utils.compat import PY2
 from nengo.utils.lock import FileLock, TimeoutError
+
+if PY2:
+    filter_resourcewarning = lambda fn: fn
+else:
+    filter_resourcewarning = pytest.mark.filterwarnings(
+        'ignore::ResourceWarning')
 
 
 def acquire_lock(filename):
@@ -36,6 +43,7 @@ def test_can_acquire_filelock_at_most_once(tmpdir):
     assert p.exitcode == 0
 
 
+@filter_resourcewarning
 def test_process_termination_releases_lock(tmpdir):
     filename = os.path.join(str(tmpdir), 'lock')
     p = multiprocessing.Process(target=acquire_lock_and_idle, args=(filename,))

--- a/nengo/utils/tests/test_logging.py
+++ b/nengo/utils/tests/test_logging.py
@@ -17,13 +17,16 @@ def test_log_to_console():
 
 def test_log_to_file(tmpdir):
     tmpfile = str(tmpdir.join("log.txt"))
-    nengo.log(path=tmpfile)
-    n_handlers = len(logging.root.handlers)
-    handler = logging.root.handlers[-1]
-    assert logging.root.getEffectiveLevel() == logging.WARNING
-    assert isinstance(handler, logging.FileHandler)
-    assert handler.baseFilename == tmpfile
-    nengo.log('debug', path=tmpfile)
-    assert logging.root.getEffectiveLevel() == logging.DEBUG
-    assert len(logging.root.handlers) == n_handlers
-    logging.root.handlers.remove(handler)
+    handler = nengo.log(path=tmpfile)
+    try:
+        n_handlers = len(logging.root.handlers)
+        handler = logging.root.handlers[-1]
+        assert logging.root.getEffectiveLevel() == logging.WARNING
+        assert isinstance(handler, logging.FileHandler)
+        assert handler.baseFilename == tmpfile
+        nengo.log('debug', path=tmpfile)
+        assert logging.root.getEffectiveLevel() == logging.DEBUG
+        assert len(logging.root.handlers) == n_handlers
+        logging.root.handlers.remove(handler)
+    finally:
+        handler.close()

--- a/nengo/utils/tests/test_magic.py
+++ b/nengo/utils/tests/test_magic.py
@@ -1,5 +1,6 @@
 import inspect
 
+from nengo.utils.compat import getfullargspec
 from nengo.utils.magic import decorator
 
 state = None  # Used to make sure decorators are running
@@ -36,7 +37,7 @@ def test_function():
     _test_decorated(f)
 
     # Make sure introspection works
-    assert inspect.getargspec(f).args == ['a', 'b']
+    assert getfullargspec(f).args == ['a', 'b']
     assert inspect.getsource(f) == ('    @test_decorator\n'
                                     '    def f(a, b):\n'
                                     '        """Return 1."""\n'
@@ -63,7 +64,7 @@ def test_boundfunction():
     _test_decorated(inst.f)
 
     # Make sure introspection works
-    assert inspect.getargspec(inst.f).args == ['self', 'a', 'b']
+    assert getfullargspec(inst.f).args == ['self', 'a', 'b']
     assert inspect.getsource(inst.f) == ('        @test_decorator\n'
                                          '        def f(self, a, b):\n'
                                          '            """Return 1."""\n'
@@ -92,7 +93,7 @@ def test_staticmethod():
     _test_decorated(inst.f)
 
     # Make sure introspection works
-    assert inspect.getargspec(inst.f).args == ['a', 'b']
+    assert getfullargspec(inst.f).args == ['a', 'b']
     assert inspect.getsource(inst.f) == ('        @test_decorator\n'
                                          '        @staticmethod\n'
                                          '        def f(a, b):\n'
@@ -112,7 +113,7 @@ def test_staticmethod():
     _test_decorated(inst.f)
 
     # Make sure introspection works
-    assert inspect.getargspec(inst.f).args == ['a', 'b']
+    assert getfullargspec(inst.f).args == ['a', 'b']
     assert inspect.getsource(inst.f) == ('        @staticmethod\n'
                                          '        @test_decorator\n'
                                          '        def f(a, b):\n'
@@ -144,7 +145,7 @@ def test_classmethod():
     _test_decorated(inst.f)
 
     # Make sure introspection works
-    assert inspect.getargspec(inst.f).args == ['cls', 'a', 'b']
+    assert getfullargspec(inst.f).args == ['cls', 'a', 'b']
     assert inspect.getsource(inst.f) == ('        @test_decorator\n'
                                          '        @classmethod\n'
                                          '        def f(cls, a, b):\n'
@@ -164,7 +165,7 @@ def test_classmethod():
     _test_decorated(inst.f)
 
     # Make sure introspection works
-    assert inspect.getargspec(inst.f).args == ['cls', 'a', 'b']
+    assert getfullargspec(inst.f).args == ['cls', 'a', 'b']
     assert inspect.getsource(inst.f) == ('        @classmethod\n'
                                          '        @test_decorator\n'
                                          '        def f(cls, a, b):\n'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 matplotlib>=1.4
 jupyter
-pytest
+pytest>=3.2

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'all_solvers': ["scipy>=0.13", "scikit-learn"],
     },
     tests_require=[
-        'pytest>=2.3',
+        'pytest>=3.2',
     ],
     entry_points={
         'nengo.backends': [

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,12 @@ markers =
     example: Mark a test as an example.
     noassertions: Mark a test without assertions. It will only be run if plots or analytics data are produced.
     slow: Mark a test as slow to skip it per default.
+filterwarnings =
+    ignore::ImportWarning
+    ignore:(Buffer|Memory):DeprecationWarning
+    ignore:Skipping some optimization steps
+    ignore:SciPy is not installed
+    ignore:numpy.(dtype|ufunc) size changed
 
 [tox]
 envlist = py27,py33,py34,static


### PR DESCRIPTION
**Motivation and context:**
Starting with pytest 3.2 it displays warnings raised during tests. At the moment this produces a lot of noise when running the tests and requires a lot of scrolling to find the actual test failures; on Travis CI it might even cut off the log (though you can download a full log). Also, at least one of the warnings did highlight a relevant problem that required fixing for future compatibility.

Note that this bumps up the pytest requirement (for tests) to 3.2 (for `pytest.filterwarnings`).

This is currently work in progress. See to do list below for details. Creating this PR to make sure that the tests do not fail on Travis-CI (as we had warnings related problems in #1011 before, [though it seems to be fixed now](https://github.com/nengo/nengo/issues/1378#issuecomment-342571414)).

Closes #1378.

**Interactions with other PRs:**
For a particular Python 3.4 the latest available IPython/Jupyter notebook versions produce a bunch of warnings that are most likely related to the progress bar. These will probably be fixed with the merge of #1380.

**How has this been tested?**
existing tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

<!--- - Quick (less than 40 lines changed or changes are straightforward) -->
- Average (neither quick nor lengthy)
<!--- - Lengthy (more than 150 lines changed or changes are complicated) -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry. [not user facing]
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [x] At the moment there is still a large number of warnings related to Sigmoid (and RectifiedLinear) neurons that will require some understanding of the test cases and what exactly causes the warnings for those neuron types. These might be warnings hinting at actual problems with the tests (at least for Sigmoid neurons).
- [x] There is a warning in one example produced on purpose. Not sure at the moment what the best way to filter it out is.
- [n/a] There is some `ResourceWarning` output that is shown immediatly when running the tests, but does not enter the warning summary. 😕 --> not our fault, but an issue with xdist: pytest-dev/pytest-xdist#247
- [x] Warnings when SciPy is not installed.
- [x] slow tests
- [x] logging tests
- [x] analytics + compare tests