### PR TITLE
Make sim.n_steps and sim.time scalars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,10 @@ Release History
 - Fixed validation checks that prevented the default
   from being set on certain parameters.
   (`#1372 <https://github.com/nengo/nengo/pull/1372>`__)
+- The ``Simulator.n_steps`` and ``Simulator.time`` properties
+  now return scalars, as was stated in the documentation.
+  (`#1406 <https://github.com/nengo/nengo/pull/1406>`_)
+
 
 2.6.0 (October 6, 2017)
 =======================

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -240,8 +240,8 @@ class Simulator(object):
                 self._probe_outputs[probe].append(tmp)
 
     def _probe_step_time(self):
-        self._n_steps = self.signals[self.model.step].copy()
-        self._time = self.signals[self.model.time].copy()
+        self._n_steps = self.signals[self.model.step].item()
+        self._time = self.signals[self.model.time].item()
 
     def reset(self, seed=None):
         """Reset the simulator state.

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -25,6 +25,9 @@ def test_steps(RefSimulator):
         assert sim.n_steps == 2
         assert np.allclose(sim.time, 2 * dt)
 
+        assert np.isscalar(sim.n_steps)
+        assert np.isscalar(sim.time)
+
 
 def test_time_absolute(Simulator):
     m = nengo.Network()


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

These values were being returned as arrays with shape `(1,)`, which means you can't do things like `for i in range(sim.n_steps)`.  This also doesn't match up with our documentation, which says these values are ints/floats.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a check in `test_simulator.py`

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

