### PR TITLE
Create a custom op for PES learning rule

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,9 @@ Release History
 - The ``NeuronType.current`` and ``NeuronType.rates`` methods now document
   the supported shapes of parameters and return values.
   (`#1437 <https://github.com/nengo/nengo/pull/1437>`__)
+- PES learning updates are now applied on the next timestep rather than
+  the current one.
+  (`#1398 <https://github.com/nengo/nengo/pull/1398>`_)
 
 **Deprecated**
 
@@ -123,6 +126,8 @@ Release History
 - Removed the ``probe_all`` function. It can now be found in
   `nengo_extras <https://github.com/nengo/nengo_extras/>`__.
   (`#1187 <https://github.com/nengo/nengo/pull/1187>`_)
+- ``PES.correction`` is no longer probeable.
+  (`#1398 <https://github.com/nengo/nengo/pull/1398>`_)
 
 **Fixed**
 

--- a/docs/backend_api.rst
+++ b/docs/backend_api.rst
@@ -71,6 +71,8 @@ Operators
 
 .. autoclass:: nengo.builder.neurons.SimNeurons
 
+.. autoclass:: nengo.builder.learning_rules.SimPES
+
 .. autoclass:: nengo.builder.learning_rules.SimBCM
 
 .. autoclass:: nengo.builder.learning_rules.SimOja

--- a/docs/examples/usage/strings.ipynb
+++ b/docs/examples/usage/strings.ipynb
@@ -266,6 +266,8 @@
     "print(nengo.builder.operator.SimPyFunc(sig, lambda x: 0.0, True, sig))\n",
     "print(nengo.builder.operator.SimPyFunc(\n",
     "    sig, lambda x: 0.0, True, sig, tag=\"tag\"))\n",
+    "print(nengo.builder.learning_rules.SimPES(sig, sig, sig, sig, 0.1))\n",
+    "print(nengo.builder.learning_rules.SimPES(sig, sig, sig, sig, 0.1, tag=\"tag\"))\n",
     "print(nengo.builder.learning_rules.SimBCM(sig, sig, sig, sig, 0.1))\n",
     "print(nengo.builder.learning_rules.SimBCM(sig, sig, sig, sig, 0.1, tag=\"tag\"))\n",
     "print(nengo.builder.learning_rules.SimOja(sig, sig, sig, sig, 0.1, 1.0))\n",

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -1,12 +1,120 @@
 import numpy as np
 
 from nengo.builder import Builder, Operator, Signal
-from nengo.builder.operator import DotInc, ElementwiseInc, Copy, Reset
+from nengo.builder.operator import Copy, Reset
 from nengo.connection import LearningRule
-from nengo.ensemble import Ensemble, Neurons
+from nengo.ensemble import Ensemble
 from nengo.exceptions import BuildError
 from nengo.learning_rules import BCM, Oja, PES, Voja
 from nengo.node import Node
