### PR TITLE
Fix documentation links

### DIFF
--- a/.ci/docs.sh
+++ b/.ci/docs.sh
@@ -15,6 +15,8 @@ function usage {
 if [[ "$COMMAND" == "install" ]]; then
     conda install jupyter matplotlib scipy
     pip install "sphinx<1.7" nbsphinx numpydoc guzzle_sphinx_theme ghp-import
+elif [[ "$COMMAND" == "check" ]]; then
+    sphinx-build -b linkcheck -vW -D nbsphinx_execute=never docs docs/_build
 elif [[ "$COMMAND" == "run" ]]; then
     sphinx-build -vW docs docs/_build
 elif [[ "$COMMAND" == "upload" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ script:
       .ci/coverage.sh run;
     elif [[ -n "$TRAVIS_TAG" && "$DOCS" == "true" ]]; then
       .ci/docs.sh run;
+    elif [[ "$DOCS" == "true" ]]; then
+      .ci/docs.sh check;
     else
       .ci/test.sh run;
     fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -187,7 +187,7 @@ Release History
 - Learning rules now have a ``size_in`` parameter and attribute,
   allowing both integers and strings to define the dimensionality
   of the learning rule. This replaces the ``error_type`` attribute.
-  (`#1307 <https://github.com/nengo/nengo/issues/1307>`_,
+  (`#1307 <https://github.com/nengo/nengo/pull/1307>`_,
   `#1310 <https://github.com/nengo/nengo/pull/1310>`_)
 - ``EnsembleArray.n_neurons`` now gives the total number of neurons
   in all ensembles, including those in subnetworks.
@@ -603,8 +603,8 @@ Release History
   injected random signals and noise are identical between runs,
   unless the seed is changed (which can be done through
   ``Simulator.reset``).
-  (`#582 <https://github.com/nengo/nengo/pull/582>`_,
-  `#616 <https://github.com/nengo/nengo/pull/616>`_,
+  (`#582 <https://github.com/nengo/nengo/issues/582>`_,
+  `#616 <https://github.com/nengo/nengo/issues/616>`_,
   `#652 <https://github.com/nengo/nengo/pull/652>`_)
 - An exception is raised if SPA modules are not properly assigned to an SPA
   attribute.
@@ -625,7 +625,7 @@ Release History
 - Added the ``Voja`` (Vector Oja) learning rule type, which updates an
   ensemble's encoders to fire selectively for its inputs. (see
   ``examples/learning/learn_associations.ipynb``).
-  (`#727 <https://github.com/nengo/nengo/issues/727>`_)
+  (`#727 <https://github.com/nengo/nengo/pull/727>`_)
 - Added a clipped exponential distribution useful for thresholding, in
   particular in the AssociativeMemory.
   (`#779 <https://github.com/nengo/nengo/pull/779>`_)

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -33,8 +33,8 @@ Nengo imports or vendorizes several open source libraries.
   `BSD license <https://bitbucket.org/birkenfeld/sphinx/src/be5bd373a1a47fb68d70523b6e980e654e070e9f/LICENSE?at=default>`__
 * `numpydoc <https://github.com/numpy/numpydoc>`_ - Used under
   `BSD license <https://github.com/numpy/numpydoc/blob/master/LICENSE.txt>`__
-* `matplotlib <http://matplotlib.org/>`_ - Used under
-  `modified PSF license <http://matplotlib.org/users/license.html>`__
+* `matplotlib <https://matplotlib.org/>`_ - Used under
+  `modified PSF license <https://matplotlib.org/users/license.html>`__
 * `IPython <http://ipython.org/>`_ - Used under
   `BSD license <https://github.com/ipython/ipython/blob/master/COPYING.rst>`__
 * `pytest <https://docs.pytest.org/en/latest/>`_ - Used under

--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -328,12 +328,12 @@ and loading it up in the future.
 
 .. [1] Gosmann, Jan. Precise multiplications with the NEF.
        Waterloo, Ontario, Canada: University of Waterloo; 2015.
-       Available from: http://dx.doi.org/10.5281/zenodo.35680
+       Available from: https://zenodo.org/record/35680
 .. [2] Gosmann, Jan, and Chris Eliasmith. “Optimizing Semantic Pointer
        Representations for Symbol-Like Processing in Spiking Neural Networks.”
        PLoS ONE 11, no. 2 (February 22, 2016): e0149928.
        `doi:10.1371/journal.pone.0149928
-       <http://dx.doi.org/10.1371%2Fjournal.pone.0149928>`_.
+       <http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0149928>`_.
 .. [3] Note that decoded connections
        also accept the ``transform`` argument.
        In the case of decoded connections,

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -91,8 +91,8 @@ Writing your own tests
 ----------------------
 
 When writing your own tests, please make use of
-custom Nengo `fixtures <http://pytest.org/latest/fixture.html>`_
-and `markers <http://pytest.org/latest/example/markers.html>`_
+custom Nengo `fixtures <https://docs.pytest.org/en/latest/fixture.html>`_
+and `markers <https://docs.pytest.org/en/latest/example/markers.html>`_
 to integrate well with existing tests.
 See existing tests for examples, or consult
 
@@ -106,7 +106,7 @@ and
 
    pytest --pyargs nengo --markers
 
-.. _pytest: http://pytest.org/latest/
+.. _pytest: https://docs.pytest.org/en/latest/
 
 How to build the documentation
 ==============================

--- a/docs/converting.rst
+++ b/docs/converting.rst
@@ -6,7 +6,7 @@ On this page, we'll go over the changes between Nengo 1.4 and 2.0.
 They will first be reviewed heuristically in the section Big Changes, before
 being broken down practically in Changes to Common Functions
 
-Big Changes
+Big changes
 ===========
 
 Objects instead of strings
@@ -87,7 +87,7 @@ meaning that you can run the same model
 with different timesteps to see if
 there is a marked functional difference.
 
-Changes to Common Functions
+Changes to common functions
 ---------------------------
 
 Many commonly used functions have been
@@ -112,8 +112,8 @@ A simple example::
 
   A = nengo.Ensemble(40, 1, neuron_type=nengo.LIF(), label='A')
 
-See `Ensemble documentation <user_api.html#ensemble>`_
-for a list of properties that can be manipulated.
+See :class:`nengo.Ensemble` for
+a list of properties that can be manipulated.
 
 Making ensemble arrays (i.e., network arrays)
 ---------------------------------------------
@@ -133,12 +133,10 @@ New API::
 
   nengo.networks.EnsembleArray(name, neurons, n_ensembles, dimensions_per_ensemble, **ens_args)
 
-See `EnsembleArray documentation <networks.html#ensemblearray>`_
-for more information.
+See :class:`nengo.networks.EnsembleArray` for more information.
 
-Changes to Common Functions
+Changes to common functions
 ===========================
-
 
 Making nodes
 ------------
@@ -162,8 +160,7 @@ where ``output`` is either a constant value
 (float, list, NumPy array), a function, or
 ``None`` when passing through values unchanged.
 
-See `Node documentation <user_api.html#node>`_
-for more information.
+See :class:`nengo.Node` for more information.
 
 Making inputs
 -------------
@@ -246,10 +243,3 @@ to route dimensions easily::
   nengo.Connection(pre_1d, post_2d[0])
 
 The keyword argument ``pstc`` has been renamed to ``synapse``.
-
-Under the hood changes
-======================
-
-Under the hood, Nengo has been completely rewritten.
-If you want to know the underlying structure of
-Nengo 2.0, see the `developer documentation <dev_guide.html>`_.

--- a/docs/converting.rst
+++ b/docs/converting.rst
@@ -174,8 +174,7 @@ In the old API, inputs were defined as::
 
 Inputs are just nodes whose sole function are to output a function.
 
-See the first example `Node documentation <user_api.html#node>`_
-for an example of this.
+Many of the :doc:`examples` use function output nodes.
 
 Terminations and Origins
 ------------------------

--- a/docs/examples/learning/learn_unsupervised.ipynb
+++ b/docs/examples/learning/learn_unsupervised.ipynb
@@ -189,7 +189,7 @@
       "\n",
       "As well, we can show that BCM sparsifies the weights.\n",
       "The sparsity measure below uses the Gini measure of sparsity,\n",
-      "for reasons explained [in this paper](http://arxiv.org/pdf/0811.4706.pdf)."
+      "for reasons explained [in this paper](https://arxiv.org/pdf/0811.4706.pdf)."
      ]
     },
     {
@@ -358,4 +358,3 @@
   }
  ]
 }
