### PR TITLE
Allow to slice learning rule error signal input.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Release History
 
 **Changed**
 
+- Learning rules can now be sliced when providing error input.
+  (`#1365 <https://github.com/nengo/nengo/issues/1365>`_,
+  `#1385 <https://github.com/nengo/nengo/pull/1385>`_)
 - The order of parameters in learning rules has changed such that
   ``learning_rate`` always comes first.
   (`#1095 <https://github.com/nengo/nengo/pull/1095>`__)

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -574,6 +574,9 @@ class LearningRule(object):
         # +1 to avoid collision with ensemble
         return hash(self._connection) + hash(self.learning_rule_type) + 1
 
+    def __getitem__(self, key):
+        return ObjView(self, key)
+
     @property
     def connection(self):
         """(Connection) The connection modified by the learning rule."""


### PR DESCRIPTION
**Motivation and context:**
#1310 added the possibility for error signals of arbitrary size in learning rules. But to combine multiple low-dimensional signal into higher-dimensional error signals, one had to got through a node. This PR adds the possibility to slice into the error signal to make this use case easier to use.

Fixes #1365.

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)?
- New feature (non-breaking change which adds functionality)?

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