+
+
+class SimPES(Operator):
+    r"""Calculate connection weight change according to the PES rule.
+
+    Implements the PES learning rule of the form
+
+    .. math:: \Delta \omega_{ij} = \frac{\kappa}{n} e_j a_i
+
+    where
+
+    * :math:`\kappa` is a scalar learning rate,
+    * :math:`n` is the number of presynaptic neurons
+    * :math:`e_j` is the error for the jth output dimension, and
+    * :math:`a_i` is the activity of a presynaptic neuron.
+
+    Parameters
+    ----------
+    pre_filtered : Signal
+        The presynaptic activity, :math:`a_i`.
+    error : Signal
+        The error signal, :math:`e_j`.
+    delta : Signal
+        The synaptic weight change to be applied, :math:`\Delta \omega_{ij}`.
+    learning_rate : float
+        The scalar learning rate, :math:`\kappa`.
+    encoders : Signal, optional
+        If not None, multiply the error signal by these post-synaptic
+        encoders (in the case that we want to learn a neuron-to-neuron
+        weight matrix instead of decoder weights).
+    tag : str, optional (Default: None)
+        A label associated with the operator, for debugging purposes.
+
+    Attributes
+    ----------
+    pre_filtered : Signal
+        The presynaptic activity, :math:`a_i`.
+    error : Signal
+        The error signal, :math:`e_j`.
+    delta : Signal
+        The synaptic weight change to be applied, :math:`\Delta \omega_{ij}`.
+    learning_rate : float
+        The scalar learning rate, :math:`\kappa`.
+    encoders : Signal, optional
+        If not None, multiply the error signal by these post-synaptic
+        encoders (in the case that we want to learn a neuron-to-neuron
+        weight matrix instead of decoder weights).
+    tag : str, optional (Default: None)
+        A label associated with the operator, for debugging purposes.
+
+    Notes
+    -----
+    1. sets ``[]``
+    2. incs ``[]``
+    3. reads ``[pre_filtered, error, encoders]``
+    4. updates ``[delta]``
+    """
+
+    def __init__(self, pre_filtered, error, delta, learning_rate,
+                 encoders=None, tag=None):
+        super(SimPES, self).__init__(tag=tag)
+
+        self.learning_rate = learning_rate
+
+        self.sets = []
+        self.incs = []
+        self.reads = [pre_filtered, error] + (
+            [] if encoders is None else [encoders])
+        self.updates = [delta]
+
+    @property
+    def delta(self):
+        return self.updates[0]
+
+    @property
+    def encoders(self):
+        return None if len(self.reads) < 3 else self.reads[2]
+
+    @property
+    def error(self):
+        return self.reads[1]
+
+    @property
+    def pre_filtered(self):
+        return self.reads[0]
+
+    def _descstr(self):
+        return 'pre=%s, error=%s -> %s' % (
+            self.pre_filtered, self.error, self.delta)
+
+    def make_step(self, signals, dt, rng):
+        pre_filtered = signals[self.pre_filtered]
+        error = signals[self.error]
+        delta = signals[self.delta]
+        n_neurons = pre_filtered.shape[0]
+        alpha = -self.learning_rate * dt / n_neurons
+
+        if self.encoders is None:
+            def step_simpes():
+                np.outer(alpha * error, pre_filtered, out=delta)
+        else:
+            encoders = signals[self.encoders]
+
+            def step_simpes():
+                np.outer(alpha * np.dot(encoders, error), pre_filtered,
+                         out=delta)
+
+        return step_simpes
 
 
 class SimBCM(Operator):
@@ -207,7 +315,6 @@ class SimOja(Operator):
 
             # perform update
             delta[...] += np.outer(alpha * post_filtered, pre_filtered)
-
         return step_simoja
 
 
@@ -317,6 +424,7 @@ class SimVoja(Operator):
             delta[...] = alpha * learning_signal * (
                 scale * np.outer(post_filtered, pre_decoded)
                 - post_filtered[:, np.newaxis] * scaled_encoders)
+
         return step_simvoja
 
 
@@ -536,12 +644,7 @@ def build_pes(model, pes, rule):
     """Builds a `.PES` object into a model.
 
     Calls synapse build functions to filter the pre activities,
-    and adds several operators to implement the PES learning rule.
-    Unlike other learning rules, there is no corresponding `.Operator`
-    subclass for the PES rule. Instead, the rule is implemented with
-    generic operators like `.ElementwiseInc` and `.DotInc`.
-    Generic operators are used because they are more likely to be
-    implemented on other backends like Nengo OCL.
+    and adds a `.SimPES` operator to the model to calculate the delta.
 
     Parameters
     ----------
@@ -569,40 +672,16 @@ def build_pes(model, pes, rule):
     acts = build_or_passthrough(model, pes.pre_synapse,
                                 model.sig[conn.pre_obj]['out'])
 
-    # Compute the correction, i.e. the scaled negative error
-    correction = Signal(np.zeros(error.shape), name="PES:correction")
-    model.add_op(Reset(correction))
-
-    # correction = -learning_rate * (dt / n_neurons) * error
-    n_neurons = (conn.pre_obj.n_neurons if isinstance(conn.pre_obj, Ensemble)
-                 else conn.pre_obj.size_in)
-    lr_sig = Signal(-pes.learning_rate * model.dt / n_neurons,
-                    name="PES:learning_rate")
-    model.add_op(ElementwiseInc(lr_sig, error, correction, tag="PES:correct"))
-
-    if not conn.is_decoded:
+    if conn.is_decoded:
+        encoders = None
+    else:
         post = get_post_ens(conn)
-        weights = model.sig[conn]['weights']
         encoders = model.sig[post]['encoders'][:, conn.post_slice]
 
-        # encoded = dot(encoders, correction)
-        encoded = Signal(np.zeros(weights.shape[0]), name="PES:encoded")
-        model.add_op(Reset(encoded))
-        model.add_op(DotInc(encoders, correction, encoded, tag="PES:encode"))
-        local_error = encoded
-    elif isinstance(conn.pre_obj, (Ensemble, Neurons)):
-        local_error = correction
-    else:
-        raise BuildError("'pre' object '%s' not suitable for PES learning"
-                         % (conn.pre_obj))
-
-    # delta = local_error * activities
-    model.add_op(Reset(model.sig[rule]['delta']))
-    model.add_op(ElementwiseInc(
-        local_error.column(), acts.row(), model.sig[rule]['delta'],
-        tag="PES:Inc Delta"))
+    model.add_op(SimPES(
+        acts, error, model.sig[rule]['delta'], pes.learning_rate,
+        encoders=encoders))
 
     # expose these for probes
     model.sig[rule]['error'] = error
-    model.sig[rule]['correction'] = correction
     model.sig[rule]['activities'] = acts

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -212,10 +212,6 @@ class Signal:
         """(tuple) Strides of data in bytes."""
         return self.initial_value.strides
 
-    def column(self):
-        """Return a view on this signal with column vector shape."""
-        return self.reshape((self.size, 1))
-
     def may_share_memory(self, other):
         """Determine if two signals might overlap in memory.
 
