### PR TITLE
More reliable CI

### DIFF
--- a/.ci/conda.sh
+++ b/.ci/conda.sh
@@ -12,13 +12,13 @@ function usage {
 }
 
 if [[ "$COMMAND" == "install" ]]; then
-    wget "$MINICONDA" -O miniconda.sh
+    wget "$MINICONDA" --quiet -O miniconda.sh
     bash miniconda.sh -b -p "$HOME/miniconda"
     export PATH="$HOME/miniconda/bin:$PATH"
     conda config --set always_yes yes --set changeps1 no
-    conda update -q conda
+    conda update --quiet conda
     conda info -a
-    conda create -q -n test python="$PYTHON" pip
+    conda create --quiet -n test python="$PYTHON" pip
     source activate test
 else
     if [[ -z "$COMMAND" ]]; then

--- a/.ci/docs.sh
+++ b/.ci/docs.sh
@@ -13,7 +13,7 @@ function usage {
 }
 
 if [[ "$COMMAND" == "install" ]]; then
-    conda install jupyter matplotlib scipy
+    conda install --quiet jupyter matplotlib scipy
     pip install "sphinx<1.7" nbsphinx numpydoc guzzle_sphinx_theme ghp-import
 elif [[ "$COMMAND" == "check" ]]; then
     sphinx-build -b linkcheck -vW -D nbsphinx_execute=never docs docs/_build

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -12,9 +12,9 @@ function usage {
 }
 
 if [[ "$COMMAND" == "install" ]]; then
-    conda install jupyter matplotlib numpy="$NUMPY"
+    conda install --quiet jupyter matplotlib numpy="$NUMPY"
     if [[ "$SCIPY" == "true" ]]; then
-        conda install scipy
+        conda install --quiet scipy
     fi
     pip install pytest
     pip install -e .

--- a/docs/backend_api.rst
+++ b/docs/backend_api.rst
@@ -22,6 +22,12 @@ create and close a `nengo.Simulator` instance.
 
 .. autoclass:: nengo.Simulator
 
+.. autoclass:: nengo.simulator.ProbeDict
+
+.. autoclass:: nengo.simulator.SignalDict
+
+.. autoclass:: nengo.exceptions.SimulatorClosed
+
 The build process
 -----------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,8 +53,9 @@ autodoc_member_order = 'bysource'  # default is alphabetical
 # -- sphinx.ext.intersphinx
 intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
-    'python': ('https://docs.python.org/3/', None),
+    'python': ('https://docs.python.org/3', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+    'sklearn': ('http://scikit-learn.org/dev', None),
 }
 
 # -- sphinx.ext.todo
@@ -64,6 +65,7 @@ numpydoc_show_class_members = False
 
 # -- sphinx
 needs_sphinx = '1.3'
+nitpicky = True
 exclude_patterns = ['_build', '**/.ipynb_checkpoints']
 source_suffix = '.rst'
 source_encoding = 'utf-8'

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -50,3 +50,38 @@ Quirks
 .. toctree::
 
    examples/quirks/config
+
+Parameters
+==========
+
+Under the hood, Nengo objects store information
+using `.Parameter` instances,
+which are also used by the config system.
+Most users will not need to know about
+`.Parameter` objects.
+
+.. autoclass:: nengo.params.Parameter
+
+.. autoclass:: nengo.params.ObsoleteParam
+
+.. autoclass:: nengo.params.BoolParam
+
+.. autoclass:: nengo.params.NumberParam
+
+.. autoclass:: nengo.params.IntParam
+
+.. autoclass:: nengo.params.StringParam
+
+.. autoclass:: nengo.params.EnumParam
+
+.. autoclass:: nengo.params.TupleParam
+
+.. autoclass:: nengo.params.ShapeParam
+
+.. autoclass:: nengo.params.DictParam
+
+.. autoclass:: nengo.params.NdarrayParam
+
+.. autoclass:: nengo.params.FunctionParam
+
+.. autoclass:: nengo.exceptions.ValidationError

