### PR TITLE
Do not overwrite existing seeds when building

### DIFF
--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -53,13 +53,15 @@ def build_network(model, network, progress=None):
         # Generate a seed no matter what, so that setting a seed or not on
         # one object doesn't affect the seeds of other objects.
         seed = rng.randint(npext.maxint)
-        return (seed if not hasattr(obj, 'seed') or obj.seed is None
-                else obj.seed)
+        if obj in model.seeds:
+            return model.seeds[obj]
+        if hasattr(obj, "seed") and obj.seed is not None:
+            return obj.seed
+        return seed
 
     if model.toplevel is None:
         model.toplevel = network
-        if network not in model.seeds:
-            model.seeds[network] = get_seed(network, np.random)
+        model.seeds[network] = get_seed(network, np.random)
         if network not in model.seeded:
             model.seeded[network] = getattr(network, 'seed', None) is not None
         max_steps = len(network.all_objects) + 1  # +1 for top level network
@@ -89,8 +91,7 @@ def build_network(model, network, progress=None):
             if obj not in model.seeded:
                 model.seeded[obj] = (model.seeded[network] or
                                      getattr(obj, 'seed', None) is not None)
-            if obj not in model.seeds:
-                model.seeds[obj] = get_seed(obj, rng)
+            model.seeds[obj] = get_seed(obj, rng)
 
     # If this is the toplevel network, enter the decoder cache
     context = (model.decoder_cache if model.toplevel is network

--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -58,8 +58,10 @@ def build_network(model, network, progress=None):
 
     if model.toplevel is None:
         model.toplevel = network
-        model.seeds[network] = get_seed(network, np.random)
-        model.seeded[network] = getattr(network, 'seed', None) is not None
+        if network not in model.seeds:
+            model.seeds[network] = get_seed(network, np.random)
+        if network not in model.seeded:
+            model.seeded[network] = getattr(network, 'seed', None) is not None
         max_steps = len(network.all_objects) + 1  # +1 for top level network
 
         if progress is not None:
@@ -84,9 +86,11 @@ def build_network(model, network, progress=None):
     assert all(tp in sorted_types for tp in network.objects)
     for obj_type in sorted_types:
         for obj in network.objects[obj_type]:
-            model.seeded[obj] = (model.seeded[network] or
-                                 getattr(obj, 'seed', None) is not None)
-            model.seeds[obj] = get_seed(obj, rng)
+            if obj not in model.seeded:
+                model.seeded[obj] = (model.seeded[network] or
+                                     getattr(obj, 'seed', None) is not None)
+            if obj not in model.seeds:
+                model.seeds[obj] = get_seed(obj, rng)
 
     # If this is the toplevel network, enter the decoder cache
     context = (model.decoder_cache if model.toplevel is network


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

This allows someone to pre-set seeds for some or all objects. I'm using this in `nengo_loihi` so that I can make sure the `nengo` models that we use to simulate the parts of the model that are on the host, have the same seeds.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

This is supporting nengo/nengo-loihi#70.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

This is tested with `nengo_loihi`.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [ ] Discuss whether we want to have this and the `nengo_loihi` PR both done as currently proposed, or whether we want to bring the `nengo_loihi` function for pre-seeding networks over here. Computing seeds before build-time has been something that we've talked about for a while, and it would make a lot of backend stuff easier.
