### PR TITLE
Fix iterating over Mock objects

### DIFF
--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -25,6 +25,9 @@ class Mock(object):
     def __getitem__(self, key):
         return Mock()
 
+    def __iter__(self):
+        return iter([])
+
     def __mul__(self, other):
         return 1.0
 

--- a/nengo/utils/tests/test_testing.py
+++ b/nengo/utils/tests/test_testing.py
@@ -72,3 +72,10 @@ def test_logger_norecord():
         logger.info("Testing that logger doesn't record")
     with pytest.raises(ValueError):
         logger_obj.get_filepath(ext='txt')
+
+
+def test_mock_iter(plt):
+    fig = plt.figure()
+    for i, ax in enumerate(fig.axes):
+        assert False, "Mock object iterating forever"
+    plt.saveas = None


### PR DESCRIPTION
**Motivation and context:**
As reported in #1441, previously if you tried to iterate over an object that was mocked out (e.g., something in `plt`) it would loop forever. This fixes it by returning a iterator to an empty list, so no iteration will occur.

Since this is a change only to testing infrastructure, I think it doesn't need a changelog entry as it's entirely an under-the-hood change.

**How has this been tested?**
Added a test, which will fail without the change to `Mock`.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