--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -205,7 +205,7 @@ For example, the `.EnsembleArray` network
 is often used to represent a high-dimensional vector
 with many lower-dimensional ensemble.
 The high-dimensional vector is still available
-as `.EnsembleArray.output` through the use
+as ``EnsembleArray.output`` through the use
 of a passthrough node that collects the output
 of all the lower-dimensional ensembles.
 

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -211,6 +211,15 @@ Decoder and connection weight solvers
    nengo.solvers.NnlsL2
    nengo.solvers.NnlsL2nz
    nengo.solvers.NoSolver
+   nengo.utils.least_squares_solvers.LeastSquaresSolver
+   nengo.utils.least_squares_solvers.Cholesky
+   nengo.utils.least_squares_solvers.ConjgradScipy
+   nengo.utils.least_squares_solvers.LSMRScipy
+   nengo.utils.least_squares_solvers.Conjgrad
+   nengo.utils.least_squares_solvers.BlockConjgrad
+   nengo.utils.least_squares_solvers.SVD
+   nengo.utils.least_squares_solvers.RandomizedSVD
+
 
 .. autoclass:: nengo.solvers.Solver
    :special-members: __call__
@@ -236,3 +245,19 @@ Decoder and connection weight solvers
 .. autoclass:: nengo.solvers.NnlsL2nz
 
 .. autoclass:: nengo.solvers.NoSolver
+
+.. autoclass:: nengo.utils.least_squares_solvers.LeastSquaresSolver
+
+.. autoclass:: nengo.utils.least_squares_solvers.Cholesky
+
+.. autoclass:: nengo.utils.least_squares_solvers.ConjgradScipy
+
+.. autoclass:: nengo.utils.least_squares_solvers.LSMRScipy
+
+.. autoclass:: nengo.utils.least_squares_solvers.Conjgrad
+
+.. autoclass:: nengo.utils.least_squares_solvers.BlockConjgrad
+
+.. autoclass:: nengo.utils.least_squares_solvers.SVD
+
+.. autoclass:: nengo.utils.least_squares_solvers.RandomizedSVD

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -141,7 +141,7 @@ In other words, this ensemble represents a single number.
 
 In order to provide input to this ensemble
 (to emulate some signal that exists in nature, for example)
-we create a :class:`Node`.
+we create a :class:`nengo.Node`.
 
 ::
 

--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -40,7 +40,7 @@ def build_network(model, network, progress=None):
         The model to build into.
     network : Network
         The network to build.
-    progress : `nengo.utils.progress.Progress`, optional
+    progress : Progress, optional
         Object used to track the build progress.
 
         Note that this will only affect top-level networks.

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -53,7 +53,7 @@ class PDF(Distribution):
     x : vector_like (n,)
         Values of the points to sample from (interpolated).
     p : vector_like (n,)
-        Probabilities of the `x` points.
+        Probabilities of the ``x`` points.
     """
 
     x = NdarrayParam('x', shape='*')
@@ -179,9 +179,9 @@ class Exponential(Distribution):
                |  n                                 if x == high - eps
                |  0                                 if x >= high
 
-    where `n` is such that the PDF integrates to one, and `eps` is an
-    infintesimally small number such that samples of `x` are strictly less than
-    `high` (in practice, `eps` depends on the floating point precision).
+    where ``n`` is such that the PDF integrates to one, and ``eps`` is an
+    infintesimally small number such that samples of ``x`` are strictly less
+    than ``high`` (in practice, ``eps`` depends on floating point precision).
 
     Parameters
     ----------
@@ -278,7 +278,7 @@ class Choice(Distribution):
     ----------
     options : (N, ...) array_like
         The options (choices) to choose between. The choice is always done
-        along the first axis, so if `options` is a matrix, the options are
+        along the first axis, so if ``options`` is a matrix, the options are
         the rows of that matrix.
     weights : (N,) array_like, optional (Default: None)
         Weights controlling the probability of selecting each option. Will
@@ -422,7 +422,7 @@ class SqrtBeta(Distribution):
         Returns
         -------
         cdf : array_like
-            Probability that `X <= x`.
+            Probability that ``X <= x``.
         """
         from scipy.special import betainc
         sq_x = x * x

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -38,7 +38,7 @@ class Ensemble(NengoObject):
         (-radius, radius) in each dimension, or a distribution from which
         to choose evaluation points.
     n_eval_points : int, optional (Default: None)
