### PR TITLE
Build docs with -v flag

### DIFF
--- a/.ci/docs.sh
+++ b/.ci/docs.sh
@@ -17,7 +17,7 @@ if [[ "$COMMAND" == "install" ]]; then
     pip install "ipython[all]==2.4.1" sphinx guzzle_sphinx_theme ghp-import
 elif [[ "$COMMAND" == "run" ]]; then
     rm "$HOME/.ipython/profile_default/ipython_config.py"
-    sphinx-build -W docs docs/_build
+    sphinx-build -vW docs docs/_build
 elif [[ "$COMMAND" == "upload" ]]; then
     DATE=$(date '+%Y-%m-%d %T')
     git config --global user.email "travis@travis-ci.org"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
       .ci/static.sh run;
     elif [[ "$COVERAGE" == "true" ]]; then
       .ci/coverage.sh run;
-    elif [[ "$DOCS" == "true" && -n "$TRAVIS_TAG" ]]; then
+    elif [[ -n "$TRAVIS_TAG" && "$DOCS" == "true" ]]; then
       .ci/docs.sh run;
     else
       .ci/test.sh run;


### PR DESCRIPTION
**Motivation and context:**
Chris noticed that our Nengo core docs were still at 2.6 even though we did a 2.7 release. Turns out the [doc build timed out](https://travis-ci.org/nengo/nengo/jobs/350350669). It's non-trivial to speed up the notebook rendering, so as a quick hack to fix this, I added the `-v` flag to the Sphinx build, which increases the amount of output it produces. TravisCI uses shell output to figure out if the build has stalled, so it should make it so that it doesn't time out.

**How has this been tested?**
I first pushed this without the `-n "$TRAVIS_TAG` check for doc building and [it passed](https://travis-ci.org/nengo/nengo/jobs/373554009).

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
