### PR TITLE
Programmatically check `repr`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,9 @@ Release History
   given ``size_in``/``size_out``.
   (`#1452 <https://github.com/nengo/nengo/issues/1452>`_,
   `#1434 <https://github.com/nengo/nengo/pull/1434>`_)
+- Several objects had elements missing from their string representations.
+  These strings are now automatically generated and tested to be complete.
+  (`#1472 <https://github.com/nengo/nengo/pull/1472>`__)
 
 2.8.0 (June 9, 2018)
 ====================

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -79,9 +79,6 @@ class PDF(Distribution):
         cumsum[1:] = cumsum[:-1] + cumsum[1:]
         self.cdf = cumsum
 
-    def __repr__(self):
-        return "PDF(x=%r, p=%r)" % (self.x, self.p)
-
     def sample(self, n, d=None, rng=np.random):
         shape = self._sample_shape(n, d)
         return np.interp(rng.uniform(size=shape), self.cdf, self.x)
@@ -117,10 +114,6 @@ class Uniform(Distribution):
         self.high = high
         self.integer = integer
 
-    def __repr__(self):
-        return "Uniform(low=%r, high=%r%s)" % (
-            self.low, self.high, ", integer=True" if self.integer else "")
-
     def sample(self, n, d=None, rng=np.random):
         shape = self._sample_shape(n, d)
         if self.integer:
@@ -154,9 +147,6 @@ class Gaussian(Distribution):
         super(Gaussian, self).__init__()
         self.mean = mean
         self.std = std
-
-    def __repr__(self):
-        return "Gaussian(mean=%r, std=%r)" % (self.mean, self.std)
 
     def sample(self, n, d=None, rng=np.random):
         shape = self._sample_shape(n, d)
@@ -241,14 +231,6 @@ class UniformHypersphere(Distribution):
         self.surface = surface
         self.min_magnitude = min_magnitude
 
-    def __repr__(self):
-        args = []
-        if self.surface:
-            args.append("surface=%s" % self.surface)
-        if self.min_magnitude > 0:
-            args.append("min_magnitude=%r" % self.min_magnitude)
-        return "%s(%s)" % (type(self).__name__, ', '.join(args))
-
     def sample(self, n, d=None, rng=np.random):
         if d is None or d < 1:  # check this, since other dists allow d = None
             raise ValidationError("Dimensions must be a positive integer", 'd')
@@ -308,11 +290,6 @@ class Choice(Distribution):
                                   % total, attr='weights', obj=self)
         self.p = weights / total
 
-    def __repr__(self):
-        return "Choice(options=%r%s)" % (
-            self.options,
-            "" if self.weights is None else ", weights=%r" % self.weights)
-
     @property
     def dimensions(self):
         return np.prod(self.options.shape[1:])
@@ -347,9 +324,6 @@ class Samples(Distribution):
     def __init__(self, samples):
         super(Samples, self).__init__()
         self.samples = samples
-
-    def __repr__(self):
-        return "Samples(samples=%r)" % (self.samples,)
 
     def sample(self, n, d=None, rng=np.random):
         samples = np.array(self.samples)
@@ -402,9 +376,6 @@ class SqrtBeta(Distribution):
         super(SqrtBeta, self).__init__()
         self.n = n
         self.m = m
-
-    def __repr__(self):
-        return "%s(n=%r, m=%r)" % (type(self).__name__, self.n, self.m)
 
     def sample(self, num, d=None, rng=np.random):
         shape = self._sample_shape(num, d)
@@ -489,9 +460,13 @@ class SubvectorLength(SqrtBeta):
         super(SubvectorLength, self).__init__(
             dimensions - subdimensions, subdimensions)
 
-    def __repr__(self):
-        return "%s(%r, subdimensions=%r)" % (
-            type(self).__name__, self.n + self.m, self.m)
+    @property
+    def dimensions(self):
+        return self.n + self.m
+
+    @property
+    def subdimensions(self):
+        return self.m
 
 
 class CosineSimilarity(SubvectorLength):

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -538,19 +538,27 @@ class AdaptiveLIFRate(LIFRate):
     tau_n = NumberParam('tau_n', low=0, low_open=True)
     inc_n = NumberParam('inc_n', low=0)
 
-    def __init__(self, tau_n=1, inc_n=0.01, **lif_args):
-        super(AdaptiveLIFRate, self).__init__(**lif_args)
+    def __init__(
+        self,
+        tau_n=1,
+        inc_n=0.01,
+        tau_rc=0.02,
+        tau_ref=0.002,
+        amplitude=1,
+    ):
+        super(AdaptiveLIFRate, self).__init__(
+            tau_rc=tau_rc, tau_ref=tau_ref, amplitude=amplitude)
         self.tau_n = tau_n
         self.inc_n = inc_n
 
     def step_math(self, dt, J, output, adaptation):
         """Implement the AdaptiveLIFRate nonlinearity."""
         n = adaptation
-        LIFRate.step_math(self, dt, J - n, output)
+        super(AdaptiveLIFRate, self).step_math(dt, J - n, output)
         n += (dt / self.tau_n) * (self.inc_n * output - n)
 
 