-

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -268,7 +268,7 @@ for analysis or visualization.
   print(sim.data[product_probe][-10:])
 
 For more details on these objects,
-see `the API documentation <user_api.html>`_.
+see :doc:`the API documentation <frontend_api>`.
 
 Next steps
 ==========

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -29,12 +29,12 @@ on each operating system is:
 
 - Windows: Use Anaconda_ or
   the `official installer <https://www.python.org/downloads/>`_ and
-  `unofficial binaries <http://www.lfd.uci.edu/~gohlke/pythonlibs/>`_
+  unofficial binaries (www.lfd.uci.edu/~gohlke/pythonlibs/)
 - Mac OS X: Use Anaconda_ or Homebrew_
 - Linux: Use a package manager or install from source
 
 For more options, see
-`SciPy.org's installation page <http://www.scipy.org/install.html>`_.
+`SciPy.org's installation page <https://www.scipy.org/install.html>`_.
 For our recommended options, read on.
 
 Anaconda
@@ -105,7 +105,7 @@ through ``pip`` when installing Nengo.
    pip install nengo[tests]  # For running the test suite
    pip install nengo[all]  # All of the above
 
-.. _Anaconda: https://store.continuum.io/cshop/anaconda/
+.. _Anaconda: https://www.anaconda.com/download/
 .. _Homebrew: https://brew.sh/
 
 Usage
