### PR TITLE
Index lists with double references using negative indices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,9 @@ Release History
 - Fixed validation checks that prevented the default
   from being set on certain parameters.
   (`#1372 <https://github.com/nengo/nengo/pull/1372>`__)
+- Fixed an issue with repeated elements in slices in which
+  a positive and negative index referred to the same dimension.
+  (`#1395 <https://github.com/nengo/nengo/pull/1395>`_)
 - The ``Simulator.n_steps`` and ``Simulator.time`` properties
   now return scalars, as was stated in the documentation.
   (`#1406 <https://github.com/nengo/nengo/pull/1406>`_)

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -150,13 +150,14 @@ class ObjView(object):
         self.obj = obj
 
         # Node.size_in != size_out, so one of these can be invalid
+        # NumPy <= 1.8 rises a ValueError instead of an IndexError.
         try:
             self.size_in = np.arange(self.obj.size_in)[key].size
         except (IndexError, ValueError):
             self.size_in = None
         try:
             self.size_out = np.arange(self.obj.size_out)[key].size
-        except IndexError:
+        except (IndexError, ValueError):
             self.size_out = None
         if self.size_in is None and self.size_out is None:
             raise IndexError("Invalid slice '%s' of %s" % (key, self.obj))

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -150,7 +150,7 @@ class ObjView(object):
         self.obj = obj
 
         # Node.size_in != size_out, so one of these can be invalid
-        # NumPy <= 1.8 rises a ValueError instead of an IndexError.
+        # NumPy <= 1.8 raises a ValueError instead of an IndexError.
         try:
             self.size_in = np.arange(self.obj.size_in)[key].size
         except (IndexError, ValueError):

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -615,7 +615,8 @@ def test_slicing_function(Simulator, plt, seed):
     assert np.allclose(w, y, atol=0.1)
 
 
-def test_list_indexing(Simulator, plt, seed):
+@pytest.mark.parametrize("negative_indices", (True, False))
+def test_list_indexing(Simulator, plt, seed, negative_indices):
 
     with nengo.Network(seed=seed) as model:
         u = nengo.Node([-1, 1])
@@ -623,10 +624,16 @@ def test_list_indexing(Simulator, plt, seed):
         b = nengo.Ensemble(40, dimensions=1, radius=2.2)
         c = nengo.Ensemble(80, dimensions=2, radius=1.3)
         d = nengo.Ensemble(80, dimensions=2, radius=1.3)
-        nengo.Connection(u[[0, 1]], a[[0, 0]])
-        nengo.Connection(u[[1, 1]], b[[0, 0]])
-        nengo.Connection(u[[0, 1]], c[[0, 1]])
-        nengo.Connection(u[[1, 1]], d[[0, 1]])
+        if negative_indices:
+            nengo.Connection(u[[0, 1]], a[[0, -1]])
+            nengo.Connection(u[[1, -1]], b[[0, -1]])
+            nengo.Connection(u[[0, 1]], c[[0, 1]])
+            nengo.Connection(u[[1, -1]], d[[0, 1]])
+        else:
+            nengo.Connection(u[[0, 1]], a[[0, 0]])
+            nengo.Connection(u[[1, 1]], b[[0, 0]])
+            nengo.Connection(u[[0, 1]], c[[0, 1]])
+            nengo.Connection(u[[1, 1]], d[[0, 1]])
 
         a_probe = nengo.Probe(a, synapse=0.03)
         b_probe = nengo.Probe(b, synapse=0.03)
@@ -644,16 +651,17 @@ def test_list_indexing(Simulator, plt, seed):
 
     line = plt.plot(t, a_data)
     plt.axhline(0, color=line[0].get_color())
-    assert np.allclose(a_data[t > 0.15], [0], atol=0.1)
     line = plt.plot(t, b_data)
     plt.axhline(2, color=line[0].get_color())
-    assert np.allclose(b_data[t > 0.15], [2], atol=0.1)
     line = plt.plot(t, c_data)
     plt.axhline(-1, color=line[0].get_color())
-    assert np.allclose(c_data[t > 0.15], [-1, 1], atol=0.1)
     line = plt.plot(t, d_data)
     plt.axhline(1, color=line[1].get_color())
-    assert np.allclose(d_data[t > 0.15], [1, 1], atol=0.1)
+
+    assert np.allclose(a_data[t > 0.15], [0], atol=0.15)
+    assert np.allclose(b_data[t > 0.15], [2], atol=0.15)
+    assert np.allclose(c_data[t > 0.15], [-1, 1], atol=0.15)
+    assert np.allclose(d_data[t > 0.15], [1, 1], atol=0.15)
 
 
 @pytest.mark.filterwarnings('ignore:boolean index did not match')


### PR DESCRIPTION
**Motivation and context:**
There is one special case with sliced indexing that still does not correctly work: If a list of indices references the same index twice, but once with a positive integer and once with a negative integer, one of those will overwrite the other one when the slicing is done on an input. This PR fixes that by converting all indices to positive indices (as a canonical representation) before checking for repeated indices.

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
I'd recommend going commit by commit, but the PR is small enough that looking at the full diff should work too.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
