### PR TITLE
Reworking NeuronType.current and NeuronType.rates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,9 @@ Release History
   (`#1521 <https://github.com/nengo/nengo/pull/1521>`_)
 - Switched to nengo-bones templating system for TravisCI config/scripts.
   (`#1514 <https://github.com/nengo/nengo/pull/1514>`_)
+- The ``NeuronType.current`` and ``NeuronType.rates`` methods now document
+  the supported shapes of parameters and return values.
+  (`#1437 <https://github.com/nengo/nengo/pull/1437>`__)
 
 **Deprecated**
 

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -152,7 +152,6 @@ def test_lif_zero_tau_ref(Simulator):
 def test_alif_rate(Simulator, plt):
     n = 100
     max_rates = 50 * np.ones(n)
-    # max_rates = 200 * np.ones(n)
     intercepts = np.linspace(-0.99, 0.99, n)
     encoders = np.ones((n, 1))
 
@@ -167,13 +166,12 @@ def test_alif_rate(Simulator, plt):
         nengo.Connection(u, a, synapse=None)
         ap = nengo.Probe(a.neurons)
 
-    dt = 1e-3
-    with Simulator(model, dt=dt) as sim:
+    with Simulator(model) as sim:
         sim.run(2.)
 
     t = sim.trange()
     rates = sim.data[ap]
-    _, ref = tuning_curves(a, sim, inputs=np.array([0.5]))
+    _, ref = tuning_curves(a, sim, inputs=0.5)
 
     ax = plt.subplot(211)
     implot(plt, t, intercepts[::-1], rates.T, ax=ax)
@@ -217,8 +215,7 @@ def test_alif(Simulator, plt):
         ap = nengo.Probe(a.neurons)
         bp = nengo.Probe(b.neurons)
 
-    dt = 1e-3
-    with Simulator(model, dt=dt) as sim:
+    with Simulator(model) as sim:
         sim.run(2.)
 
     t = sim.trange()

--- a/nengo/utils/ensemble.py
+++ b/nengo/utils/ensemble.py
@@ -49,6 +49,8 @@ def tuning_curves(ens, sim, inputs=None):
         else:
             inputs = [inputs]
         inputs = np.asarray(inputs).T
+    else:
+        inputs = np.asarray(inputs)
 
     eval_points = inputs.reshape((-1, ens.dimensions))
     activities = get_activities(sim.data[ens], ens, eval_points)

--- a/nengo/utils/ensemble.py
+++ b/nengo/utils/ensemble.py
@@ -89,13 +89,8 @@ def response_curves(ens, sim, inputs=None):
 
     if inputs is None:
         inputs = np.linspace(-1.0, 1.0)
-
-    x = np.atleast_2d(inputs).T
-    activities = ens.neuron_type.rates(
-        x, sim.data[ens].gain, sim.data[ens].bias)
-    activities = np.squeeze(activities)
-
-    return inputs, activities
+    return inputs, ens.neuron_type.rates(
+        inputs, sim.data[ens].gain, sim.data[ens].bias)
 
 
 def _similarity(encoders, index, rows, cols=1):


### PR DESCRIPTION
**Motivation and context:**
In #1419, @arvoelke pointed out that the docstring of the `current` method (and, by association, `rates`) did not reflect the way in which these methods are being used. When I looked into it more, I realized that these were not usages that I intended, hence the incorrect docstrings, but also that these usages were now the majority of use cases because they allow for more efficient code.

To explain, `current` is just a tiny helper function that does `gain * x + bias`. I originally intended for all three of these variables to be of shape `(n_neurons,)`, so it's all simple element-wise multiplication. However, at some point we started passing in `x` values with shapes `(n_samples, 1)`, which due to NumPy's broadcasting rules, ends up giving you a result that is of shape `(n_samples, n_neurons)`.

The use case I was envisioning, passing in `(n_neurons,)`, lets you provide different `x` values to each neuron. When passing in `(n_samples, 1)`, you provide the same input to all neuron, but you can provide multiple inputs at once. When passing in `(n_samples, n_neurons)`, you can provide multiple inputs and those inputs can be different for each neuron. Hopefully it's obvious that the more efficient thing to do is to just call `current` once with all of the samples (usually eval_points), so that tends to be the most common use case. Passing in `(n_samples, 1)` ends up being useful when generating response curves, since you want to see every neuron's response to the same input. Passing in `(n_neurons,)` is, in most cases, just an inefficient version of passing in `(n_samples, n_neurons)`.

Note that in all of these cases, `x` has already been projected onto the neuron's encoding vector and has been scaled by the radius, which has further confused things because

1. We don't have a separate name for the original input vector `x` and the `x` we're using in this case.
2. I called `x` the "input vector" in the previous docstring, which is sort of defensible but quite confusing.

Also note that while everything I said above was for `current`, the same is also true of `rates` because `rates` first calls `current` and then makes other variables the same shape as the value returned by `current`.

With all that context, it is hopefully easier to understand the changes that I made in this PR. I have essentially implemented two ways to clear up the confusion that I've explained above.

The first way (commit 81a6fdf692cbe40215aa89) tries to maintain backwards compatibility, but make things slightly more consistent, but having `current` (and consequently `rates`) always return a 2d array of shape `(n_samples, n_neurons)`, even if the cases with 1 sample -- which, as I have noted above, ends up being a relatively rare use case, even though it was the one in the docstring. It was relatively easy to fix any tests that were failing as a result of this change, though it resulted in some ugliness in parts.

The second way (commit 0c0d96510220ca5a) attempts to embrace the more common use cases, at the cost of backwards compatibility. This commit assumes that we pretty much always want to be passing in more than one sample, and makes the one-sample case the slightly awkward one (e.g., you have to pass in something of shape `(1, n_neurons)` if you really want one sample). This was also somewhat easy to fix, and I think the result is easier to deal with and easier to explain. However, it may be the case that other backends are relying on the current behavior.

So, if anyone has any thoughts on whether one of these two approaches is preferred, or if there's some obviously better third option I haven't thought of, please share it here. Also, if anyone knows of any usages of these methods that will be affected by these changes (@arvoelke ?) it would be good to know ahead of time to either defer this to a 3.0 release or at least knowingly break a few things.

**How has this been tested?**
The usual test suite.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Types of changes:**

- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
