### PR TITLE
Subclass config

### DIFF
--- a/nengo/config.py
+++ b/nengo/config.py
@@ -417,10 +417,10 @@ class Config:
                               "keyword with an unconfigurable parameter.")
 
         for config in reversed(Config.context):
-
-            # If a default has been set for this config, return it
-            if nengo_cls in config.params and config[nengo_cls] in desc:
-                return getattr(config[nengo_cls], param)
+            for cls in nengo_cls.__mro__:
+                # If a default has been set for this config, return it
+                if cls in config.params and config[cls] in desc:
+                    return getattr(config[cls], param)
 
         # Otherwise, return the param default
         return desc.default


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

This allows you to subclass a Nengo object (e.g. Ensemble) and still have the config/default system work.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

I've written a unit test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**TODO**

- [x] There's some dead code at the bottom of the unit test, which illustrates a case where I'm not sure what the expected behaviour should be. We need to figure this out.