### PR TITLE
Run codespell through TravisCI

### DIFF
--- a/.ci/static.sh
+++ b/.ci/static.sh
@@ -12,9 +12,9 @@ function usage {
 }
 
 if [[ "$COMMAND" == "install" ]]; then
-    pip install flake8 pylint
+    pip install codespell flake8 pylint
 elif [[ "$COMMAND" == "run" ]]; then
-    flake8 -v nengo && pylint nengo
+    flake8 -v nengo && codespell -q 3 && pylint nengo
 else
     if [[ -z "$COMMAND" ]]; then
         echo "Command required"

--- a/nengo/spa/tests/test_pointer.py
+++ b/nengo/spa/tests/test_pointer.py
@@ -101,11 +101,11 @@ def test_convolution(rng):
     c = a.copy()
     c *= b
 
-    ans = np.fft.ifft(np.fft.fft(a.v) * np.fft.fft(b.v)).real
+    answer = np.fft.ifft(np.fft.fft(a.v) * np.fft.fft(b.v)).real
 
-    assert np.allclose((a * b).v, ans)
-    assert np.allclose(a.convolve(b).v, ans)
-    assert np.allclose(c.v, ans)
+    assert np.allclose((a * b).v, answer)
+    assert np.allclose(a.convolve(b).v, answer)
+    assert np.allclose(c.v, answer)
     assert np.allclose((a * identity).v, a.v)
     assert (a * b * ~b).compare(a) > 0.65
 

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -14,7 +14,7 @@ def test_missing_attribute():
         a = nengo.Ensemble(10, 1)
 
         with pytest.warns(SyntaxWarning):
-            a.dne = 9
+            a.new_attribute = 9
 
 
 @pytest.mark.parametrize("dimensions", [1, 200])

--- a/nengo/utils/filter_design.py
+++ b/nengo/utils/filter_design.py
@@ -265,14 +265,14 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     """
     A, B, C, D = map(_atleast_2d_or_none, (A, B, C, D))
 
-    MA, NA = _shape_or_none(A)
-    MB, NB = _shape_or_none(B)
-    MC, NC = _shape_or_none(C)
-    MD, ND = _shape_or_none(D)
+    Am, _ = _shape_or_none(A)
+    Bm, Bn = _shape_or_none(B)
+    Cm, Cn = _shape_or_none(C)
+    Dm, Dn = _shape_or_none(D)
 
-    p = _choice_not_none(MA, MB, NC)
-    q = _choice_not_none(NB, ND)
-    r = _choice_not_none(MC, MD)
+    p = _choice_not_none(Am, Bm, Cn)
+    q = _choice_not_none(Bn, Dn)
+    r = _choice_not_none(Cm, Dm)
     if p is None or q is None or r is None:
         raise ValueError("Not enough information on the system.")
 

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -293,7 +293,7 @@ class RandomizedSVD(LeastSquaresSolver):
     n_iter = IntParam('n_iter', low=0)
 
     def __init__(self, n_components=60, n_oversamples=10, n_iter=0):
-        from sklearn.utils.extmath import randomized_svd  # error early if DNE
+        from sklearn.utils.extmath import randomized_svd
         assert randomized_svd
         super(RandomizedSVD, self).__init__()
         self.n_components = n_components


### PR DESCRIPTION
**Motivation and context:**
In #1413, @luzpaz was kind enough to fix several typos using the `codespell` tool. Rather than let typos keep piling up, this PR runs `codespell` through TravisCI to spot misspelling sooner rather than later.

Note that pylint also has some [spellchecking options](https://docs.pylint.org/en/1.8/technical_reference/features.html#spelling-checker), which I tried out, and did not work well because

- Tons of false positives as variable names are not whitelisted (keeping a whitelist for them would be very time consuming)
- Only checks comments and docstrings
- Requires an additional dependency, `pyenchant`

`codespell`, while requiring a `pip install codespell`, had very few false positives (which I fixed in this PR) and seems to check all text, including variable names and text in Jupyter notebooks. I believe it only looks for a set of common misspellings, but it seems to catch quite a bit, and certainly is better than having nothing.

**How has this been tested?**
Ran this locally with `codespell -q 3`; TravisCI currently testing it.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