@@ -279,6 +279,6 @@ Next steps
   `this technical overview <http://compneuro.uwaterloo.ca/files/publications/stewart.2012d.pdf>`_.
 * If you have some understanding of the NEF already,
   or just want to dive in headfirst,
-  check out `our extensive set of examples <examples.html>`_.
+  check out :doc:`our extensive set of examples <examples>`.
 * If you want to see the real capabilities of Nengo, see our
   `publications created with the NEF and Nengo <http://compneuro.uwaterloo.ca/publications.html>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ or neuromorphic hardware.
    user_guide
    examples
    contributing
-   Nengo ecosystem <https://nengo.ai/projects.html>
+   Nengo ecosystem <https://www.nengo.ai/projects.html>
    license
 
 * :ref:`genindex`

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -519,9 +519,7 @@ class CosineSimilarity(SubvectorLength):
        Efficiently sampling vectors and coordinates from the n-sphere and
        n-ball. Technical Report, Centre for Theoretical Neuroscience,
        Waterloo, ON, 2017
-       <http://compneuro.uwaterloo.ca/publications/voelker2017.html>`_,
-       `doi:10.13140/RG.2.2.15829.01767/1
-       <https://dx.doi.org/10.13140/RG.2.2.15829.01767/1>`_.
+       <http://compneuro.uwaterloo.ca/publications/voelker2017.html>`_
 
     Parameters
     ----------


### PR DESCRIPTION
**Motivation and context:**
@Seanny123 found a broken link in #1421. A bit of grepping revealed a few other broken links. This PR fixes them by using actual Sphinx directives, which we should always use because they would have caught these issues. There is probably also a dead link checker Sphinx extension, but ... meh!

**How has this been tested?**
Built the docs, checked that the links work now.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [na] I have run the test suite locally and all tests passed.