-class AdaptiveLIF(AdaptiveLIFRate, LIF):
+class AdaptiveLIF(LIF):
     """Adaptive spiking version of the LIF neuron model.
 
     Works as the LIF model, except with adapation state ``n``, which is
@@ -590,10 +598,31 @@ class AdaptiveLIF(AdaptiveLIFRate, LIF):
 
     probeable = ('spikes', 'adaptation', 'voltage', 'refractory_time')
 
+    tau_n = NumberParam('tau_n', low=0, low_open=True)
+    inc_n = NumberParam('inc_n', low=0)
+
+    def __init__(
+        self,
+        tau_n=1,
+        inc_n=0.01,
+        tau_rc=0.02,
+        tau_ref=0.002,
+        min_voltage=0,
+        amplitude=1,
+    ):
+        super(AdaptiveLIF, self).__init__(
+            tau_rc=tau_rc,
+            tau_ref=tau_ref,
+            min_voltage=min_voltage,
+            amplitude=amplitude,
+        )
+        self.tau_n = tau_n
+        self.inc_n = inc_n
+
     def step_math(self, dt, J, output, voltage, ref, adaptation):
         """Implement the AdaptiveLIF nonlinearity."""
         n = adaptation
-        LIF.step_math(self, dt, J - n, output, voltage, ref)
+        super(AdaptiveLIF, self).step_math(dt, J - n, output, voltage, ref)
         n += (dt / self.tau_n) * (self.inc_n * output - n)
 
 

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -184,10 +184,6 @@ class LinearFilter(Synapse):
         self.den = den
         self.analog = analog
 
-    def __repr__(self):
-        return "%s(%s, %s, analog=%r)" % (
-            type(self).__name__, self.num, self.den, self.analog)
-
     def combine(self, obj):
         """Combine in series with another LinearFilter."""
         if not isinstance(obj, LinearFilter):
@@ -368,9 +364,6 @@ class Lowpass(LinearFilter):
         super(Lowpass, self).__init__([1], [tau, 1], **kwargs)
         self.tau = tau
 
-    def __repr__(self):
-        return "%s(%r)" % (type(self).__name__, self.tau)
-
     def make_step(self, shape_in, shape_out, dt, rng, y0=None,
                   dtype=np.float64, **kwargs):
         """Returns an optimized `.LinearFilter.Step` subclass."""
@@ -413,9 +406,6 @@ class Alpha(LinearFilter):
         super(Alpha, self).__init__([1], [tau**2, 2*tau, 1], **kwargs)
         self.tau = tau
 
-    def __repr__(self):
-        return "%s(%r)" % (type(self).__name__, self.tau)
-
     def make_step(self, shape_in, shape_out, dt, rng, y0=None,
                   dtype=np.float64, **kwargs):
         """Returns an optimized `.LinearFilter.Step` subclass."""
@@ -450,9 +440,6 @@ class Triangle(Synapse):
     def __init__(self, t, **kwargs):
         super(Triangle, self).__init__(**kwargs)
         self.t = t
-
-    def __repr__(self):
-        return "%s(%r)" % (type(self).__name__, self.t)
 
     def make_step(self, shape_in, shape_out, dt, rng, y0=None,
                   dtype=np.float64):

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -390,3 +390,16 @@ def test_frozenobject_reprs():
     assert repr(TestFO(3)) == "TestFO()"
     assert repr(TestFO(2)) == "TestFO(a=2)"
     assert repr(TestFO(2, b=3)) == "TestFO(a=2, b=3)"
+
+
+def test_frozenobject_missing_arg_repr():
+    class TestFO(params.FrozenObject):
+        a = params.NumberParam('a', default=3, readonly=True)
+
+        def __init__(self, a, b=4):
+            super(TestFO, self).__init__()
+            self.a = a
+
+    fo = TestFO(3)
+    assert repr(fo).startswith("<TestFO at")
+    assert fo._argreprs == "Cannot find 'b'"

--- a/nengo/tests/test_pytest.py
+++ b/nengo/tests/test_pytest.py
@@ -1,12 +1,12 @@
+import nengo.conftest
 import nengo.utils.numpy as npext
-from nengo.conftest import TestConfig
 
 pytest_plugins = ["pytester"]
 
 
 def test_seed_fixture(seed):
     """The seed should be the same on all machines"""
-    i = (seed - TestConfig.test_seed) % npext.maxint
+    i = (seed - nengo.conftest.TestConfig.test_seed) % npext.maxint
     assert i == 1832276344
 
 
@@ -35,3 +35,6 @@ def test_unsupported(testdir):
     assert outcomes["deselected"] > 700
     assert "passed" not in outcomes
     assert "failed" not in outcomes
+
+    # runpytest runs in-process, so we have to undo changes to TestConfig
+    nengo.conftest.TestConfig.Simulator = nengo.Simulator

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -1,10 +1,12 @@
 import numpy as np
+from numpy import array  # pylint: disable=unused-import
 import pytest
 
 import nengo
 from nengo.processes import WhiteSignal
 from nengo.synapses import (
     Alpha, LinearFilter, Lowpass, SynapseParam, Triangle)
+from nengo.utils.compat import getfullargspec
 from nengo.utils.testing import allclose
 
 
@@ -215,3 +217,25 @@ def test_frozen():
 
     with pytest.raises((ValueError, RuntimeError)):
         a.den[0] = 9
+
+
+def test_argreprs():
+
+    def check_init_args(cls, args):
+        assert getfullargspec(cls.__init__).args[1:] == args
+
+    def check_repr(obj):
+        assert eval(repr(obj)) == obj
+
+    check_init_args(LinearFilter, ['num', 'den', 'analog'])
+    check_repr(LinearFilter([1, 2], [3, 4]))
+    check_repr(LinearFilter([1, 2], [3, 4], analog=False))
+
+    check_init_args(Lowpass, ['tau'])
+    check_repr(Lowpass(0.3))
+
+    check_init_args(Alpha, ['tau'])
+    check_repr(Alpha(0.3))
+
+    check_init_args(Triangle, ['t'])
+    check_repr(Triangle(0.3))


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

This automates the testing of our `__repr__` functions for FrozenObjects, so that e.g. if new parameters are added we don't forget to add them to `__repr__`.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Based on #1468.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

By printing the `repr` for each object in the tests, to ensure that they look as expected, and that we're checking all different combinations.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Testing improvements

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
