### PR TITLE
Streamlined neuron argreprs and added amplitude

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
     'python': ('https://docs.python.org/3', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
-    'sklearn': ('http://scikit-learn.org/dev', None),
+    'sklearn': ('https://scikit-learn.org/dev', None),
 }
 
 # -- sphinx.ext.todo

--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -333,7 +333,7 @@ and loading it up in the future.
        Representations for Symbol-Like Processing in Spiking Neural Networks.”
        PLoS ONE 11, no. 2 (February 22, 2016): e0149928.
        `doi:10.1371/journal.pone.0149928
-       <http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0149928>`_.
+       <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0149928>`_.
 .. [3] Note that decoded connections
        also accept the ``transform`` argument.
        In the case of decoded connections,

--- a/docs/examples/advanced/nef_algorithm.ipynb
+++ b/docs/examples/advanced/nef_algorithm.ipynb
@@ -13,7 +13,7 @@
     "The theory behind the Neural Engineering Framework\n",
     "is developed at length in\n",
     "[Eliasmith & Anderson, 2003: \"Neural Engineering\"](\n",
-    "https://www.amazon.com/dp/0262550601)\n",
+    "https://mitpress.mit.edu/books/neural-engineering)\n",
     "and a short summary is available in\n",
     "[Stewart, 2012: \"A Technical Overview of the Neural Engineering Framework\"](\n",
     "http://compneuro.uwaterloo.ca/publications/stewart2012d.html).\n",

--- a/docs/examples/advanced/nef_summary.ipynb
+++ b/docs/examples/advanced/nef_summary.ipynb
@@ -10,7 +10,7 @@
     "is one set of theoretical methods that are used in\n",
     "Nengo for constructing neural models.\n",
     "The NEF is based on [Eliasmith & Anderson's (2003) book](\n",
-    "http://www.amazon.com/gp/product/0262550601) from MIT Press.\n",
+    "https://mitpress.mit.edu/books/neural-engineering) from MIT Press.\n",
     "This notebook introduces the three main principles\n",
     "discussed in that book and implemented in Nengo."
    ]

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -105,7 +105,7 @@ through ``pip`` when installing Nengo.
    pip install nengo[tests]  # For running the test suite
    pip install nengo[all]  # All of the above
 
-.. _Anaconda: https://www.anaconda.com/download/
+.. _Anaconda: https://www.anaconda.com/distribution/#download-section
 .. _Homebrew: https://brew.sh/
 
 Usage

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -231,7 +231,7 @@ class LstsqL1(Solver):
 
     def __init__(self, weights=False, l1=1e-4, l2=1e-6, max_iter=1000):
         """
-        .. note:: Requires `scikit-learn <http://scikit-learn.org/stable/>`_.
+        .. note:: Requires `scikit-learn <https://scikit-learn.org/stable/>`_.
 
         Parameters
         ----------

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -476,6 +476,95 @@ def test_frozen():
         d.coupling = 8
 
 
