### PR TITLE
Deactivate progress bar in cache benchmark.

### DIFF
--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -382,7 +382,10 @@ with model:
     '''
 
     without_cache = {
-        'rc': 'rc.set("decoder_cache", "enabled", "False")',
+        'rc': '''
+rc.set("progress", "progress_bar", "none")
+rc.set("decoder_cache", "enabled", "False")
+''',
         'stmt': '''
 with nengo.Simulator(model):
     pass
@@ -391,6 +394,7 @@ with nengo.Simulator(model):
 
     with_cache_miss_ro = {
         'rc': '''
+rc.set("progress", "progress_bar", "none")
 with nengo.cache.DecoderCache() as cache:
     cache.invalidate()
 rc.set("decoder_cache", "enabled", "True")
@@ -404,6 +408,7 @@ with nengo.Simulator(model):
 
     with_cache_miss = {
         'rc': '''
+rc.set("progress", "progress_bar", "none")
 with nengo.cache.DecoderCache() as cache:
     cache.invalidate()
 rc.set("decoder_cache", "enabled", "True")
@@ -417,6 +422,7 @@ with nengo.Simulator(model):
 
     with_cache_hit = {
         'rc': '''
+rc.set("progress", "progress_bar", "none")
 rc.set("decoder_cache", "enabled", "True")
 rc.set("decoder_cache", "readonly", "False")
 with nengo.Simulator(model):
@@ -523,6 +529,7 @@ import nengo
 import nengo.cache
 from nengo.rc import rc
 
+rc.set("progress", "progress_bar", "none")
 rc.set("decoder_cache", "path", {tmpdir!r})
 
 for i in range(10):


### PR DESCRIPTION
**Motivation and context:**
Using a progress bar starts a thread that sleeps for 0.1s for every
update. Joining the thread after completing the build thus takes up
to 0.1s too which swamps any build performance improvements for the
given test cases. By deactivating the progress bar we get the raw
build performance. Outside the tests added 0.1s are not noticeable
to the user and thus do not need to be changed.

Fixes #1447.

**Interactions with other PRs:**
none

**How has this been tested?**
Looked at the plots of the decoder cache benchmark tests. Run them with `pytest --slow --plots -- nengo/tests/test_cache.py`.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.