### PR TITLE
Fix the seed_offset option.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ Release History
 - The ``Simulator.n_steps`` and ``Simulator.time`` properties
   now return scalars, as was stated in the documentation.
   (`#1406 <https://github.com/nengo/nengo/pull/1406>`_)
+- Fixed the ``--seed-offset`` option of the test suite.
+  (`#1409 <https://github.com/nengo/nengo/pull/1409>`_)
 
 
 2.6.0 (October 6, 2017)

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -63,7 +63,7 @@ def pytest_configure(config):
         TestConfig.neuron_types = [load_class(n) for n in ntypes]
 
     if config.getoption('seed_offset'):
-        TestConfig.test_seed = config.getoption('seed-offset')[0]
+        TestConfig.test_seed = config.getoption('seed_offset')[0]
 
     TestConfig.compare_requested = config.getvalue('compare') is not None
 


### PR DESCRIPTION
**Motivation and context:**
The pytest `--seed-offset` option was not working because of a typo.

**Interactions with other PRs:**
none

**How has this been tested?**
Tried it out.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.