@@ -253,10 +249,6 @@ class Signal:
                       name="%s.reshape(%s)" % (self.name, shape),
                       base=self.base,
                       offset=self.offset)
-
-    def row(self):
-        """Return a view on this signal with row vector shape."""
-        return self.reshape((1, self.size))
 
 
 class SignalDict(dict):

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -144,7 +144,7 @@ class PES(LearningRuleType):
     """
 
     modifies = 'decoders'
-    probeable = ('error', 'correction', 'activities', 'delta')
+    probeable = ('error', 'activities', 'delta')
 
     learning_rate = NumberParam(
         'learning_rate', low=0, readonly=True, default=1e-4)

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -293,9 +293,9 @@ def test_invalid_run_time(Simulator):
 def test_sim_seed_set_by_network_seed(Simulator, seed):
     with nengo.Network(seed=seed) as model:
         pass
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim_seed = sim.seed
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         assert sim.seed == sim_seed
 
 


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

All the other learning rules act as `updates`, meaning that if you compute a parameter delta on step `t`  the weights change on `t+1`.  That's pretty standard for learning rule behaviour.

Our current PES implementation, on the other hand, actually applies the update on step `t`.  So you could, in theory, compute an error signal, update connection weights, and have that affect the behaviour of downstream ensembles on the same timestep.

One reason why I'd say this is bad is that, just conceptually, it is inconsistent with the behaviour of the other learning rules in Nengo, and I think the expected behaviour of learning rules in general.  Another reason is that it means you can get unexpected cycles in the graph if you don't have a synaptic delay on the error connection, e.g.:

``` python
import nengo

with nengo.Network() as net:
    a = nengo.Ensemble(10, 1)
    b = nengo.Node(size_in=1)
    c = nengo.Connection(a, b, synapse=None, learning_rule_type=nengo.PES())
    nengo.Connection(b, c.learning_rule, synapse=None)

with nengo.Simulator(net) as sim:
    # this network won't build, because it has cycles in the op graph
```

This PR changes PES so that it acts as an `update`, like the other rules.  In order to do this we have to implement a custom PES operator (so that we can specify its output should be an `update`).  Technically we could get away without a custom op, and instead build a delay into PES by sticking a `SimProcess(..., mode="update")` into `build_pes`.  But that seemed like a weird/awkward solution to me, pretending that we have a Process in the PES rule just so that it will act as an `update`.

One potential downside of this change is related to this comment from the `build_pes` docstring: "Generic operators are used because they are more likely to be implemented on other backends like Nengo OCL."  Note that this is only relevant to backends that use the Nengo builder, which I think is just `nengo_ocl` and `nengo_dl` at the moment.  @hunse could comment for `nengo_ocl`, but for `nengo_dl` I'd actually find it easier if PES had its own operator.  That makes it easier for me to build an efficient implementation of that operator, because I have control over how it is implemented internally rather than being tied to the generic operators.  In addition, our current PES implementation already has some weird elements in it (e.g., it uses the `ElementwiseInc` operator to perform an outer product, which isn't the defined/expected behaviour for `ElementwiseInc`).  So backends already kind of need to be aware of the PES rule, even without the custom operator.

The only other downside (I think) is that the custom operator no longer exposes the `correction` signal for probing (since it is now internal to the operator).  Technically this is a breaking change, although I'd say a minor one.  Most people probably didn't even know that was probeable, I'd guess.  And the correction is just equal to the error signal (which is still probeable) times a constant (`learning_rate / n_neurons`), so the information is still pretty easy to retrieve.  However, if anyone is really worried about this, we could have the `SimPES` operator output that signal just for probing.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

#1392 / #1095 touch build_pes, so will need to be updated
#1254 also implemented a custom PES operator, with a slightly different approach (along with a bunch of other changes)

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Passes all existing tests, and I added a new test for the cycle case described above.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.


  