### PR TITLE
Spurious missing warnings on CI servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ matrix:
     - env: PYTHON="2.7" NUMPY="1.10"
     - env: PYTHON="2.7" NUMPY="1.11"
     - env: PYTHON="2.7" NUMPY="1.12"
-    - env: PYTHON="3.4" NUMPY="1.11"  # 1.12 not packaged for py34 in conda
-    - env: PYTHON="3.5"
-    - env: PYTHON="3.6" COVERAGE="true" SCIPY="true"
-    - env: PYTHON="3.6" DOCS="true"
+    #- env: PYTHON="3.4" NUMPY="1.11"  # 1.12 not packaged for py34 in conda
+    #- env: PYTHON="3.5"
+    #- env: PYTHON="3.6" COVERAGE="true" SCIPY="true"
+    #- env: PYTHON="3.6" DOCS="true"
 
 # Setup Miniconda
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
     - PYTHON: "C:\\Miniconda"
-    - PYTHON: "C:\\Miniconda36"
-    - PYTHON: "C:\\Miniconda36-x64"
+    #- PYTHON: "C:\\Miniconda36"
+    #- PYTHON: "C:\\Miniconda36-x64"
 
 init:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -95,6 +95,7 @@ class NengoObject(with_metaclass(NetworkMember, SupportDefaultsMixin)):
 
         self._initialized = True
         if len(nengo.Network.context) > 0:
+            print('warning', len(nengo.Network.context))
             warnings.warn(NotAddedToNetworkWarning(self))
 
     def __setattr__(self, name, val):

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -95,7 +95,6 @@ class NengoObject(with_metaclass(NetworkMember, SupportDefaultsMixin)):
 
         self._initialized = True
         if len(nengo.Network.context) > 0:
-            print('warning', len(nengo.Network.context))
             warnings.warn(NotAddedToNetworkWarning(self))
 
     def __setattr__(self, name, val):

--- a/nengo/spa/tests/test_pointer.py
+++ b/nengo/spa/tests/test_pointer.py
@@ -49,7 +49,7 @@ def test_normalize():
 
 def test_str():
     a = SemanticPointer([1, 1])
-    assert str(a) == '[ 1.  1.]'
+    assert str(a) == '[ 1.  1.]' or str(a) == '[1. 1.]'
 
 
 def test_randomize(rng):

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -1,4 +1,5 @@
 from copy import copy
+import warnings
 
 import numpy as np
 import pytest

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -270,6 +270,7 @@ class TestCopy(object):
     def test_python_copy_warns_abt_adding_to_network(self, make_f, assert_f):
         original = make_f()
         copy(original)  # Fine because not in a network
+        print('---')
         with nengo.Network():
             with pytest.warns(NotAddedToNetworkWarning):
                 copy(original)

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -270,7 +270,6 @@ class TestCopy(object):
     def test_python_copy_warns_abt_adding_to_network(self, make_f, assert_f):
         original = make_f()
         copy(original)  # Fine because not in a network
-        print('---')
         with nengo.Network():
             with pytest.warns(NotAddedToNetworkWarning):
                 copy(original)

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -271,6 +271,7 @@ class TestCopy(object):
         original = make_f()
         copy(original)  # Fine because not in a network
         with nengo.Network():
+            print(warnings.filters)
             with pytest.warns(NotAddedToNetworkWarning):
                 copy(original)
 


### PR DESCRIPTION
**Motivation and context:**
I'm trying to figure out why Python 2.7 does not produce some warnings sometimes (see #1403) and whether there is a better solution than reverting back to our own warnings catcher implementation.

Ignore this PR for now as I'm using it just to build stuff on the CI servers.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)
- Average (neither quick nor lengthy)
- Lengthy (more than 150 lines changed or changes are complicated)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that causes existing functionality to change)
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