-        The number of evaluation points to be drawn from the `eval_points`
+        The number of evaluation points to be drawn from the ``eval_points``
         distribution. If None, then a heuristic is used to determine
         the number of evaluation points.
     neuron_type : `~nengo.neurons.NeuronType`, optional \
@@ -88,7 +88,7 @@ class Ensemble(NengoObject):
         The activity of each neuron when ``dot(x, e) = 1``,
         where ``e`` is the neuron's encoder.
     n_eval_points : int or None
-        The number of evaluation points to be drawn from the `eval_points`
+        The number of evaluation points to be drawn from the ``eval_points``
         distribution. If None, then a heuristic is used to determine
         the number of evaluation points.
     n_neurons : int or None

--- a/nengo/networks/product.py
+++ b/nengo/networks/product.py
@@ -11,8 +11,7 @@ def Product(n_neurons, dimensions, input_magnitude=1., net=None, **kwargs):
 
     The network used to calculate the product is described in
     `Gosmann, 2015`_. A simpler version of this network can be found in the
-    `Multiplication example
-    <https://www.nengo.ai/nengo/examples/multiplication.html>`_.
+    :doc:`Multiplication example <examples/basic/multiplication>`.
 
     Note that this network is optimized under the assumption that both input
     values (or both values for each input dimensions of the input vectors) are
@@ -27,7 +26,7 @@ def Product(n_neurons, dimensions, input_magnitude=1., net=None, **kwargs):
 
     .. _Gosmann, 2015:
        https://nbviewer.jupyter.org/github/ctn-archive/technical-reports/blob/
-       master/Precise-multiplications-with-the-NEF.ipynb#An-alternative-network
+       master/Precise-multiplications-with-the-NEF.ipynb
 
     Parameters
     ----------

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -165,7 +165,7 @@ class NeuronType(FrozenObject):
         Returns
         -------
         rates : (n_neurons,) ndarray
