### PR TITLE
Fix warning for deprecated pytest feature

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,8 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda install numpy matplotlib jupyter pytest
+  - conda install numpy matplotlib jupyter
+  - pip install pytest>=3.6
 
 build: false  # Not a C# project
 

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -137,8 +137,10 @@ def parametrize_function_name(request, function_name):
     """
     suffixes = []
     if 'parametrize' in request.keywords:
-        argnames = request.keywords['parametrize'].args[::2]
-        argnames = [x.strip() for names in argnames for x in names.split(',')]
+        argnames = []
+        for marker in request.keywords.node.iter_markers("parametrize"):
+            argnames.extend([x.strip() for names in marker.args[::2]
+                             for x in names.split(',')])
         for name in argnames:
             value = request.getfixturevalue(name)
             if inspect.isclass(value):

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -91,20 +91,18 @@ class Plotter(Recorder):
             self.plt = plt
         else:
             self.plt = Mock()
+        self.plt.saveas = self.get_filename(ext='pdf')
         return self.plt
 
     def __exit__(self, type, value, traceback):
         if self.record:
-            if hasattr(self.plt, 'saveas') and self.plt.saveas is None:
+            if self.plt.saveas is None:
                 del self.plt.saveas
                 self.plt.close('all')
                 return
-
-            if hasattr(self.plt, 'saveas'):
-                self.filename = self.plt.saveas
-                del self.plt.saveas
-            else:
-                self.filename = self.get_filename(ext='pdf')
+            # Save it again in case the user changed it
+            self.filename = self.plt.saveas
+            del self.plt.saveas
 
             if len(self.plt.gcf().get_axes()) > 0:
                 # tight_layout errors if no axes are present

--- a/nengo/utils/tests/test_testing.py
+++ b/nengo/utils/tests/test_testing.py
@@ -79,3 +79,13 @@ def test_mock_iter(plt):
     for i, ax in enumerate(fig.axes):
         assert False, "Mock object iterating forever"
     plt.saveas = None
+
+
+@pytest.mark.parametrize("a", [0, 1])
+@pytest.mark.parametrize("b", [2, 3])
+def test_double_parametrize(a, b, plt):
+    assert plt.saveas == "{}.pdf".format("+".join([
+        "utils.test_testing.test_double_parametrize",
+        "b={}".format(b),
+        "a={}".format(a)]))
+    plt.saveas = None  # Skip saving empty plot

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ optional_requires = [
 tests_require = [
     "jupyter",
     "matplotlib>=1.4",
-    "pytest>=3.2",
+    "pytest>=3.6",
 ]
 
 


### PR DESCRIPTION
**Motivation and context:**
In a recently released version of pytest, we got a bunch of warnings for a [feature that will be removed in pytest 4](https://docs.pytest.org/en/latest/mark.html#updating-code). This PR updates our code to not use the deprecated feature.

**How has this been tested?**
Ran the tests locally, no longer got any warnings.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
