### PR TITLE
Fix warnings raised in test suite

### DIFF
--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -186,15 +186,21 @@ def test_weight_solver(Solver, rng):
     assert np.allclose(W1, W2)
 
 
-def test_scipy_solvers(rng):
+def test_scipy_solvers(rng, logger):
     pytest.importorskip('scipy', minversion='0.11')  # version for lsmr
 
     A, b = get_system(1000, 100, 2, rng=rng)
     sigma = 0.1 * A.max()
 
-    x0, _ = lstsq.Cholesky()(A, b, sigma)
-    x1, _ = lstsq.ConjgradScipy()(A, b, sigma)
-    x2, _ = lstsq.LSMRScipy()(A, b, sigma)
+    x0, i0 = lstsq.Cholesky()(A, b, sigma)
+    logger.info("Cholesky rmse=%0.3f" % (i0['rmses'].mean(),))
+    x1, i1 = lstsq.ConjgradScipy()(A, b, sigma)
+    logger.info("ConjgradScipy rmse=%0.3f, itns=%0.1f (%0.1f)" % (
+        i1['rmses'].mean(), i1['iterations'].mean(), i1['iterations'].std()))
+    x2, i2 = lstsq.LSMRScipy()(A, b, sigma)
+    logger.info("LSMRScipy rmse=%0.3f, itns=%0.1f (%0.1f)" % (
+        i2['rmses'].mean(), i2['iterations'].mean(), i2['iterations'].std()))
+
     assert np.allclose(x0, x1, atol=2e-5, rtol=1e-3)
     assert np.allclose(x0, x2, atol=2e-5, rtol=1e-3)
 

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -107,7 +107,7 @@ class ConjgradScipy(LeastSquaresSolver):
                 itns[i] += 1
 
             X[:, i], infos[i] = scipy.sparse.linalg.cg(
-                G, B[:, i], tol=self.tol, callback=callback)
+                G, B[:, i], tol=self.tol, callback=callback, atol=0)
 
         info = {'rmses': rmses(A, X, Y), 'iterations': itns, 'info': infos}
         return X if matrix_in else X.ravel(), info

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -75,7 +75,7 @@ def array_hash(a, n=100):
     else:
         # pick random elements to hash
         rng = np.random.RandomState(a.size)
-        inds = [rng.randint(0, a.shape[i], size=n) for i in range(a.ndim)]
+        inds = tuple(rng.randint(0, a.shape[i], size=n) for i in range(a.ndim))
         v = a[inds]
         v.setflags(write=False)
         return hash(v.data if PY2 else v.data.tobytes())


### PR DESCRIPTION
**Motivation and context:**
#1443 fixed most of the warnings recently raised in the test suite, but there were a few more related to recent NumPy and SciPy changes.

**How has this been tested?**
Ran the test suite locally and got 0 warnings.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
- [x] Is the `atol=0` value correct in the `scipy.sparse.linalg.cg` call?