+def test_argreprs():
+    """Test repr() for each neuron type."""
+    assert repr(nengo.Direct()) == "Direct()"
+
+    assert repr(nengo.RectifiedLinear()) == "RectifiedLinear()"
+    assert (repr(nengo.RectifiedLinear(amplitude=2))
+            == "RectifiedLinear(amplitude=2)")
+
+    assert repr(nengo.SpikingRectifiedLinear()) == "SpikingRectifiedLinear()"
+    assert (repr(nengo.SpikingRectifiedLinear(amplitude=2))
+            == "SpikingRectifiedLinear(amplitude=2)")
+
+    assert repr(nengo.Sigmoid()) == "Sigmoid()"
+    assert repr(nengo.Sigmoid(tau_ref=0.1)) == "Sigmoid(tau_ref=0.1)"
+
+    assert repr(nengo.LIFRate()) == "LIFRate()"
+    assert repr(nengo.LIFRate(tau_rc=0.1)) == "LIFRate(tau_rc=0.1)"
+    assert repr(nengo.LIFRate(tau_ref=0.1)) == "LIFRate(tau_ref=0.1)"
+    assert repr(nengo.LIFRate(amplitude=2)) == "LIFRate(amplitude=2)"
+    assert (repr(nengo.LIFRate(tau_rc=0.05, tau_ref=0.02))
+            == "LIFRate(tau_rc=0.05, tau_ref=0.02)")
+    assert (repr(nengo.LIFRate(tau_rc=0.05, amplitude=2))
+            == "LIFRate(tau_rc=0.05, amplitude=2)")
+    assert (repr(nengo.LIFRate(tau_ref=0.02, amplitude=2))
+            == "LIFRate(tau_ref=0.02, amplitude=2)")
+    assert (repr(nengo.LIFRate(tau_rc=0.05, tau_ref=0.02, amplitude=2))
+            == "LIFRate(tau_rc=0.05, tau_ref=0.02, amplitude=2)")
+
+    assert repr(nengo.LIF()) == "LIF()"
+    assert repr(nengo.LIF(tau_rc=0.1)) == "LIF(tau_rc=0.1)"
+    assert repr(nengo.LIF(tau_ref=0.1)) == "LIF(tau_ref=0.1)"
+    assert repr(nengo.LIF(amplitude=2)) == "LIF(amplitude=2)"
+    assert repr(nengo.LIF(min_voltage=-0.5)) == "LIF(min_voltage=-0.5)"
+    assert (repr(nengo.LIF(tau_rc=0.05, tau_ref=0.02))
+            == "LIF(tau_rc=0.05, tau_ref=0.02)")
+    assert (repr(nengo.LIF(tau_rc=0.05, amplitude=2))
+            == "LIF(tau_rc=0.05, amplitude=2)")
+    assert (repr(nengo.LIF(tau_ref=0.02, amplitude=2))
+            == "LIF(tau_ref=0.02, amplitude=2)")
+    assert (repr(nengo.LIF(tau_rc=0.05, tau_ref=0.02, amplitude=2))
+            == "LIF(tau_rc=0.05, tau_ref=0.02, amplitude=2)")
+    assert (repr(nengo.LIF(tau_rc=0.05, tau_ref=0.02,
+                           min_voltage=-0.5, amplitude=2))
+            == "LIF(tau_rc=0.05, tau_ref=0.02, min_voltage=-0.5, amplitude=2)")
+
+    assert repr(nengo.AdaptiveLIFRate()) == "AdaptiveLIFRate()"
+    assert (repr(nengo.AdaptiveLIFRate(tau_n=0.1))
+            == "AdaptiveLIFRate(tau_n=0.1)")
+    assert (repr(nengo.AdaptiveLIFRate(inc_n=0.5))
+            == "AdaptiveLIFRate(inc_n=0.5)")
+    assert (repr(nengo.AdaptiveLIFRate(tau_rc=0.1))
+            == "AdaptiveLIFRate(tau_rc=0.1)")
+    assert (repr(nengo.AdaptiveLIFRate(tau_ref=0.1))
+            == "AdaptiveLIFRate(tau_ref=0.1)")
+    assert (repr(nengo.AdaptiveLIFRate(amplitude=2))
+            == "AdaptiveLIFRate(amplitude=2)")
+    assert (repr(nengo.AdaptiveLIFRate(tau_n=0.1, inc_n=0.5, tau_rc=0.05,
+                                       tau_ref=0.02, amplitude=2))
+            == "AdaptiveLIFRate(tau_n=0.1, inc_n=0.5, tau_rc=0.05, "
+               "tau_ref=0.02, amplitude=2)")
+
+    assert repr(nengo.AdaptiveLIF()) == "AdaptiveLIF()"
+    assert repr(nengo.AdaptiveLIF(tau_n=0.1)) == "AdaptiveLIF(tau_n=0.1)"
+    assert repr(nengo.AdaptiveLIF(inc_n=0.5)) == "AdaptiveLIF(inc_n=0.5)"
+    assert repr(nengo.AdaptiveLIF(tau_rc=0.1)) == "AdaptiveLIF(tau_rc=0.1)"
+    assert repr(nengo.AdaptiveLIF(tau_ref=0.1)) == "AdaptiveLIF(tau_ref=0.1)"
+    assert (repr(nengo.AdaptiveLIF(min_voltage=-0.5))
+            == "AdaptiveLIF(min_voltage=-0.5)")
+    assert (repr(nengo.AdaptiveLIF(tau_n=0.1, inc_n=0.5, tau_rc=0.05,
+                                   tau_ref=0.02, min_voltage=-0.5,
+                                   amplitude=2))
+            == "AdaptiveLIF(tau_n=0.1, inc_n=0.5, tau_rc=0.05, tau_ref=0.02, "
+               "min_voltage=-0.5, amplitude=2)")
+
+    assert repr(nengo.Izhikevich()) == "Izhikevich()"
+    assert (repr(nengo.Izhikevich(tau_recovery=0.1))
+            == "Izhikevich(tau_recovery=0.1)")
+    assert (repr(nengo.Izhikevich(coupling=0.3))
+            == "Izhikevich(coupling=0.3)")
+    assert (repr(nengo.Izhikevich(reset_voltage=-1))
+            == "Izhikevich(reset_voltage=-1)")
+    assert (repr(nengo.Izhikevich(reset_recovery=5))
+            == "Izhikevich(reset_recovery=5)")
+    assert (repr(nengo.Izhikevich(tau_recovery=0.1, coupling=0.3,
+                                  reset_voltage=-1, reset_recovery=5))
+            == "Izhikevich(tau_recovery=0.1, coupling=0.3, "
+               "reset_voltage=-1, reset_recovery=5)")
+
+
 @pytest.mark.filterwarnings('ignore:divide by zero')
 def test_direct_mode_nonfinite_value(Simulator):
     with nengo.Network() as model:

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -373,3 +373,20 @@ def test_configure_all_nengo_parameters():
             except Exception:
                 print("Error setting %s.%s" % (obj, name))
                 raise