-            The firing rates at each given value of `x`.
+            The firing rates at each given value of ``x``.
         """
         J = self.current(x, gain, bias)
         out = np.zeros_like(J)
@@ -648,10 +648,7 @@ class Izhikevich(NeuronType):
         return args
 
     def rates(self, x, gain, bias):
-        """Estimates steady-state firing rate given gain and bias.
-
-        Uses the `.settled_firingrate` helper function.
-        """
+        """Estimates steady-state firing rate given gain and bias."""
         J = self.current(x, gain, bias)
         voltage = np.zeros_like(J)
         recovery = np.zeros_like(J)

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -96,14 +96,14 @@ class Simulator(object):
         want to build the network manually, or you want to inject build
         artifacts in the model before building the network, then you can
         pass in a `.Model` instance.
-    progress_bar : bool or `.ProgressBar` or `.ProgressUpdater`, optional \
+    progress_bar : bool or ProgressBar, optional \
                    (Default: True)
         Progress bar for displaying build and simulation progress.
 
         If ``True``, the default progress bar will be used.
         If ``False``, the progress bar will be disabled.
-        For more control over the progress bar, pass in a `.ProgressBar`
-        or `.ProgressUpdater` instance.
+        For more control over the progress bar, pass in a ``ProgressBar``
+        instance.
     optimize : bool, optional (Default: True)
         If ``True``, the builder will run an additional optimization step
         that can speed up simulations significantly at the cost of slower
@@ -297,14 +297,13 @@ class Simulator(object):
         ----------
         time_in_seconds : float
             Amount of time to run the simulation for. Must be positive.
-        progress_bar : bool or `.ProgressBar` or `.ProgressUpdater`, optional \
-                       (Default: True)
+        progress_bar : bool or ProgressBar, optional (Default: True)
             Progress bar for displaying the progress of the simulation run.
 
             If True, the default progress bar will be used.
             If False, the progress bar will be disabled.
-            For more control over the progress bar, pass in a `.ProgressBar`
-            or `.ProgressUpdater` instance.
+            For more control over the progress bar, pass in a ``ProgressBar``
+            instance.
         """
         if time_in_seconds < 0:
             raise ValidationError("Must be positive (got %g)"
@@ -327,14 +326,13 @@ class Simulator(object):
         ----------
         steps : int
             Number of steps to run the simulation for.
-        progress_bar : bool or `.ProgressBar` or `.ProgressUpdater`, optional \
-                       (Default: True)
+        progress_bar : bool or ProgressBar, optional (Default: True)
             Progress bar for displaying the progress of the simulation run.
 
             If True, the default progress bar will be used.
             If False, the progress bar will be disabled.
-            For more control over the progress bar, pass in a `.ProgressBar`
-            or `.ProgressUpdater` instance.
+            For more control over the progress bar, pass in a ``ProgressBar``
+            instance.
         """
         if progress_bar is None:
             progress_bar = self.progress_bar

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -1,5 +1,4 @@
-"""
-Functions concerned with solving for decoders or full weight matrices.
+"""Functions concerned with solving for decoders or full weight matrices.
 
 Many of the solvers in this file can solve for decoders or weight matrices,
 depending on whether the post-population encoders `E` are provided (see below).
@@ -42,7 +41,7 @@ class Solver(with_metaclass(DocstringInheritor, FrozenObject)):
         Y : (n_eval_points, dimensions) array_like
             Matrix of the target decoded values for each of the D dimensions,
             at each of the evaluation points.
-        rng : `numpy.random.RandomState`, optional (Default: `np.random`)
+        rng : `numpy.random.RandomState`, optional (Default: ``numpy.random``)
             A random number generator to use as required.
         E : (dimensions, post.n_neurons) array_like, optional (Default: None)
             Array of post-population encoders. Providing this tells the solver

--- a/nengo/spa/action_objects.py
+++ b/nengo/spa/action_objects.py
@@ -135,9 +135,7 @@ class DotProduct(object):
     so that the 0.5 in ``"0.5*DotProduct(Source('vision'), Symbol('DOG'))"``
     can be correctly tracked.
 
-    This class is meant to be used with an eval-based parsing system in the
-    `.Condition` class, so that the above ``DotProduct`` can also be created
-    with ``"0.5*dot(vision, 'DOG')"``.
+    This is used by the `.spa.Actions` parsing system.
     """
 
     def __init__(self, item1, item2, scale=1.0):

--- a/nengo/spa/actions.py
+++ b/nengo/spa/actions.py
@@ -89,7 +89,7 @@ class Effect(object):
         The names of valid places to send information (SPA module inputs).
     effect: str
         The action to implement. This is a set of assignment statements
-        which can be parsed into a `.VectorList`.
+        where the right hand side can be parsed with the `.Expression` class.
     """
 
     def __init__(self, sources, sinks, effect):

--- a/nengo/spa/bind.py
+++ b/nengo/spa/bind.py
@@ -7,7 +7,7 @@ class Bind(Module):
     """A module for binding together two inputs.
 
     Binding is done with circular convolution. For more details on how
-    this is computed, see the underlying `~.network.CircularConvolution`
+    this is computed, see the underlying `~.networks.CircularConvolution`
     network.
 
     Parameters

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -62,7 +62,7 @@ class SPA(nengo.Network):
 
     For complex cognitive control, the key modules are the `.spa.BasalGanglia`
     and the `.spa.Thalamus`. Together, these allow us to define complex actions
-    using the `.spa.Action` syntax::
+    using the `.spa.Actions` syntax::
 
         class SequenceExample(spa.SPA):
             def __init__(self):

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -274,18 +274,18 @@ class RandomizedSVD(LeastSquaresSolver):
 
     Parameters
     ----------
-    n_components : int (default is 60)
+    n_components : int, optional (Default: 60)
         The number of SVD components to compute. A small survey of activity
         matrices suggests that the first 60 components capture almost all
         the variance.
-    n_oversamples: int (default is 10)
+    n_oversamples : int, optional (Default: 10)
         The number of additional samples on the range of A.
-    n_iter : int (default is 0)
+    n_iter : int, optional (Default: 0)
         The number of power iterations to perform (can help with noisy data).
 
     See also
     --------
-    ``sklearn.utils.extmath.randomized_svd`` for details about the parameters.
+    sklearn.utils.extmath.randomized_svd : Function used by this class
     """
 
     n_components = IntParam('n_components', low=1)

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -181,7 +181,7 @@ class ProgressBar(object):
 
         Parameters
         ----------
-        progress : :class:`Progress`
+        progress : Progress
             The progress information to display.
         """
         raise NotImplementedError()
@@ -468,7 +468,7 @@ class AutoProgressBar(ProgressBar):
 
     Parameters
     ----------
-    delegate : :class:`ProgressBar`
+    delegate : ProgressBar
         The actual progress bar to display, if ETA is high enough.
     min_eta : float, optional
         The minimum ETA threshold for displaying the progress bar.
@@ -505,7 +505,7 @@ class ProgressTracker(object):
 
     Parameters
     ----------
-    progress_bar : :class:`ProgressBar` or bool or None
+    progress_bar : ProgressBar or bool or None
         The progress bar to display the progress (or True to use the default
         progress bar, False/None to disable progress bar).
     total_progress : int
@@ -572,7 +572,7 @@ def get_default_progressbar():
 
     Returns
     -------
-    :class:`ProgressBar`
+    ``ProgressBar``
     """
     try:
         pbar = rc.getboolean('progress', 'progress_bar')
@@ -599,19 +599,19 @@ def get_default_progressbar():
 
 
 def to_progressbar(progress_bar):
-    """Converts to a `.ProgressBar` instance.
+    """Converts to a ``ProgressBar`` instance.
 
     Parameters
     ----------
-    progress_bar : None, bool, or `.ProgressBar`
-        Object to be converted to a `.ProgressBar`.
+    progress_bar : None, bool, or ProgressBar
+        Object to be converted to a ``ProgressBar``.
 
     Returns
     -------
     ProgressBar
-        Return *progress_bar* if it is already a progress bar, the default
-        progress bar if *progress_bar* is *True*, and `NoProgressBar` if it is
-        *None* or *False*.
+        Return ``progress_bar`` if it is already a progress bar, the default
+        progress bar if ``progress_bar`` is ``True``, and ``NoProgressBar`` if
+        it is ``None`` or ``False``.
     """
     if progress_bar is False or progress_bar is None:
         progress_bar = NoProgressBar()


### PR DESCRIPTION
**Motivation and context:**
This PR does two sort of related things -- I can split them into separate PRs if either of the two is contentious, but they should be straightforward.

First, I had an issue with Nengo Extras in which TravisCI would fail jobs because the logs exceeded the limit (4 MB). A bit part of those logs is commands that have progress bars (`conda` and `wget`, at least) because progress bars usually print a bunch of stuff, which end up being overwritten in a terminal, but not in a log. So I added `--quiet` flags wherever I could. For `conda` and `wget`, `--quiet` only suppresses the progress bar, not other output.

Second, I noticed that Sphinx has a `nitpicky` option which does some additional checks and warns if they don't pass. This finds a lot of things that I tend to look for manually, so by failing them in CI I can rest my weary brain.

**How has this been tested?**
Waited for CI builds to finish before making the PR. They finished successfully :+1:

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
