### PR TITLE
Set sim seed from network if sim seed not given.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,10 @@ Release History
 - Default values can no longer be set for
   ``Ensemble.n_neurons`` or ``Ensemble.dimensions``.
   (`#1372 <https://github.com/nengo/nengo/pull/1372>`__)
+- If the simulator seed is not specified, it will now be set
+  from the network seed if a network seed is specified.
+  (`#980 <https://github.com/nengo/nengo/issues/980>`__,
+  `#1386 <https://github.com/nengo/nengo/pull/1386>`__)
 
 **Fixed**
 

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -89,6 +89,7 @@ class Simulator(object):
         The length of a simulator timestep, in seconds.
     seed : int, optional (Default: None)
         A seed for all stochastic operators used in this simulator.
+        Will be set to ``network.seed + 1`` if not given.
     model : Model, optional (Default: None)
         A `.Model` that contains build artifacts to be simulated.
         Usually the simulator will build this model for you; however, if you
@@ -175,7 +176,11 @@ class Simulator(object):
         # Provide a nicer interface to probe outputs
         self.data = ProbeDict(self._probe_outputs)
 
-        seed = np.random.randint(npext.maxint) if seed is None else seed
+        if seed is None:
+            if network is not None and network.seed is not None:
+                seed = network.seed + 1
+            else:
+                seed = np.random.randint(npext.maxint)
         self.reset(seed=seed)
 
     def __del__(self):

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -285,3 +285,12 @@ def test_invalid_run_time(Simulator):
             sim.run(0)
         sim.run(0.0006)  # Rounds up to 0.001
         assert sim.n_steps == 1
+
+
+def test_sim_seed_set_by_network_seed(Simulator, seed):
+    with nengo.Network(seed=seed) as model:
+        pass
+    with nengo.Simulator(model) as sim:
+        sim_seed = sim.seed
+    with nengo.Simulator(model) as sim:
+        assert sim.seed == sim_seed


### PR DESCRIPTION
**Motivation and context:**
Issue #980 hasn't gotten any attention in a while, but apparently the last decision was to implement the behavior as in this PR, i.e. to set the simulator seed from the network seed if no simulator seed is given. Still seems like a good idea to me because today I was again surprised that my network with a process was behaving non-deterministic despite a network seed being set.

Fixes #980.

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)?
- New feature (non-breaking change which adds functionality)?

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.