+
+
+def test_frozenobject_reprs():
+    class TestFO(params.FrozenObject):
+        a = params.NumberParam('a', default=3, readonly=True)
+        b = params.NumberParam('b')
+
+        def __init__(self, a, b=4):
+            super(TestFO, self).__init__()
+            self.a = a
+            self.b = b
+
+    # test that parameters are only shown in repr if their values are different
+    # than the default, for both parameter defaults and argument defaults
+    assert repr(TestFO(3)) == "TestFO()"
+    assert repr(TestFO(2)) == "TestFO(a=2)"
+    assert repr(TestFO(2, b=3)) == "TestFO(a=2, b=3)"

--- a/nengo/tests/test_transforms.py
+++ b/nengo/tests/test_transforms.py
@@ -3,6 +3,7 @@ import pytest
 
 import nengo
 from nengo.exceptions import ValidationError
+from nengo.transforms import ChannelShape
 from nengo._vendor.npconv2d import conv2d
 
 
@@ -83,3 +84,28 @@ def test_convolution(
         truth = np.moveaxis(truth, -1, 0)
 
     assert np.allclose(sim.data[p][0], np.ravel(truth))
+
+
+def test_argreprs():
+    """Test repr() for each transform type."""
+    assert repr(nengo.Dense((1, 2), init=[[1, 1]])) == "Dense(shape=(1, 2))"
+
+    assert (repr(nengo.Convolution(3, (1, 2, 3)))
+            == "Convolution(n_filters=3, input_shape=(1, 2, 3))")
+    assert (repr(nengo.Convolution(3, (1, 2, 3), kernel_size=(3, 2)))
+            == "Convolution(n_filters=3, input_shape=(1, 2, 3), "
+               "kernel_size=(3, 2))")
+    assert (repr(nengo.Convolution(3, (1, 2, 3), channels_last=False))
+            == "Convolution(n_filters=3, input_shape=(1, 2, 3), "
+               "channels_last=False)")
+
+
+def test_channelshape_str():
+    assert (repr(ChannelShape((1, 2, 3)))
+            == "ChannelShape(shape=(1, 2, 3), channels_last=True)")
+    assert (repr(ChannelShape((1, 2, 3), channels_last=False))
+            == "ChannelShape(shape=(1, 2, 3), channels_last=False)")
+
+    # `str` always has channels last
+    assert str(ChannelShape((1, 2, 3))) == "(1, 2, ch=3)"
+    assert str(ChannelShape((1, 2, 3), channels_last=False)) == "(ch=1, 2, 3)"

--- a/nengo/transforms.py
+++ b/nengo/transforms.py
@@ -11,13 +11,6 @@ from nengo.utils.compat import is_array_like
 class Transform(FrozenObject):
     """A base class for connection transforms."""
 
-    def __repr__(self):
-        return "%s(%s)" % (type(self).__name__, ", ".join(self._argreprs))
-
-    @property
-    def _argreprs(self):
-        return []
-
     def sample(self, rng=np.random):
         """Returns concrete weights to implement the specified transform.
 

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -91,8 +91,8 @@ class ConjgradScipy(LeastSquaresSolver):
 
     References
     ----------
-    .. [1] scipy.sparse.linalg.cg documentation, https://docs.scipy.org/
-        doc/scipy/reference/generated/scipy.sparse.linalg.cg.html
+    .. [1] scipy.sparse.linalg.cg documentation,
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.cg.html
     """
 
     tol = NumberParam('tol', low=0)


### PR DESCRIPTION
- Amplitude is now printed in the argreprs (`str` representation)
  for LIF and RectifiedLinear.
- Added an `_add_argrepr` helper function to make argreprs more
  concise for all neuron types (had been done only for Izhikevich
  before).

**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

When printing the string representation for `LIF`, `LIFRate`, `RectifiedLinear`, and `SpikingRectifiedLinear`, the amplitude parameter was not included.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

I encountered this when making plots with these neuron types in nengo_loihi, so I tested it there.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
