### PR TITLE
Activate attribute-defined-outside-init warnings.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,7 @@ disable = all,
           import-error,
           reimported,
 enable = anomalous-backslash-in-string,
+         attribute-defined-outside-init
          bad-mcs-classmethod-argument,
          bad-super-call,
          bad-whitespace,

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -35,7 +35,7 @@ class NetworkMember(type):
         inst.__init__(*args, **kwargs)
         if add_to_container:
             nengo.Network.add(inst)
-        inst._initialized = True  # value doesn't matter, just existence
+        inst._initialized = True
         return inst
 
 
@@ -68,12 +68,13 @@ class NengoObject(with_metaclass(NetworkMember, SupportDefaultsMixin)):
 
     def __init__(self, label, seed):
         super(NengoObject, self).__init__()
+        self._initialized = False
         self.label = label
         self.seed = seed
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        del state['_initialized']
+        state['_initialized'] = False
 
         for attr in self.params:
             param = getattr(type(self), attr)
@@ -98,7 +99,8 @@ class NengoObject(with_metaclass(NetworkMember, SupportDefaultsMixin)):
             warnings.warn(NotAddedToNetworkWarning(self))
 
     def __setattr__(self, name, val):
-        if hasattr(self, '_initialized') and not hasattr(self, name):
+        initialized = hasattr(self, '_initialized') and self._initialized
+        if initialized and not hasattr(self, name):
             warnings.warn(
                 "Creating new attribute '%s' on '%s'. "
                 "Did you mean to change an existing attribute?" % (name, self),

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -62,7 +62,7 @@ class Operator(object):
     and which of these four types of manipulations is done to each signal
     so that the simulator can order all of the operators properly.
 
-    .. note:: There are intentionally no default values for the
+    .. note:: There are intentionally no valid default values for the
               `~.Operator.reads`, `~.Operator.sets`, `~.Operator.incs`,
               and `~.Operator.updates` properties to ensure that subclasses
               explicitly set these values.
@@ -80,6 +80,11 @@ class Operator(object):
 
     def __init__(self, tag=None):
         self.tag = tag
+
+        self._sets = None
+        self._incs = None
+        self._reads = None
+        self._updates = None
 
     def __repr__(self):
         return "<%s %s at 0x%x>" % (

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -137,6 +137,10 @@ class AssociativeMemory(nengo.Network):
                 # am_ensembles have [1] encoders
             else:
                 self.inhibit = None
+
+            self.thresh_bias = None
+            self.thresholded_utilities = None
+
         self.add_input_mapping("input", input_vectors, input_scales)
         self.add_output_mapping("output", output_vectors)
 

--- a/nengo/spa/basalganglia.py
+++ b/nengo/spa/basalganglia.py
@@ -30,6 +30,7 @@ class BasalGanglia(Module):
                  label=None, seed=None, add_to_container=None):
         self.actions = actions
         self.input_synapse = input_synapse
+        self.spa = None
         self._bias = None
         Module.__init__(self, label, seed, add_to_container)
         nengo.networks.BasalGanglia(dimensions=self.actions.count, net=self)

--- a/nengo/spa/cortical.py
+++ b/nengo/spa/cortical.py
@@ -33,6 +33,7 @@ class Cortical(Module):
         self.actions = actions
         self.synapse = synapse
         self.neurons_cconv = neurons_cconv
+        self.spa = None
 
     def on_add(self, spa):
         Module.on_add(self, spa)

--- a/nengo/spa/thalamus.py
+++ b/nengo/spa/thalamus.py
@@ -78,6 +78,7 @@ class Thalamus(Module):
         self.threshold_gate = threshold_gate
         self.synapse_to_gate = synapse_to_gate
         self.synapse_bg = synapse_bg
+        self.spa = None
 
         self.gates = {}     # gating ensembles per action (created as needed)
         self.channels = {}  # channels to pass transformed data between modules


### PR DESCRIPTION
**Motivation and context:**
When attributes are defined outside of init they are not always available which can easily lead to AttributeErrors.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
Based on #1278, related to other pylint PRs.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
ran pylint

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
