### PR TITLE
Make conda install quiet as workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - if [[ "$SCIPY" == "true" ]]; then
       export CONDA_DEPS="$CONDA_DEPS scipy";
     fi
-  - if [[ -n "$CONDA_DEPS" ]]; then eval conda install "$CONDA_DEPS"; fi
+  - if [[ -n "$CONDA_DEPS" ]]; then eval conda install --quiet "$CONDA_DEPS"; fi
   - if [[ -n "$PIP_DEPS" ]]; then eval pip install "$PIP_DEPS"; fi
 
 # Run the tests


### PR DESCRIPTION
**Motivation and context:**
As noted in #1392, TravisCI has started crashing during conda installs. After consulting [various issues](https://github.com/travis-ci/travis-ci/issues/8934) this seems to be caused by writing too much output. This is resolved by quietly installing `conda`.

**Note**: One of the recommended workarounds is setting `.travisci` to `filter_secret: false`, however this didn't work. ):

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
