### PR TITLE
Fix lstsq warning in NumPy>=1.14.0

### DIFF
--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -77,7 +77,7 @@ def test_cholesky(rng):
     A = rng.normal(size=(m, n))
     b = rng.normal(size=(m, ))
 
-    x0, _, _, _ = np.linalg.lstsq(A, b)
+    x0, _, _, _ = np.linalg.lstsq(A, b, rcond=-1)
     x1, _ = lstsq.Cholesky(transpose=False)(A, b, 0)
     x2, _ = lstsq.Cholesky(transpose=True)(A, b, 0)
     assert np.allclose(x0, x1)


### PR DESCRIPTION
**Motivation and context:**
As noted in the updated [`np.linalg.lstsq` docs](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.lstsq.html), the `rcond` parameter now raises a FutureWarning if nothing is passed. Explicitly passing `None` sets `rcond` to machine precision times `max(M, N)`, while passing `-1` sets `rcond` to machine precision, which is the previous behavior.

I went with -1 because that was the previous behavior, i.e., what we were using in that test previously. If anyone has any reason to pass `None` instead, let me know!

**How has this been tested?**
Ran the tests again; passed like a champ.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
