### PR TITLE
Fix the string representation of RectifiedLinear

### DIFF
--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -241,10 +241,19 @@ class RectifiedLinear(NeuronType):
 
     probeable = ('rates',)
 
+    amplitude = NumberParam('amplitude', low=0, low_open=True)
+
     def __init__(self, amplitude=1):
         super(RectifiedLinear, self).__init__()
 
         self.amplitude = amplitude
+
+    @property
+    def _argreprs(self):
+        args = []
+        if self.amplitude != 1:
+            args.append("amplitude=%s" % self.amplitude)
+        return args
 
     def gain_bias(self, max_rates, intercepts):
         """Determine gain and bias by shifting and scaling the lines."""


### PR DESCRIPTION
**Motivation and context:**

This just fixes the string representation of RectifiedLinear and SpikingRectifiedLinear neurons.  Without this fix, we got this behaviour:

```python
print(nengo.SpikingRectifiedLinear(amplitude=0.5))
>>> SpikingRectifiedLinear()
```

**How has this been tested?**

Just by doing the above example in Jupyter notebook

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

This feels like too small a fix to add a test, and I'm not sure it even warrants a changelog entry.  If I'm wrong about that, let me know!