### PR TITLE
Allow PES.pre_tau to be 0 or None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Release History
 - Default values can no longer be set for
   ``Ensemble.n_neurons`` or ``Ensemble.dimensions``.
   (`#1372 <https://github.com/nengo/nengo/pull/1372>`__)
+- ``PES.pre_tau`` can now be >= 0 or None. (`TODO <pr link>`_)
 
 **Fixed**
 

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -562,7 +562,11 @@ def build_pes(model, pes, rule):
     model.add_op(Reset(error))
     model.sig[rule]['in'] = error  # error connection will attach here
 
-    acts = model.build(Lowpass(pes.pre_tau), model.sig[conn.pre_obj]['out'])
+    acts = model.sig[conn.pre_obj]['out']
+
+    # Filter presynaptic activities
+    if pes.pre_tau is not None:
+        acts = model.build(Lowpass(pes.pre_tau), acts)
 
     # Compute the correction, i.e. the scaled negative error
     correction = Signal(np.zeros(error.shape), name="PES:correction")

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -111,7 +111,7 @@ class PES(LearningRuleType):
     modifies = 'decoders'
     probeable = ('error', 'correction', 'activities', 'delta')
 
-    pre_tau = NumberParam('pre_tau', low=0, low_open=True)
+    pre_tau = NumberParam('pre_tau', low=0, optional=True)
 
     def __init__(self, learning_rate=1e-4, pre_tau=0.005):
         if learning_rate >= 1.0:
@@ -126,7 +126,7 @@ class PES(LearningRuleType):
         if self.learning_rate != 1e-4:
             args.append("learning_rate=%g" % self.learning_rate)
         if self.pre_tau != 0.005:
-            args.append("pre_tau=%g" % self.pre_tau)
+            args.append("pre_tau=%s" % self.pre_tau)
         return args
 
 

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -14,7 +14,8 @@ from nengo.processes import WhiteSignal
 def _test_pes(Simulator, nl, plt, seed,
               pre_neurons=False, post_neurons=False, weight_solver=False,
               vin=np.array([0.5, -0.5]), vout=None, n=200,
-              function=None, transform=np.array(1.), rate=1e-3):
+              function=None, transform=np.array(1.), rate=1e-3,
+              pre_tau=0.005):
 
     vout = np.array(vin) if vout is None else vout
 
@@ -36,7 +37,7 @@ def _test_pes(Simulator, nl, plt, seed,
 
         conn = nengo.Connection(pre, post,
                                 function=function, transform=transform,
-                                learning_rule_type=PES(rate))
+                                learning_rule_type=PES(rate, pre_tau=pre_tau))
         if weight_solver:
             conn.solver = nengo.solvers.LstsqL2(weights=True)
 
@@ -73,9 +74,11 @@ def _test_pes(Simulator, nl, plt, seed,
     assert not np.allclose(weights[0], weights[-1], atol=1e-5)
 
 
-def test_pes_ens_ens(Simulator, nl_nodirect, plt, seed):
+@pytest.mark.parametrize("pre_tau", (0.005, 0, None))
+def test_pes_ens_ens(Simulator, pre_tau, nl_nodirect, plt, seed):
     function = lambda x: [x[1], x[0]]
-    _test_pes(Simulator, nl_nodirect, plt, seed, function=function)
+    _test_pes(Simulator, nl_nodirect, plt, seed, function=function,
+              pre_tau=pre_tau)
 
 
 def test_pes_weight_solver(Simulator, plt, seed):


### PR DESCRIPTION
**Motivation and context:**
``PES.pre_tau`` was previously restricted to be > 0, but I don't think there's anything wrong with letting it be 0 or `None` if the user wants.

**How has this been tested?**
Added `pre_tau` parameter to the tests in `test_pes_ens_ens`

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.