### PR TITLE
Add configurable allclose fixture for tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ Release History
   ``dt`` is now an alias for ``sample_every`` and will be removed in the future.
   (`#1368 <https://github.com/nengo/nengo/issues/1368>`_,
   `#1384 <https://github.com/nengo/nengo/pull/1384>`_)
+- Renamed ``utils/testing.py:allclose`` to ``utils/test.py:signal_allclose``.
 
 2.8.0 (June 9, 2018)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ Release History
 - Renamed ``utils/testing.py:allclose`` to ``utils/test.py:signal_allclose``.
 - Added new pytest config option, ``nengo_test_unsupported`` (replacing the
   previous ``Simulator.unsupported`` functionality).
+- Deprecated ``utils/numpy.py:rmse``, since this can easily be done by calling
+  ``rms`` on the difference between two arrays.
 
 2.8.0 (June 9, 2018)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Release History
   (`#1368 <https://github.com/nengo/nengo/issues/1368>`_,
   `#1384 <https://github.com/nengo/nengo/pull/1384>`_)
 - Renamed ``utils/testing.py:allclose`` to ``utils/test.py:signal_allclose``.
+- Added new pytest config option, ``nengo_test_unsupported`` (replacing the
+  previous ``Simulator.unsupported`` functionality).
 
 2.8.0 (June 9, 2018)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ Release History
 - We now warn that the progress bar is not supported in Jupyter Notebook <5.
   (`#1428 <https://github.com/nengo/nengo/pull/1428>`__,
   `#1426 <https://github.com/nengo/nengo/issues/1426>`__)
+- Added new pytest config option, ``nengo_test_tolerances``, which can be used
+  to adjust unit test tolerances on a test-by-test basis (useful for other
+  backends using Nengo's unit tests).
 
 **Changed**
 

--- a/nengo/builder/tests/test_optimizer.py
+++ b/nengo/builder/tests/test_optimizer.py
@@ -99,22 +99,22 @@ def test_sigmerger_check_views():
         SigMerger.check_views([s1[:2], s2[2:]])
 
 
-def test_sigmerger_merge():
+def test_sigmerger_merge(allclose):
     s1 = Signal(np.array([[0, 1], [2, 3]]))
     s2 = Signal(np.array([[4, 5]]))
 
     sig, replacements = SigMerger.merge([s1, s2])
-    assert np.allclose(sig.initial_value, np.array([[0, 1], [2, 3], [4, 5]]))
-    assert np.allclose(replacements[s1].initial_value, s1.initial_value)
-    assert np.allclose(replacements[s2].initial_value, s2.initial_value)
+    assert allclose(sig.initial_value, np.array([[0, 1], [2, 3], [4, 5]]))
+    assert allclose(replacements[s1].initial_value, s1.initial_value)
+    assert allclose(replacements[s2].initial_value, s2.initial_value)
 
 
-def test_sigmerger_merge_views():
+def test_sigmerger_merge_views(allclose):
     s = Signal(np.array([[0, 1], [2, 3], [4, 5]]))
     v1, v2 = s[:2], s[2:]
     merged, _ = SigMerger.merge_views([v1, v2])
 
-    assert np.allclose(merged.initial_value, s.initial_value)
+    assert allclose(merged.initial_value, s.initial_value)
     assert v1.base is s
     assert v2.base is s
 

--- a/nengo/builder/tests/test_signal.py
+++ b/nengo/builder/tests/test_signal.py
@@ -8,7 +8,7 @@ from nengo.exceptions import SignalError
 from nengo.utils.compat import itervalues
 
 
-def test_signaldict():
+def test_signaldict(allclose):
     """Tests SignalDict's dict overrides."""
     signaldict = SignalDict()
 
@@ -21,39 +21,39 @@ def test_signaldict():
         signaldict[scalar] = np.array(1.)
 
     signaldict.init(scalar)
-    assert np.allclose(signaldict[scalar], np.array(1.))
+    assert allclose(signaldict[scalar], np.array(1.))
     # __getitem__ handles scalars
     assert signaldict[scalar].shape == ()
 
     one_d = Signal([1.])
     signaldict.init(one_d)
-    assert np.allclose(signaldict[one_d], np.array([1.]))
+    assert allclose(signaldict[one_d], np.array([1.]))
     assert signaldict[one_d].shape == (1,)
 
     two_d = Signal([[1.], [1.]])
     signaldict.init(two_d)
-    assert np.allclose(signaldict[two_d], np.array([[1.], [1.]]))
+    assert allclose(signaldict[two_d], np.array([[1.], [1.]]))
     assert signaldict[two_d].shape == (2, 1)
 
     # __getitem__ handles views implicitly (note no .init)
     two_d_view = two_d[0, :]
-    assert np.allclose(signaldict[two_d_view], np.array([1.]))
+    assert allclose(signaldict[two_d_view], np.array([1.]))
     assert signaldict[two_d_view].shape == (1,)
 
     # __setitem__ ensures memory location stays the same
     memloc = signaldict[scalar].__array_interface__['data'][0]
     signaldict[scalar] = np.array(0.)
-    assert np.allclose(signaldict[scalar], np.array(0.))
+    assert allclose(signaldict[scalar], np.array(0.))
     assert signaldict[scalar].__array_interface__['data'][0] == memloc
 
     memloc = signaldict[one_d].__array_interface__['data'][0]
     signaldict[one_d] = np.array([0.])
-    assert np.allclose(signaldict[one_d], np.array([0.]))
+    assert allclose(signaldict[one_d], np.array([0.]))
     assert signaldict[one_d].__array_interface__['data'][0] == memloc
 
     memloc = signaldict[two_d].__array_interface__['data'][0]
     signaldict[two_d] = np.array([[0.], [0.]])
-    assert np.allclose(signaldict[two_d], np.array([[0.], [0.]]))
+    assert allclose(signaldict[two_d], np.array([[0.], [0.]]))
     assert signaldict[two_d].__array_interface__['data'][0] == memloc
 
     # __str__ pretty-prints signals and current values
@@ -62,7 +62,7 @@ def test_signaldict():
         assert "%s %s" % (repr(k), repr(signaldict[k])) in str(signaldict)
 
 
-def test_signaldict_reset():
+def test_signaldict_reset(allclose):
     """Tests SignalDict's reset function."""
     signaldict = SignalDict()
     two_d = Signal([[1.], [1.]])
@@ -72,18 +72,18 @@ def test_signaldict_reset():
     signaldict.init(two_d_view)
 
     signaldict[two_d_view] = -0.5
-    assert np.allclose(signaldict[two_d], np.array([[-0.5], [1]]))
+    assert allclose(signaldict[two_d], np.array([[-0.5], [1]]))
 
     signaldict[two_d] = np.array([[-1], [-1]])
-    assert np.allclose(signaldict[two_d], np.array([[-1], [-1]]))
-    assert np.allclose(signaldict[two_d_view], np.array([-1]))
+    assert allclose(signaldict[two_d], np.array([[-1], [-1]]))
+    assert allclose(signaldict[two_d_view], np.array([-1]))
 
     signaldict.reset(two_d_view)
-    assert np.allclose(signaldict[two_d_view], np.array([1]))
-    assert np.allclose(signaldict[two_d], np.array([[1], [-1]]))
+    assert allclose(signaldict[two_d_view], np.array([1]))
+    assert allclose(signaldict[two_d], np.array([[1], [-1]]))
 
     signaldict.reset(two_d)
-    assert np.allclose(signaldict[two_d], np.array([[1], [1]]))
+    assert allclose(signaldict[two_d], np.array([[1], [1]]))
 
 
 def test_assert_named_signals():
@@ -97,12 +97,12 @@ def test_assert_named_signals():
     Signal.assert_named_signals = False
 
 
-def test_signal_values():
+def test_signal_values(allclose):
     """Make sure Signal.initial_value works."""
     two_d = Signal([[1.], [1.]])
-    assert np.allclose(two_d.initial_value, np.array([[1], [1]]))
+    assert allclose(two_d.initial_value, np.array([[1], [1]]))
     two_d_view = two_d[0, :]
-    assert np.allclose(two_d_view.initial_value, np.array([1]))
+    assert allclose(two_d_view.initial_value, np.array([1]))
 
     # cannot change signal value after creation
     with pytest.raises(SignalError):

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -1,9 +1,10 @@
+from fnmatch import fnmatch
 import hashlib
 import inspect
 import importlib
 import os
 import re
-from fnmatch import fnmatch
+import shlex
 import warnings
 
 import matplotlib
@@ -437,18 +438,19 @@ def pytest_runtest_setup(item):  # noqa: C901
     if not hasattr(item, 'obj'):
         return  # Occurs for doctests, possibly other weird tests
 
-    test_uses_sim = 'Simulator' in item.fixturenames
-    test_uses_refsim = 'RefSimulator' in item.fixturenames
-    tests_frontend = not (test_uses_sim or test_uses_refsim)
+    item_name = get_item_name(item)
 
-    if not tests_frontend:
-        item_name = get_item_name(item)
+    # join all the lines and then split (preserving quoted strings)
+    unsupported = shlex.split(
+        " ".join(item.config.getini("nengo_test_unsupported")))
+    # group pairs (representing test name/reason)
+    unsupported = [unsupported[i:i + 2] for i in range(0, len(unsupported), 2)]
 
-        for test, reason in TestConfig.Simulator.unsupported:
-            # We add a '*' before test to eliminate the surprise of needing
-            # a '*' before the name of a test function.
-            if fnmatch(item_name, '*' + test):
-                pytest.xfail(reason)
+    for test, reason in unsupported:
+        # We add a '*' before test to eliminate the surprise of needing
+        # a '*' before the name of a test function.
+        if fnmatch(item_name, "*" + test):
+            pytest.xfail(reason)
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -287,7 +287,8 @@ def allclose(request):
 
     If a test contains multiple ``allclose`` checks then multiple entries
     with the same testname can be added to the config, and will be applied
-    in the given order.
+    in the given order. If there are fewer config entries than tests, the
+    last entry will be applied to remaining tests with the same testname.
     """
 
     call_count = [0]  # need to access the closure this way for 2.7 compat

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -269,6 +269,57 @@ def seed(request):
     return function_seed(request.function, mod=TestConfig.test_seed)
 
 
+@pytest.fixture
+def allclose(request):
+    """A functional replacement for np.allclose.
+
+    This allows backends to specify different tolerances by adding
+
+    .. code-block:: ini
+
+        nengo_test_tolerances =
+            path/to/test/file:testname atol=x rtol=y
+            path/to/other/file:testname2 atol=z  # this is a comment
+            ...
+
+    to their pytest config file.
+
+    If a test contains multiple ``allclose`` checks then multiple entries
+    with the same testname can be added to the config, and will be applied
+    in the given order.
+    """
+
+    call_count = [0]  # need to access the closure this way for 2.7 compat
+    override = []
+    for line in request.config.getini("nengo_test_tolerances"):
+        split_line = line.split()
+        testname = "*" + split_line[0]
+        nodename = get_item_name(request.node)
+        if fnmatch(nodename, testname):
+            kwargs = {}
+            for entry in split_line[1:]:
+                if entry.startswith("#"):
+                    break
+                k, v = entry.split("=")
+                kwargs[k] = float(v)
+            override.append(kwargs)
+
+    def _allclose(a, b, **kwargs):
+        # set tolerances
+        if override:
+            kwargs.update(override[min(call_count[0], len(override) - 1)])
+            call_count[0] += 1
+
+        # record rmse
+        rmse = npext.rmse(a, b)
+        if not np.any(np.isnan(rmse)):
+            request.node.user_properties.append(("rmse", rmse))
+
+        return np.allclose(a, b, **kwargs)
+
+    return _allclose
+
+
 def pytest_generate_tests(metafunc):
     marks = [
         getattr(pytest.mark, m.name)(*m.args, **m.kwargs)

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -285,6 +285,10 @@ def allclose(request):
 
     to their pytest config file.
 
+    If the test is parametrized then ``testname[param0-param1]`` will match
+    specific parameter settings, and ``testname*`` will match all parameter
+    settings.
+
     If a test contains multiple ``allclose`` checks then multiple entries
     with the same testname can be added to the config, and will be applied
     in the given order. If there are fewer config entries than tests, the
@@ -297,6 +301,15 @@ def allclose(request):
         split_line = line.split()
         testname = "*" + split_line[0]
         nodename = get_item_name(request.node)
+
+        # escape special characters
+        escaped = "[]?"
+        testname = list(testname)
+        for i, c in enumerate(testname):
+            if c in escaped:
+                testname[i] = "[%s]" % c
+        testname = "".join(testname)
+
         if fnmatch(nodename, testname):
             kwargs = {}
             for entry in split_line[1:]:

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -311,11 +311,6 @@ def allclose(request):
             kwargs.update(override[min(call_count[0], len(override) - 1)])
             call_count[0] += 1
 
-        # record rmse
-        rmse = npext.rmse(a, b)
-        if not np.any(np.isnan(rmse)):
-            request.node.user_properties.append(("rmse", rmse))
-
         return np.allclose(a, b, **kwargs)
 
     return _allclose

--- a/nengo/networks/tests/test_circularconv.py
+++ b/nengo/networks/tests/test_circularconv.py
@@ -9,7 +9,7 @@ from nengo.utils.numpy import rmse
 
 @pytest.mark.parametrize('invert_a', [True, False])
 @pytest.mark.parametrize('invert_b', [True, False])
-def test_circularconv_transforms(invert_a, invert_b, rng):
+def test_circularconv_transforms(invert_a, invert_b, rng, allclose):
     """Test the circular convolution transforms"""
     dims = 100
     x = rng.randn(dims)
@@ -22,7 +22,7 @@ def test_circularconv_transforms(invert_a, invert_b, rng):
     XY = np.dot(tr_a, x) * np.dot(tr_b, y)
     z1 = np.dot(tr_out, XY)
 
-    assert np.allclose(z0, z1)
+    assert allclose(z0, z1)
 
 
 def test_input_magnitude(Simulator, seed, rng, dims=16, magnitude=10):
@@ -33,8 +33,8 @@ def test_input_magnitude(Simulator, seed, rng, dims=16, magnitude=10):
     """
     neurons_per_product = 128
 
-    a = rng.normal(scale=np.sqrt(1./dims), size=dims) * magnitude
-    b = rng.normal(scale=np.sqrt(1./dims), size=dims) * magnitude
+    a = rng.normal(scale=np.sqrt(1. / dims), size=dims) * magnitude
+    b = rng.normal(scale=np.sqrt(1. / dims), size=dims) * magnitude
     result = circconv(a, b)
 
     model = nengo.Network(label="circular conv", seed=seed)
@@ -66,8 +66,8 @@ def test_input_magnitude(Simulator, seed, rng, dims=16, magnitude=10):
 
 @pytest.mark.parametrize('dims', [4, 32])
 def test_neural_accuracy(Simulator, seed, rng, dims, neurons_per_product=128):
-    a = rng.normal(scale=np.sqrt(1./dims), size=dims)
-    b = rng.normal(scale=np.sqrt(1./dims), size=dims)
+    a = rng.normal(scale=np.sqrt(1. / dims), size=dims)
+    b = rng.normal(scale=np.sqrt(1. / dims), size=dims)
     result = circconv(a, b)
 
     model = nengo.Network(label="circular conv", seed=seed)

--- a/nengo/networks/tests/test_ensemblearray.py
+++ b/nengo/networks/tests/test_ensemblearray.py
@@ -7,7 +7,7 @@ from nengo.exceptions import ValidationError
 from nengo.utils.compat import range
 
 
-def test_multidim(Simulator, plt, seed, rng):
+def test_multidim(Simulator, plt, seed, rng, allclose):
     """Tests with multiple dimensions per ensemble"""
     dims = 3
     n_neurons = 60
@@ -65,9 +65,9 @@ def test_multidim(Simulator, plt, seed, rng):
     c_sim = sim.data[C_p][t > 0.2].mean(axis=0)
 
     rtol, atol = 0.1, 0.05
-    assert np.allclose(a, a_sim, atol=atol, rtol=rtol)
-    assert np.allclose(b, b_sim, atol=atol, rtol=rtol)
-    assert np.allclose(c, c_sim, atol=atol, rtol=rtol)
+    assert allclose(a, a_sim, atol=atol, rtol=rtol)
+    assert allclose(b, b_sim, atol=atol, rtol=rtol)
+    assert allclose(c, c_sim, atol=atol, rtol=rtol)
 
 
 def _mmul_transforms(A_shape, B_shape, C_dim):
@@ -90,9 +90,9 @@ def test_multifunc(Simulator, plt, seed, rng):
     n_neurons = 60
 
     inp = rng.uniform(low=-0.7, high=0.7, size=dims)
-    functions = [lambda x: [x*2],
-                 lambda x: [-x, -x*2],
-                 lambda x: [.5*x]]
+    functions = [lambda x: [x * 2],
+                 lambda x: [-x, -x * 2],
+                 lambda x: [.5 * x]]
     output = []
     for i in range(len(functions)):
         output.extend(functions[i](inp[i]))
@@ -129,7 +129,7 @@ def test_multifunc(Simulator, plt, seed, rng):
     plot(sim, output, ea_funcs_p, title="B")
 
 
-def test_matrix_mul(Simulator, plt, seed):
+def test_matrix_mul(Simulator, plt, seed, allclose):
     N = 100
 
     Amat = np.asarray([[0.5, -0.5]])
@@ -185,15 +185,15 @@ def test_matrix_mul(Simulator, plt, seed):
 
     tols = dict(atol=0.1, rtol=0.01)
     for i in range(Amat.size):
-        assert np.allclose(sim.data[A_p][tmask, i], Amat.flat[i], **tols)
+        assert allclose(sim.data[A_p][tmask, i], Amat.flat[i], **tols)
     for i in range(Bmat.size):
-        assert np.allclose(sim.data[B_p][tmask, i], Bmat.flat[i], **tols)
+        assert allclose(sim.data[B_p][tmask, i], Bmat.flat[i], **tols)
 
     Dmat = np.dot(Amat, Bmat)
     for i in range(Amat.shape[0]):
         for k in range(Bmat.shape[1]):
             data_ik = sim.data[D_p][tmask, i * Bmat.shape[1] + k]
-            assert np.allclose(data_ik, Dmat[i, k], **tols)
+            assert allclose(data_ik, Dmat[i, k], **tols)
 
 
 def test_arguments():
@@ -240,7 +240,7 @@ def test_neuronoutput(Simulator, seed):
     assert np.all(sim.data[p] < 1e-2)
 
 
-def test_ndarrays(Simulator, rng):
+def test_ndarrays(Simulator, rng, allclose):
     encoders = UniformHypersphere(surface=True).sample(10, 1, rng=rng)
     max_rates = rng.uniform(200, 400, size=10)
     intercepts = rng.uniform(-1, 1, size=10)
@@ -257,10 +257,10 @@ def test_ndarrays(Simulator, rng):
     with Simulator(net) as sim:
         pass
     built = sim.data[ea.ea_ensembles[0]]
-    assert np.allclose(built.encoders, encoders)
-    assert np.allclose(built.max_rates, max_rates)
-    assert np.allclose(built.intercepts, intercepts)
-    assert np.allclose(built.eval_points, eval_points)
+    assert allclose(built.encoders, encoders)
+    assert allclose(built.max_rates, max_rates)
+    assert allclose(built.intercepts, intercepts)
+    assert allclose(built.eval_points, eval_points)
     assert built.eval_points.shape == eval_points.shape
 
     with nengo.Network() as net:

--- a/nengo/spa/tests/test_basalganglia.py
+++ b/nengo/spa/tests/test_basalganglia.py
@@ -1,11 +1,10 @@
-import numpy as np
 import pytest
 
 import nengo
 from nengo import spa
 
 
-def test_basal_ganglia(Simulator, seed, plt):
+def test_basal_ganglia(Simulator, seed, plt, allclose):
     model = spa.SPA(seed=seed)
 
     with model:
@@ -64,9 +63,9 @@ def test_basal_ganglia(Simulator, seed, plt):
     assert sim.data[p][t == 0.3, 2] > 0.6
 
     # Motor B should be the same as Motor D
-    assert np.allclose(sim.data[p][:, 1], sim.data[p][:, 3])
+    assert allclose(sim.data[p][:, 1], sim.data[p][:, 3])
     # Motor A should be the same as Motor E
-    assert np.allclose(sim.data[p][:, 0], sim.data[p][:, 4])
+    assert allclose(sim.data[p][:, 0], sim.data[p][:, 4])
 
 
 def test_errors():

--- a/nengo/spa/tests/test_cortical.py
+++ b/nengo/spa/tests/test_cortical.py
@@ -116,7 +116,7 @@ def test_direct(Simulator, seed):
     assert match2[199] > 0.75
 
 
-def test_convolution(Simulator, plt, seed):
+def test_convolution(Simulator, plt, seed, allclose):
     D = 5
     with spa.SPA(seed=seed) as model:
         model.inA = spa.Buffer(dimensions=D)
@@ -131,7 +131,7 @@ def test_convolution(Simulator, plt, seed):
             'outABinv = inA * ~inB',
             'outAinvB = ~inA * inB',
             'outAinvBinv = ~inA * ~inB',
-            ))
+        ))
         nengo.Connection(nengo.Node([0, 1, 0, 0, 0]), model.inA.state.input)
         nengo.Connection(nengo.Node([0, 0, 1, 0, 0]), model.inB.state.input)
 
@@ -172,17 +172,17 @@ def test_convolution(Simulator, plt, seed):
     #  is X rotated to the right once)
 
     # Ideal answer: A*B = [0,0,0,1,0]
-    assert np.allclose(np.mean(sim.data[pAB][-10:], axis=0),
-                       np.array([0, 0, 0, 1, 0]), atol=0.15)
+    assert allclose(np.mean(sim.data[pAB][-10:], axis=0),
+                    np.array([0, 0, 0, 1, 0]), atol=0.15)
 
     # Ideal answer: A*~B = [0,0,0,0,1]
-    assert np.allclose(np.mean(sim.data[pABinv][-10:], axis=0),
-                       np.array([0, 0, 0, 0, 1]), atol=0.15)
+    assert allclose(np.mean(sim.data[pABinv][-10:], axis=0),
+                    np.array([0, 0, 0, 0, 1]), atol=0.15)
 
     # Ideal answer: ~A*B = [0,1,0,0,0]
-    assert np.allclose(np.mean(sim.data[pAinvB][-10:], axis=0),
-                       np.array([0, 1, 0, 0, 0]), atol=0.15)
+    assert allclose(np.mean(sim.data[pAinvB][-10:], axis=0),
+                    np.array([0, 1, 0, 0, 0]), atol=0.15)
 
     # Ideal answer: ~A*~B = [0,0,1,0,0]
-    assert np.allclose(np.mean(sim.data[pAinvBinv][-10:], axis=0),
-                       np.array([0, 0, 1, 0, 0]), atol=0.15)
+    assert allclose(np.mean(sim.data[pAinvBinv][-10:], axis=0),
+                    np.array([0, 0, 1, 0, 0]), atol=0.15)

--- a/nengo/spa/tests/test_input.py
+++ b/nengo/spa/tests/test_input.py
@@ -3,7 +3,7 @@ import numpy as np
 from nengo import spa
 
 
-def test_fixed():
+def test_fixed(allclose):
     with spa.SPA() as model:
         model.buffer1 = spa.Buffer(dimensions=16)
         model.buffer2 = spa.Buffer(dimensions=8, subdimensions=2)
@@ -12,13 +12,13 @@ def test_fixed():
     input1, vocab1 = model.get_module_input('buffer1')
     input2, vocab2 = model.get_module_input('buffer2')
 
-    assert np.allclose(model.input.input_nodes['buffer1'].output,
-                       vocab1.parse('A').v)
-    assert np.allclose(model.input.input_nodes['buffer2'].output,
-                       vocab2.parse('B').v)
+    assert allclose(model.input.input_nodes['buffer1'].output,
+                    vocab1.parse('A').v)
+    assert allclose(model.input.input_nodes['buffer2'].output,
+                    vocab2.parse('B').v)
 
 
-def test_time_varying():
+def test_time_varying(allclose):
     with spa.SPA() as model:
         model.buffer = spa.Buffer(dimensions=16)
         model.buffer2 = spa.Buffer(dimensions=16)
@@ -35,15 +35,15 @@ def test_time_varying():
 
     input, vocab = model.get_module_input('buffer')
 
-    assert np.allclose(model.input.input_nodes['buffer'].output(t=0),
-                       vocab.parse('A').v)
-    assert np.allclose(model.input.input_nodes['buffer'].output(t=0.1),
-                       vocab.parse('B').v)
-    assert np.allclose(model.input.input_nodes['buffer'].output(t=0.2),
-                       np.zeros(16))
+    assert allclose(model.input.input_nodes['buffer'].output(t=0),
+                    vocab.parse('A').v)
+    assert allclose(model.input.input_nodes['buffer'].output(t=0.1),
+                    vocab.parse('B').v)
+    assert allclose(model.input.input_nodes['buffer'].output(t=0.2),
+                    np.zeros(16))
 
 
-def test_predefined_vocabs():
+def test_predefined_vocabs(allclose):
     D = 64
 
     with spa.SPA() as model:
@@ -74,13 +74,13 @@ def test_predefined_vocabs():
     b2 = model.input.input_nodes['buffer2'].output(t=0.1)
     c2 = model.input.input_nodes['buffer2'].output(t=0.2)
 
-    assert np.allclose(a1, model.vocab1.parse('A').v)
-    assert np.allclose(b1, model.vocab1.parse('B').v)
-    assert np.allclose(c1, model.vocab1.parse('C').v)
+    assert allclose(a1, model.vocab1.parse('A').v)
+    assert allclose(b1, model.vocab1.parse('B').v)
+    assert allclose(c1, model.vocab1.parse('C').v)
 
-    assert np.allclose(a2, model.vocab2.parse('A').v)
-    assert np.allclose(b2, model.vocab2.parse('B').v)
-    assert np.allclose(c2, model.vocab2.parse('C').v)
+    assert allclose(a2, model.vocab2.parse('A').v)
+    assert allclose(b2, model.vocab2.parse('B').v)
+    assert allclose(c2, model.vocab2.parse('C').v)
 
     assert np.dot(a1, a2) < 0.95
     assert np.dot(b1, b2) < 0.95

--- a/nengo/spa/tests/test_pointer.py
+++ b/nengo/spa/tests/test_pointer.py
@@ -5,7 +5,7 @@ from nengo.spa.pointer import SemanticPointer
 from nengo.utils.compat import range
 
 
-def test_init():
+def test_init(allclose):
     a = SemanticPointer([1, 2, 3, 4])
     assert len(a) == 4
 
@@ -17,7 +17,7 @@ def test_init():
 
     a = SemanticPointer(27)
     assert len(a) == 27
-    assert np.allclose(a.length(), 1)
+    assert allclose(a.length(), 1)
 
     with pytest.raises(Exception):
         a = SemanticPointer(np.zeros(2, 2))
@@ -34,17 +34,17 @@ def test_init():
         a = SemanticPointer(int)
 
 
-def test_length():
+def test_length(allclose):
     a = SemanticPointer([1, 1])
-    assert np.allclose(a.length(), np.sqrt(2))
-    a = SemanticPointer(10)*1.2
-    assert np.allclose(a.length(), 1.2)
+    assert allclose(a.length(), np.sqrt(2))
+    a = SemanticPointer(10) * 1.2
+    assert allclose(a.length(), 1.2)
 
 
-def test_normalize():
+def test_normalize(allclose):
     a = SemanticPointer([1, 1])
     a.normalize()
-    assert np.allclose(a.length(), 1)
+    assert allclose(a.length(), 1)
 
 
 def test_str():
@@ -52,33 +52,33 @@ def test_str():
     assert str(a) == str(np.array([1., 1.]))
 
 
-def test_randomize(rng):
+def test_randomize(rng, allclose):
     a = SemanticPointer(100, rng=rng)
     std = np.std(a.v)
-    assert np.allclose(std, 1.0 / np.sqrt(len(a)), rtol=0.02)
+    assert allclose(std, 1.0 / np.sqrt(len(a)), rtol=0.02)
 
     a = SemanticPointer(100)
     a.randomize(rng=rng)
     assert len(a) == 100
     std = np.std(a.v)
-    assert np.allclose(std, 1.0 / np.sqrt(len(a)), rtol=0.02)
+    assert allclose(std, 1.0 / np.sqrt(len(a)), rtol=0.02)
 
     a = SemanticPointer(5)
     a.randomize(N=100, rng=rng)
     assert len(a) == 100
     std = np.std(a.v)
-    assert np.allclose(std, 1.0 / np.sqrt(len(a)), rtol=0.02)
+    assert allclose(std, 1.0 / np.sqrt(len(a)), rtol=0.02)
 
 
-def test_make_unitary(rng):
+def test_make_unitary(rng, allclose):
     a = SemanticPointer(100, rng=rng)
     a.make_unitary()
-    assert np.allclose(1, a.length())
-    assert np.allclose(1, (a * a).length())
-    assert np.allclose(1, (a * a * a).length())
+    assert allclose(1, a.length())
+    assert allclose(1, (a * a).length())
+    assert allclose(1, (a * a * a).length())
 
 
-def test_add_sub():
+def test_add_sub(allclose):
     a = SemanticPointer(10)
     b = SemanticPointer(10)
     c = a.copy()
@@ -87,13 +87,13 @@ def test_add_sub():
     c += b
     d -= -a
 
-    assert np.allclose((a + b).v, a.v + b.v)
-    assert np.allclose((a + b).v, c.v)
-    assert np.allclose((a + b).v, d.v)
-    assert np.allclose((a + b).v, (a - (-b)).v)
+    assert allclose((a + b).v, a.v + b.v)
+    assert allclose((a + b).v, c.v)
+    assert allclose((a + b).v, d.v)
+    assert allclose((a + b).v, (a - (-b)).v)
 
 
-def test_convolution(rng):
+def test_convolution(rng, allclose):
     a = SemanticPointer(64, rng=rng)
     b = SemanticPointer(64, rng=rng)
     identity = SemanticPointer(np.eye(64)[0])
@@ -103,22 +103,22 @@ def test_convolution(rng):
 
     answer = np.fft.ifft(np.fft.fft(a.v) * np.fft.fft(b.v)).real
 
-    assert np.allclose((a * b).v, answer)
-    assert np.allclose(a.convolve(b).v, answer)
-    assert np.allclose(c.v, answer)
-    assert np.allclose((a * identity).v, a.v)
+    assert allclose((a * b).v, answer)
+    assert allclose(a.convolve(b).v, answer)
+    assert allclose(c.v, answer)
+    assert allclose((a * identity).v, a.v)
     assert (a * b * ~b).compare(a) > 0.65
 
 
-def test_multiply():
+def test_multiply(allclose):
     a = SemanticPointer(50)
 
-    assert np.allclose((a * 5).v, a.v * 5)
-    assert np.allclose((5 * a).v, a.v * 5)
-    assert np.allclose((a * 5.7).v, a.v * 5.7)
-    assert np.allclose((5.7 * a).v, a.v * 5.7)
-    assert np.allclose((0 * a).v, np.zeros(50))
-    assert np.allclose((1 * a).v, a.v)
+    assert allclose((a * 5).v, a.v * 5)
+    assert allclose((5 * a).v, a.v * 5)
+    assert allclose((a * 5.7).v, a.v * 5.7)
+    assert allclose((5.7 * a).v, a.v * 5.7)
+    assert allclose((0 * a).v, np.zeros(50))
+    assert allclose((1 * a).v, a.v)
 
     with pytest.raises(Exception):
         a * None
@@ -126,19 +126,19 @@ def test_multiply():
         a * 'string'
 
 
-def test_compare(rng):
+def test_compare(rng, allclose):
     a = SemanticPointer(50, rng=rng) * 10
     b = SemanticPointer(50, rng=rng) * 0.1
 
     assert a.compare(a) > 0.99
     assert a.compare(b) < 0.2
-    assert np.allclose(a.compare(b), a.dot(b) / (a.length() * b.length()))
+    assert allclose(a.compare(b), a.dot(b) / (a.length() * b.length()))
 
 
-def test_dot(rng):
+def test_dot(rng, allclose):
     a = SemanticPointer(50, rng=rng) * 1.1
     b = SemanticPointer(50, rng=rng) * (-1.5)
-    assert np.allclose(a.dot(b), np.dot(a.v, b.v))
+    assert allclose(a.dot(b), np.dot(a.v, b.v))
 
 
 def test_distance(rng):
@@ -148,11 +148,11 @@ def test_distance(rng):
     assert a.distance(b) > 0.9
 
 
-def test_invert():
+def test_invert(allclose):
     a = SemanticPointer(50)
     assert a.v[0] == (~a).v[0]
     assert a.v[49] == (~a).v[1]
-    assert np.allclose(a.v[1:], (~a).v[:0:-1])
+    assert allclose(a.v[1:], (~a).v[:0:-1])
 
 
 def test_len():
@@ -163,25 +163,25 @@ def test_len():
     assert len(a) == 10
 
 
-def test_copy():
+def test_copy(allclose):
     a = SemanticPointer(5)
     b = a.copy()
     assert a is not b
     assert a.v is not b.v
-    assert np.allclose(a.v, b.v)
+    assert allclose(a.v, b.v)
 
 
-def test_mse():
+def test_mse(allclose):
     a = SemanticPointer(50)
     b = SemanticPointer(50)
 
-    assert np.allclose(((a - b).length() ** 2) / 50, a.mse(b))
+    assert allclose(((a - b).length() ** 2) / 50, a.mse(b))
 
 
-def test_conv_matrix():
+def test_conv_matrix(allclose):
     a = SemanticPointer(50)
     b = SemanticPointer(50)
 
     m = b.get_convolution_matrix()
 
-    assert np.allclose((a*b).v, np.dot(m, a.v))
+    assert allclose((a * b).v, np.dot(m, a.v))

--- a/nengo/spa/tests/test_vocabulary.py
+++ b/nengo/spa/tests/test_vocabulary.py
@@ -7,12 +7,12 @@ from nengo.exceptions import SpaParseError, ValidationError
 from nengo.spa import Vocabulary
 
 
-def test_add(rng):
+def test_add(rng, allclose):
     v = Vocabulary(3, rng=rng)
     v.add('A', [1, 2, 3])
     v.add('B', [4, 5, 6])
     v.add('C', [7, 8, 9])
-    assert np.allclose(v.vectors, [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert allclose(v.vectors, [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
 
 def test_include_pairs(rng):
@@ -36,19 +36,19 @@ def test_include_pairs(rng):
     assert v.key_pairs == ['A*B', 'A*C', 'B*C']
 
 
-def test_parse(rng):
+def test_parse(rng, allclose):
     v = Vocabulary(64, rng=rng)
     A = v.parse('A')
     B = v.parse('B')
     C = v.parse('C')
-    assert np.allclose((A * B).v, v.parse('A * B').v)
-    assert np.allclose((A * ~B).v, v.parse('A * ~B').v)
-    assert np.allclose((A + B).v, v.parse('A + B').v)
-    assert np.allclose((A - (B*C)*3 + ~C).v, v.parse('A-(B*C)*3+~C').v)
+    assert allclose((A * B).v, v.parse('A * B').v)
+    assert allclose((A * ~B).v, v.parse('A * ~B').v)
+    assert allclose((A + B).v, v.parse('A + B').v)
+    assert allclose((A - (B * C) * 3 + ~C).v, v.parse('A-(B*C)*3+~C').v)
 
-    assert np.allclose(v.parse('0').v, np.zeros(64))
-    assert np.allclose(v.parse('1').v, np.eye(64)[0])
-    assert np.allclose(v.parse('1.7').v, np.eye(64)[0] * 1.7)
+    assert allclose(v.parse('0').v, np.zeros(64))
+    assert allclose(v.parse('1').v, np.eye(64)[0])
+    assert allclose(v.parse('1.7').v, np.eye(64)[0] * 1.7)
 
     with pytest.raises(SyntaxError):
         v.parse('A((')
@@ -65,9 +65,9 @@ def test_invalid_dimensions():
         Vocabulary(-1)
 
 
-def test_identity(rng):
+def test_identity(rng, allclose):
     v = Vocabulary(64, rng=rng)
-    assert np.allclose(v.identity.v, np.eye(64)[0])
+    assert allclose(v.identity.v, np.eye(64)[0])
 
 
 def test_text(rng):
@@ -89,7 +89,7 @@ def test_text(rng):
     assert v.text(x, join=',') == v.text(x).replace(';', ',')
     assert re.match(';'.join([ptr] * 2), v.text(x, normalize=True))
 
-    assert v.text([0]*64) == '0.00F'
+    assert v.text([0] * 64) == '0.00F'
     assert v.text(v['D'].v) == '1.00D'
 
 
@@ -220,7 +220,7 @@ def test_subset(rng):
     assert v2.parse('A').compare(np.dot(t, v1.parse('A').v)) >= 0.99999999
 
 
-def test_extend(rng):
+def test_extend(rng, allclose):
     v = Vocabulary(16, rng=rng)
     v.parse('A+B')
     assert v.keys == ['A', 'B']
@@ -240,7 +240,7 @@ def test_extend(rng):
     fft_imag = fft_val.imag
     fft_real = fft_val.real
     fft_norms = np.sqrt(fft_imag ** 2 + fft_real ** 2)
-    assert np.allclose(fft_norms, np.ones(16))
+    assert allclose(fft_norms, np.ones(16))
 
     v.extend(['G', 'H'], unitary=True)
     assert v.keys == ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']

--- a/nengo/tests/options.py
+++ b/nengo/tests/options.py
@@ -24,3 +24,10 @@ def pytest_addoption(parser):
         help='Also run slow tests.')
     parser.addoption('--seed-offset', nargs=1, type=int, default=0,
                      help="Specify offset of the seed values used in tests.")
+
+    parser.addini("nengo_test_tolerances", type="linelist",
+                  help="List of 'testname atol=x rtol=y' to override "
+                       "tolerances on a test-by-test basis; if there are"
+                       "multiple calls to 'allclose' within a single test,"
+                       "repeated items with the same testname will be applied"
+                       "in sequence")

--- a/nengo/tests/options.py
+++ b/nengo/tests/options.py
@@ -31,3 +31,6 @@ def pytest_addoption(parser):
                        "multiple calls to 'allclose' within a single test,"
                        "repeated items with the same testname will be applied"
                        "in sequence")
+    parser.addini("nengo_test_unsupported", type="linelist",
+                  help="List of unsupported unit tests with reason for "
+                       "exclusion")

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -9,7 +9,7 @@ from nengo.exceptions import ObsoleteError, SignalError
 from nengo.utils.compat import itervalues, range
 
 
-def test_seeding(RefSimulator, logger):
+def test_seeding(RefSimulator, logger, allclose):
     """Test that setting the model seed fixes everything"""
 
     #  TODO: this really just checks random parameters in ensembles.
@@ -35,7 +35,7 @@ def test_seeding(RefSimulator, logger):
 
     def compare_objs(obj1, obj2, attrs, equal=True):
         for attr in attrs:
-            check = (np.allclose(getattr(obj1, attr), getattr(obj2, attr)) ==
+            check = (allclose(getattr(obj1, attr), getattr(obj2, attr)) ==
                      equal)
             if not check:
                 logger.info("%s: %s", attr, getattr(obj1, attr))
@@ -110,12 +110,12 @@ def test_signal():
     Signal.assert_named_signals = False
 
 
-def test_signal_values():
+def test_signal_values(allclose):
     """Make sure Signal.initial_value works."""
     two_d = Signal([[1.], [1.]])
-    assert np.allclose(two_d.initial_value, np.array([[1], [1]]))
+    assert allclose(two_d.initial_value, np.array([[1], [1]]))
     two_d_view = two_d[0, :]
-    assert np.allclose(two_d_view.initial_value, np.array([1]))
+    assert allclose(two_d_view.initial_value, np.array([1]))
 
     # cannot change signal value after creation
     with pytest.raises(SignalError):
@@ -124,7 +124,7 @@ def test_signal_values():
         two_d.initial_value[...] = np.array([[0.5], [-0.5]])
 
 
-def test_signaldict():
+def test_signaldict(allclose):
     """Tests SignalDict's dict overrides."""
     signaldict = SignalDict()
 
@@ -137,39 +137,39 @@ def test_signaldict():
         signaldict[scalar] = np.array(1.)
 
     signaldict.init(scalar)
-    assert np.allclose(signaldict[scalar], np.array(1.))
+    assert allclose(signaldict[scalar], np.array(1.))
     # __getitem__ handles scalars
     assert signaldict[scalar].shape == ()
 
     one_d = Signal([1.])
     signaldict.init(one_d)
-    assert np.allclose(signaldict[one_d], np.array([1.]))
+    assert allclose(signaldict[one_d], np.array([1.]))
     assert signaldict[one_d].shape == (1,)
 
     two_d = Signal([[1.], [1.]])
     signaldict.init(two_d)
-    assert np.allclose(signaldict[two_d], np.array([[1.], [1.]]))
+    assert allclose(signaldict[two_d], np.array([[1.], [1.]]))
     assert signaldict[two_d].shape == (2, 1)
 
     # __getitem__ handles views implicitly (note no .init)
     two_d_view = two_d[0, :]
-    assert np.allclose(signaldict[two_d_view], np.array([1.]))
+    assert allclose(signaldict[two_d_view], np.array([1.]))
     assert signaldict[two_d_view].shape == (1,)
 
     # __setitem__ ensures memory location stays the same
     memloc = signaldict[scalar].__array_interface__['data'][0]
     signaldict[scalar] = np.array(0.)
-    assert np.allclose(signaldict[scalar], np.array(0.))
+    assert allclose(signaldict[scalar], np.array(0.))
     assert signaldict[scalar].__array_interface__['data'][0] == memloc
 
     memloc = signaldict[one_d].__array_interface__['data'][0]
     signaldict[one_d] = np.array([0.])
-    assert np.allclose(signaldict[one_d], np.array([0.]))
+    assert allclose(signaldict[one_d], np.array([0.]))
     assert signaldict[one_d].__array_interface__['data'][0] == memloc
 
     memloc = signaldict[two_d].__array_interface__['data'][0]
     signaldict[two_d] = np.array([[0.], [0.]])
-    assert np.allclose(signaldict[two_d], np.array([[0.], [0.]]))
+    assert allclose(signaldict[two_d], np.array([[0.], [0.]]))
     assert signaldict[two_d].__array_interface__['data'][0] == memloc
 
     # __str__ pretty-prints signals and current values
@@ -178,7 +178,7 @@ def test_signaldict():
         assert "%s %s" % (repr(k), repr(signaldict[k])) in str(signaldict)
 
 
-def test_signaldict_reset():
+def test_signaldict_reset(allclose):
     """Tests SignalDict's reset function."""
     signaldict = SignalDict()
     two_d = Signal([[1.], [1.]])
@@ -188,18 +188,18 @@ def test_signaldict_reset():
     signaldict.init(two_d_view)
 
     signaldict[two_d_view] = -0.5
-    assert np.allclose(signaldict[two_d], np.array([[-0.5], [1]]))
+    assert allclose(signaldict[two_d], np.array([[-0.5], [1]]))
 
     signaldict[two_d] = np.array([[-1], [-1]])
-    assert np.allclose(signaldict[two_d], np.array([[-1], [-1]]))
-    assert np.allclose(signaldict[two_d_view], np.array([-1]))
+    assert allclose(signaldict[two_d], np.array([[-1], [-1]]))
+    assert allclose(signaldict[two_d_view], np.array([-1]))
 
     signaldict.reset(two_d_view)
-    assert np.allclose(signaldict[two_d_view], np.array([1]))
-    assert np.allclose(signaldict[two_d], np.array([[1], [-1]]))
+    assert allclose(signaldict[two_d_view], np.array([1]))
+    assert allclose(signaldict[two_d], np.array([[1], [-1]]))
 
     signaldict.reset(two_d)
-    assert np.allclose(signaldict[two_d], np.array([[1], [1]]))
+    assert allclose(signaldict[two_d], np.array([[1], [1]]))
 
 
 def test_signal_reshape():

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -10,7 +10,7 @@ from nengo.dists import UniformHypersphere
 from nengo.exceptions import BuildError, ObsoleteError, ValidationError
 from nengo.solvers import LstsqL2
 from nengo.processes import Piecewise
-from nengo.utils.testing import allclose
+from nengo.utils.testing import signals_allclose
 
 
 def test_args(nl, seed, rng):
@@ -102,7 +102,8 @@ def test_node_to_ensemble(Simulator, nl_nodirect, plt, seed, allclose):
     m = nengo.Network(seed=seed)
     with m:
         m.config[nengo.Ensemble].neuron_type = nl_nodirect()
-        input_node = nengo.Node(output=lambda t: [np.sin(t*3), np.cos(t*3)])
+        input_node = nengo.Node(
+            output=lambda t: [np.sin(t * 3), np.cos(t * 3)])
         a = nengo.Ensemble(N * 1, dimensions=1)
         b = nengo.Ensemble(N * 1, dimensions=1)
         c = nengo.Ensemble(N * 2, dimensions=2)
@@ -110,9 +111,10 @@ def test_node_to_ensemble(Simulator, nl_nodirect, plt, seed, allclose):
 
         nengo.Connection(input_node, a, function=lambda x: -x[0])
         nengo.Connection(input_node[:1], b, function=lambda x: -x)
-        nengo.Connection(input_node, c, function=lambda x: -(x**2))
+        nengo.Connection(input_node, c, function=lambda x: -(x ** 2))
         nengo.Connection(input_node, d,
-                         function=lambda x: [-x[0], -(x[0]**2), -(x[1]**2)])
+                         function=lambda x: [-x[0], -(x[0] ** 2),
+                                             -(x[1] ** 2)])
 
         a_p = nengo.Probe(a, 'decoded_output', synapse=0.01)
         b_p = nengo.Probe(b, 'decoded_output', synapse=0.01)
@@ -332,7 +334,7 @@ def test_weights(Simulator, nl, plt, seed):
     x = np.array(func(t)).T
     y = np.dot(x, transform.T)
     z = nengo.Lowpass(0.005).filtfilt(sim.data[bp], dt=sim.dt)
-    assert allclose(t, y, z, atol=0.1, buf=0.1, delay=0.01, plt=plt)
+    assert signals_allclose(t, y, z, atol=0.1, buf=0.1, delay=0.01, plt=plt)
 
 
 def test_vector(Simulator, nl, plt, seed, allclose):
@@ -955,8 +957,9 @@ def test_function_points(Simulator, seed, rng, plt):
     with Simulator(model, seed=seed) as sim:
         sim.run(1.0)
 
-    assert allclose(sim.trange(), -sim.data[up], sim.data[vp],
-                    buf=0.01, delay=0.005, atol=5e-2, rtol=3e-2, plt=plt)
+    assert signals_allclose(
+        sim.trange(), -sim.data[up], sim.data[vp], buf=0.01, delay=0.005,
+        atol=5e-2, rtol=3e-2, plt=plt)
 
 
 def test_connectionfunctionparam_array(RefSimulator, seed):

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -29,7 +29,7 @@ def test_args(nl, seed, rng):
             transform=rng.normal(size=(d2, d1)))
 
 
-def test_node_to_neurons(Simulator, nl_nodirect, plt, seed):
+def test_node_to_neurons(Simulator, nl_nodirect, plt, seed, allclose):
     N = 30
 
     m = nengo.Network(seed=seed)
@@ -57,10 +57,10 @@ def test_node_to_neurons(Simulator, nl_nodirect, plt, seed):
     plt.plot(t, ideal, label='Ideal output')
     plt.legend(loc='best', fontsize='small')
 
-    assert np.allclose(sim.data[a_p][-10:], 0, atol=.1, rtol=.01)
+    assert allclose(sim.data[a_p][-10:], 0, atol=.1, rtol=.01)
 
 
-def test_ensemble_to_neurons(Simulator, nl_nodirect, plt, seed):
+def test_ensemble_to_neurons(Simulator, nl_nodirect, plt, seed, allclose):
     N = 30
 
     m = nengo.Network(seed=seed)
@@ -92,11 +92,11 @@ def test_ensemble_to_neurons(Simulator, nl_nodirect, plt, seed):
     plt.plot(t, ideal, label='Ideal output')
     plt.legend(loc=0, prop={'size': 10})
 
-    assert np.allclose(sim.data[a_p][-10:], 0, atol=.1, rtol=.01)
-    assert np.allclose(sim.data[b_p][-10:], 1, atol=.1, rtol=.01)
+    assert allclose(sim.data[a_p][-10:], 0, atol=.1, rtol=.01)
+    assert allclose(sim.data[b_p][-10:], 1, atol=.1, rtol=.01)
 
 
-def test_node_to_ensemble(Simulator, nl_nodirect, plt, seed):
+def test_node_to_ensemble(Simulator, nl_nodirect, plt, seed, allclose):
     N = 50
 
     m = nengo.Network(seed=seed)
@@ -130,12 +130,12 @@ def test_node_to_ensemble(Simulator, nl_nodirect, plt, seed):
     plt.legend(['-sin', '-sin', '-(sin ** 2)', '-(cos ** 2)', '-sin',
                 '-(sin ** 2)', '-(cos ** 2)'], loc='best', fontsize='small')
 
-    assert np.allclose(sim.data[a_p][-10:], sim.data[d_p][-10:][:, 0],
-                       atol=0.1, rtol=0.01)
-    assert np.allclose(sim.data[b_p][-10:], sim.data[d_p][-10:][:, 0],
-                       atol=0.1, rtol=0.01)
-    assert np.allclose(sim.data[c_p][-10:], sim.data[d_p][-10:][:, 1:3],
-                       atol=0.1, rtol=0.01)
+    assert allclose(sim.data[a_p][-10:], sim.data[d_p][-10:][:, 0],
+                    atol=0.1, rtol=0.01)
+    assert allclose(sim.data[b_p][-10:], sim.data[d_p][-10:][:, 0],
+                    atol=0.1, rtol=0.01)
+    assert allclose(sim.data[c_p][-10:], sim.data[d_p][-10:][:, 1:3],
+                    atol=0.1, rtol=0.01)
 
 
 def test_neurons_to_ensemble(Simulator, nl_nodirect, plt, seed):
@@ -146,8 +146,8 @@ def test_neurons_to_ensemble(Simulator, nl_nodirect, plt, seed):
         m.config[nengo.Ensemble].neuron_type = nl_nodirect()
         a = nengo.Ensemble(N * 2, dimensions=2)
         b = nengo.Ensemble(N, dimensions=1)
-        c = nengo.Ensemble(N, dimensions=N*2)
-        nengo.Connection(a.neurons, b, transform=-5 * np.ones((1, N*2)))
+        c = nengo.Ensemble(N, dimensions=N * 2)
+        nengo.Connection(a.neurons, b, transform=-5 * np.ones((1, N * 2)))
         nengo.Connection(a.neurons, c)
 
         b_p = nengo.Probe(b, 'decoded_output', synapse=0.01)
@@ -166,7 +166,7 @@ def test_neurons_to_ensemble(Simulator, nl_nodirect, plt, seed):
     assert np.all(sim.data[b_p][-10:] < 0)
 
 
-def test_neurons_to_node(Simulator, nl_nodirect, plt, seed):
+def test_neurons_to_node(Simulator, nl_nodirect, plt, seed, allclose):
     N = 5
 
     m = nengo.Network(seed=seed)
@@ -194,10 +194,10 @@ def test_neurons_to_node(Simulator, nl_nodirect, plt, seed):
     plt.plot(t, sim.data[out_p])
     plt.xlim(right=t[-1])
 
-    assert np.allclose(sim.data[a_spikes], sim.data[out_p])
+    assert allclose(sim.data[a_spikes], sim.data[out_p])
 
 
-def test_neurons_to_neurons(Simulator, nl_nodirect, plt, seed):
+def test_neurons_to_neurons(Simulator, nl_nodirect, plt, seed, allclose):
     N1, N2 = 30, 50
 
     m = nengo.Network(seed=seed)
@@ -225,11 +225,11 @@ def test_neurons_to_neurons(Simulator, nl_nodirect, plt, seed):
     plt.xlim(right=t[-1])
     plt.legend(loc='best')
 
-    assert np.allclose(sim.data[a_p][-10:], 1, atol=.1, rtol=.01)
-    assert np.allclose(sim.data[b_p][-10:], 0, atol=.1, rtol=.01)
+    assert allclose(sim.data[a_p][-10:], 1, atol=.1, rtol=.01)
+    assert allclose(sim.data[b_p][-10:], 0, atol=.1, rtol=.01)
 
 
-def test_function_and_transform(Simulator, plt, seed):
+def test_function_and_transform(Simulator, plt, seed, allclose):
     """Test using both a function and a transform"""
 
     model = nengo.Network(seed=seed)
@@ -244,7 +244,7 @@ def test_function_and_transform(Simulator, plt, seed):
 
     with Simulator(model) as sim:
         sim.run(0.8)
-    x0, x1 = np.dot(sim.data[ap]**2, [[1., -1]]).T
+    x0, x1 = np.dot(sim.data[ap] ** 2, [[1., -1]]).T
     y0, y1 = sim.data[bp].T
 
     t = sim.trange()
@@ -255,11 +255,11 @@ def test_function_and_transform(Simulator, plt, seed):
     plt.legend(loc=0, prop={'size': 10})
     plt.xlim(right=t[-1])
 
-    assert np.allclose(x0, y0, atol=.1, rtol=.01)
-    assert np.allclose(x1, y1, atol=.1, rtol=.01)
+    assert allclose(x0, y0, atol=.1, rtol=.01)
+    assert allclose(x1, y1, atol=.1, rtol=.01)
 
 
-def test_dist_transform(Simulator, seed):
+def test_dist_transform(Simulator, seed, allclose):
     """Using a distribution to initialize transform."""
 
     with nengo.Network(seed=seed) as net:
@@ -284,8 +284,8 @@ def test_dist_transform(Simulator, seed):
         pass
 
     w = sim.data[conn1].weights
-    assert np.allclose(np.mean(w), 0.5, atol=0.01)
-    assert np.allclose(np.std(w), 1, atol=0.01)
+    assert allclose(np.mean(w), 0.5, atol=0.01)
+    assert allclose(np.std(w), 1, atol=0.01)
     assert w.shape == (101, 100)
 
     assert sim.data[conn2].weights.shape == (10, 101)
@@ -302,7 +302,7 @@ def test_dist_transform(Simulator, seed):
 
     with Simulator(net) as sim:
         pass
-    assert np.allclose(w, sim.data[conn].weights)
+    assert allclose(w, sim.data[conn].weights)
 
 
 def test_weights(Simulator, nl, plt, seed):
@@ -335,7 +335,7 @@ def test_weights(Simulator, nl, plt, seed):
     assert allclose(t, y, z, atol=0.1, buf=0.1, delay=0.01, plt=plt)
 
 
-def test_vector(Simulator, nl, plt, seed):
+def test_vector(Simulator, nl, plt, seed, allclose):
     N1, N2 = 50, 50
     transform = [-1, 0.5]
 
@@ -361,7 +361,7 @@ def test_vector(Simulator, nl, plt, seed):
     plt.plot(t, y, '--')
     plt.plot(t, yhat)
 
-    assert np.allclose(y[-10:], yhat[-10:], atol=.1, rtol=.01)
+    assert allclose(y[-10:], yhat[-10:], atol=.1, rtol=.01)
 
 
 def test_dimensionality_errors(nl_nodirect, seed, rng):
@@ -389,7 +389,7 @@ def test_dimensionality_errors(nl_nodirect, seed, rng):
         with pytest.raises(ValidationError):
             nengo.Connection(e1, e2)
         with pytest.raises(ValidationError):
-            nengo.Connection(e2.neurons, e1, transform=rng.randn(1, N+1))
+            nengo.Connection(e2.neurons, e1, transform=rng.randn(1, N + 1))
         with pytest.raises(ValidationError):
             nengo.Connection(e2.neurons, e1, transform=rng.randn(2, N))
         with pytest.raises(ValidationError):
@@ -416,7 +416,7 @@ def test_dimensionality_errors(nl_nodirect, seed, rng):
             nengo.Connection(e2[0], e2, transform=[[1, 2]])
 
 
-def test_slicing(Simulator, nl, plt, seed):
+def test_slicing(Simulator, nl, plt, seed, allclose):
     N = 300
 
     x = np.array([-1, -0.25, 1])
@@ -476,11 +476,11 @@ def test_slicing(Simulator, nl, plt, seed):
 
     atol = 0.01 if nl is nengo.Direct else 0.1
     for i, [y, p, wp] in enumerate(zip(ys, probes, weight_probes)):
-        assert np.allclose(y, sim.data[p][-20:], atol=atol), "Failed %d" % i
-        assert np.allclose(y, sim.data[wp][-20:], atol=atol), "Weights %d" % i
+        assert allclose(y, sim.data[p][-20:], atol=atol), "Failed %d" % i
+        assert allclose(y, sim.data[wp][-20:], atol=atol), "Weights %d" % i
 
 
-def test_neuron_slicing(Simulator, plt, seed, rng):
+def test_neuron_slicing(Simulator, plt, seed, rng, allclose):
     N = 6
     sa = slice(None, None, 2)
     sb = slice(None, None, -2)
@@ -511,7 +511,7 @@ def test_neuron_slicing(Simulator, plt, seed, rng):
 
     plt.plot(t, y, 'k--')
     plt.plot(t, sim.data[bp])
-    assert np.allclose(y[-10:], sim.data[bp][-10:], atol=3.0, rtol=0.0)
+    assert allclose(y[-10:], sim.data[bp][-10:], atol=3.0, rtol=0.0)
 
 
 def test_shortfilter(Simulator, nl):
@@ -558,8 +558,9 @@ def test_zerofilter(Simulator, seed):
     assert np.unique(sim.data[bp]).size == 2
 
 
-def test_function_output_size(Simulator, plt, seed):
+def test_function_output_size(Simulator, plt, seed, allclose):
     """Try a function that outputs both 0-d and 1-d arrays"""
+
     def bad_function(x):
         return x if x > 0 else 0
 
@@ -582,14 +583,14 @@ def test_function_output_size(Simulator, plt, seed):
     plt.plot(t, x, 'k')
     plt.plot(t, y)
 
-    assert np.allclose(x, y, atol=0.1)
+    assert allclose(x, y, atol=0.1)
 
 
-def test_slicing_function(Simulator, plt, seed):
+def test_slicing_function(Simulator, plt, seed, allclose):
     """Test using a pre-slice and a function"""
     N = 300
-    f_in = lambda t: [np.cos(3*t), np.sin(3*t)]
-    f_x = lambda x: [x, -x**2]
+    f_in = lambda t: [np.cos(3 * t), np.sin(3 * t)]
+    f_x = lambda x: [x, -x ** 2]
 
     with nengo.Network(seed=seed) as model:
         u = nengo.Node(output=f_in)
@@ -612,12 +613,11 @@ def test_slicing_function(Simulator, plt, seed):
     plt.plot(t, y)
     plt.plot(t, w, ':')
 
-    assert np.allclose(w, y, atol=0.1)
+    assert allclose(w, y, atol=0.1)
 
 
 @pytest.mark.parametrize("negative_indices", (True, False))
-def test_list_indexing(Simulator, plt, seed, negative_indices):
-
+def test_list_indexing(Simulator, plt, seed, negative_indices, allclose):
     with nengo.Network(seed=seed) as model:
         u = nengo.Node([-1, 1])
         a = nengo.Ensemble(40, dimensions=1)
@@ -658,14 +658,14 @@ def test_list_indexing(Simulator, plt, seed, negative_indices):
     line = plt.plot(t, d_data)
     plt.axhline(1, color=line[1].get_color())
 
-    assert np.allclose(a_data[t > 0.15], [0], atol=0.15)
-    assert np.allclose(b_data[t > 0.15], [2], atol=0.15)
-    assert np.allclose(c_data[t > 0.15], [-1, 1], atol=0.15)
-    assert np.allclose(d_data[t > 0.15], [1, 1], atol=0.15)
+    assert allclose(a_data[t > 0.15], [0], atol=0.15)
+    assert allclose(b_data[t > 0.15], [2], atol=0.15)
+    assert allclose(c_data[t > 0.15], [-1, 1], atol=0.15)
+    assert allclose(d_data[t > 0.15], [1, 1], atol=0.15)
 
 
 @pytest.mark.filterwarnings('ignore:boolean index did not match')
-def test_boolean_indexing(Simulator, rng, plt):
+def test_boolean_indexing(Simulator, rng, plt, allclose):
     D = 10
     mu = np.arange(D) % 2 == 0
     mv = np.arange(D) % 2 == 1
@@ -683,7 +683,7 @@ def test_boolean_indexing(Simulator, rng, plt):
         sim.run(0.01)
 
     plt.plot(sim.trange(), sim.data[v_probe])
-    assert np.allclose(sim.data[v_probe][1:], y, atol=1e-5, rtol=1e-3)
+    assert allclose(sim.data[v_probe][1:], y, atol=1e-5, rtol=1e-3)
 
 
 def test_set_weight_solver():
@@ -803,6 +803,7 @@ def test_eval_points_scaling(Simulator, sample, radius, seed, rng, scale):
 
 def test_solverparam():
     """SolverParam must be a solver."""
+
     class Test(object):
         sp = ConnectionSolverParam('sp', default=None)
 
@@ -923,7 +924,6 @@ def test_connectionlearningruletypeparam():
 
 
 def test_function_with_no_name(Simulator):
-
     def add(x, val):
         return x + val
 

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -307,7 +307,7 @@ def test_dist_transform(Simulator, seed, allclose):
     assert allclose(w, sim.data[conn].weights)
 
 
-def test_weights(Simulator, nl, plt, seed):
+def test_weights(Simulator, nl, plt, seed, allclose):
     n1, n2 = 100, 50
 
     def func(t):
@@ -334,7 +334,8 @@ def test_weights(Simulator, nl, plt, seed):
     x = np.array(func(t)).T
     y = np.dot(x, transform.T)
     z = nengo.Lowpass(0.005).filtfilt(sim.data[bp], dt=sim.dt)
-    assert signals_allclose(t, y, z, atol=0.1, buf=0.1, delay=0.01, plt=plt)
+    assert signals_allclose(t, y, z, atol=0.1, buf=0.1, delay=0.01, plt=plt,
+                            allclose=allclose)
 
 
 def test_vector(Simulator, nl, plt, seed, allclose):
@@ -940,7 +941,7 @@ def test_function_with_no_name(Simulator):
         assert sim
 
 
-def test_function_points(Simulator, seed, rng, plt):
+def test_function_points(Simulator, seed, rng, plt, allclose):
     x = rng.uniform(-1, 1, size=(1000, 1))
     y = -x
 
@@ -959,7 +960,7 @@ def test_function_points(Simulator, seed, rng, plt):
 
     assert signals_allclose(
         sim.trange(), -sim.data[up], sim.data[vp], buf=0.01, delay=0.005,
-        atol=5e-2, rtol=3e-2, plt=plt)
+        atol=5e-2, rtol=3e-2, plt=plt, allclose=allclose)
 
 
 def test_connectionfunctionparam_array(RefSimulator, seed):

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -67,7 +67,7 @@ def make_function_connection():
     with nengo.Network():
         e1 = nengo.Ensemble(10, 1)
         e2 = nengo.Ensemble(10, 1)
-        c = nengo.Connection(e1, e2, function=lambda x: x**2)
+        c = nengo.Connection(e1, e2, function=lambda x: x ** 2)
     return c
 
 
@@ -345,7 +345,7 @@ def test_copy_instance_params():
     assert cp.config[cp.ensembles[0]].test == 42
 
 
-def test_pickle_model(RefSimulator, seed):
+def test_pickle_model(RefSimulator, seed, allclose):
     trun = 0.5
     simseed = seed + 1
 
@@ -374,7 +374,7 @@ def test_pickle_model(RefSimulator, seed):
         t1, u1, a1, b1 = sim.trange(), sim.data[up], sim.data[ap], sim.data[bp]
 
     tols = dict(atol=1e-5)
-    assert np.allclose(t1, t0, **tols)
-    assert np.allclose(u1, u0, **tols)
-    assert np.allclose(a1, a0, **tols)
-    assert np.allclose(b1, b0, **tols)
+    assert allclose(t1, t0, **tols)
+    assert allclose(u1, u0, **tols)
+    assert allclose(a1, a0, **tols)
+    assert allclose(b1, b0, **tols)

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -6,10 +6,10 @@ import nengo.utils.numpy as npext
 from nengo.exceptions import ValidationError
 
 
-def test_pdf(rng):
+def test_pdf(rng, allclose):
     s = 0.25
-    f = lambda x: (np.exp(-0.5 * (x + 0.5)**2 / s**2) +
-                   np.exp(-0.5 * (x - 0.5)**2 / s**2))
+    f = lambda x: (np.exp(-0.5 * (x + 0.5) ** 2 / s ** 2) +
+                   np.exp(-0.5 * (x - 0.5) ** 2 / s ** 2))
 
     xref = np.linspace(-2, 2, 101)
     pref = f(xref)
@@ -24,11 +24,11 @@ def test_pdf(rng):
     y = h / float(h.sum()) / dx
     z = f(x)
     z = z / z.sum() / dx
-    assert np.allclose(y, z, atol=0.05)
+    assert allclose(y, z, atol=0.05)
 
 
 @pytest.mark.parametrize("low,high", [(-2, -1), (-1, 1), (1, 2), (1, -1)])
-def test_uniform(low, high, rng):
+def test_uniform(low, high, rng, allclose):
     n = 100
     dist = dists.Uniform(low, high)
     samples = dist.sample(n, rng=rng)
@@ -39,7 +39,7 @@ def test_uniform(low, high, rng):
         assert np.all(samples <= low)
         assert np.all(samples > high)
     hist, _ = np.histogram(samples, bins=5)
-    assert np.allclose(hist - np.mean(hist), 0, atol=0.1 * n)
+    assert allclose(hist - np.mean(hist), 0, atol=0.1 * n)
 
 
 @pytest.mark.parametrize("mean,std", [(0, 1), (0, 0), (10, 2)])
@@ -71,23 +71,23 @@ def test_exponential(scale, shift, high, rng):
 
 @pytest.mark.parametrize(
     "min_magnitude,d", [(0, 1), (0, 2), (0, 5), (0.6, 1), (0.3, 2), (0.4, 5)])
-def test_hypersphere_volume(min_magnitude, d, rng):
+def test_hypersphere_volume(min_magnitude, d, rng, allclose):
     n = 150 * d
     dist = dists.UniformHypersphere(min_magnitude=min_magnitude)
     samples = dist.sample(n, d, rng=rng)
     assert samples.shape == (n, d)
-    assert np.allclose(np.mean(samples, axis=0), 0, atol=0.1)
+    assert allclose(np.mean(samples, axis=0), 0, atol=0.1)
     assert np.all(npext.norm(samples, axis=1) >= min_magnitude)
 
 
 @pytest.mark.parametrize("dimensions", [1, 2, 5])
-def test_hypersphere_surface(dimensions, rng):
+def test_hypersphere_surface(dimensions, rng, allclose):
     n = 150 * dimensions
     dist = dists.UniformHypersphere(surface=True)
     samples = dist.sample(n, dimensions, rng=rng)
     assert samples.shape == (n, dimensions)
-    assert np.allclose(npext.norm(samples, axis=1), 1)
-    assert np.allclose(np.mean(samples, axis=0), 0, atol=0.25 / dimensions)
+    assert allclose(npext.norm(samples, axis=1), 1)
+    assert allclose(np.mean(samples, axis=0), 0, atol=0.25 / dimensions)
 
 
 def test_hypersphere_dimension_fail(rng):
@@ -101,7 +101,7 @@ def test_hypersphere_warns(rng):
 
 
 @pytest.mark.parametrize("weights", [None, [5, 1, 2, 9], [3, 2, 1, 0]])
-def test_choice(weights, rng):
+def test_choice(weights, rng, allclose):
     n = 1000
     choices = [[1, 1], [1, -1], [-1, 1], [-1, -1]]
     N = len(choices)
@@ -119,23 +119,23 @@ def test_choice(weights, rng):
     p_empirical = hist / float(hist.sum())
     p = np.ones(N) / N if dist.p is None else dist.p
     sterr = 1. / np.sqrt(n)  # expected maximum standard error
-    assert np.allclose(p, p_empirical, atol=2 * sterr)
+    assert allclose(p, p_empirical, atol=2 * sterr)
 
 
 @pytest.mark.parametrize("shape", [(12, 2), (7, 1), (7,), (1, 1)])
-def test_samples(shape, rng):
+def test_samples(shape, rng, allclose):
     samples = rng.random_sample(size=shape)
     d = dists.Samples(samples)
     dims = None if len(shape) == 1 else shape[1]
-    assert np.allclose(d.sample(shape[0], dims), samples)
+    assert allclose(d.sample(shape[0], dims), samples)
 
 
 @pytest.mark.parametrize("samples", [[1., 2., 3.], [[1, 2], [3, 4]]])
-def test_samples_list(samples):
+def test_samples_list(samples, allclose):
     d = dists.Samples(samples)
     shape = np.array(samples).shape
     dims = None if len(shape) == 1 else shape[1]
-    assert np.allclose(d.sample(shape[0], dims), samples)
+    assert allclose(d.sample(shape[0], dims), samples)
 
 
 def test_samples_errors(rng):
@@ -170,12 +170,12 @@ def test_sqrt_beta(n, m, rng):
 
 
 @pytest.mark.parametrize("n,m", [(4, 1), (10, 5)])
-def test_sqrt_beta_analytical(n, m, rng):
+def test_sqrt_beta_analytical(n, m, rng, allclose):
     """Tests pdf, cdf, and ppf of SqrtBeta distribution."""
     pytest.importorskip('scipy')  # beta and betainc
 
     dt = 0.001
-    x = np.arange(dt, 1+dt, dt)
+    x = np.arange(dt, 1 + dt, dt)
 
     dist = dists.SqrtBeta(n, m)
 
@@ -189,16 +189,16 @@ def test_sqrt_beta_analytical(n, m, rng):
 
     samples = dist.sample(num_samples, rng=rng)
     act_hist, _ = np.histogram(samples, bins=num_bins)
-    bin_points = np.linspace(0, 1, num_bins+1)
+    bin_points = np.linspace(0, 1, num_bins + 1)
     bin_cdf = dist.cdf(bin_points)
     exp_freq = bin_cdf[1:] - bin_cdf[:-1]
     assert np.all(np.abs(np.asfarray(act_hist) / num_samples - exp_freq) < 0.1)
 
     # The cdf should be the accumulated pdf
-    assert np.allclose(cdf, np.cumsum(pdf) * dt, atol=0.01)
+    assert allclose(cdf, np.cumsum(pdf) * dt, atol=0.01)
 
     # The ppf should give back x
-    assert np.allclose(x, ppf, atol=0.01)
+    assert allclose(x, ppf, atol=0.01)
 
 
 @pytest.mark.parametrize("d", [2, 3, 10, 50])
@@ -221,15 +221,15 @@ def test_cosine_similarity(d, rng):
 
 
 @pytest.mark.parametrize("d", [2, 3, 10])
-def test_cosine_analytical(d):
+def test_cosine_analytical(d, allclose):
     pytest.importorskip('scipy')  # beta, betainc, betaincinv
 
     dt = 0.0001
-    x = np.arange(-1+dt, 1, dt)
+    x = np.arange(-1 + dt, 1, dt)
 
     def p(x, d):
         # unnormalized CosineSimilarity distribution, derived by Eric H.
-        return (1 - x*x)**((d - 3) / 2.0)
+        return (1 - x * x) ** ((d - 3) / 2.0)
 
     dist = dists.CosineSimilarity(d)
 
@@ -240,29 +240,29 @@ def test_cosine_analytical(d):
     cdf_act = np.cumsum(pdf_act) / np.sum(pdf_act)
 
     # Check that we get the expected pdf after normalization
-    assert np.allclose(
+    assert allclose(
         pdf_exp / np.sum(pdf_exp), pdf_act / np.sum(pdf_act), atol=0.01)
 
     # Check that this accumulates to the expected cdf
-    assert np.allclose(cdf_exp, cdf_act, atol=0.01)
+    assert allclose(cdf_exp, cdf_act, atol=0.01)
 
     # Check that the inverse cdf gives back x
-    assert np.allclose(dist.ppf(cdf_exp), x, atol=0.01)
+    assert allclose(dist.ppf(cdf_exp), x, atol=0.01)
 
 
-def test_cosine_sample_shape(seed):
+def test_cosine_sample_shape(seed, allclose):
     """"Tests that CosineSimilarity sample has correct shape."""
     # sampling (n, d) should be the exact same as sampling (n*d,)
     n = 3
     d = 4
     dist = dists.CosineSimilarity(2)
     a = dist.sample(n, d, rng=np.random.RandomState(seed))
-    b = dist.sample(n*d, rng=np.random.RandomState(seed))
-    assert np.allclose(a.flatten(), b)
+    b = dist.sample(n * d, rng=np.random.RandomState(seed))
+    assert allclose(a.flatten(), b)
 
 
 @pytest.mark.parametrize("d,p", [(3, 0), (5, 0.4), (10, 0.7), (50, 1.0)])
-def test_cosine_intercept(d, p, rng):
+def test_cosine_intercept(d, p, rng, allclose):
     """Tests CosineSimilarity inverse cdf for finding intercepts."""
     pytest.importorskip('scipy')  # betaincinv
 
@@ -275,11 +275,12 @@ def test_cosine_intercept(d, p, rng):
 
     # Find the desired intercept so that dots >= c with probability p
     c = act_dist.ppf(1 - p)
-    assert np.allclose(np.sum(dots >= c) / float(num_samples), p, atol=0.05)
+    assert allclose(np.sum(dots >= c) / float(num_samples), p, atol=0.05)
 
 
 def test_distorarrayparam():
     """DistOrArrayParams can be distributions or samples."""
+
     class Test(object):
         dp = dists.DistOrArrayParam('dp',
                                     default=None, sample_shape=['*', '*'])
@@ -298,6 +299,7 @@ def test_distorarrayparam():
 
 def test_distorarrayparam_sample_shape():
     """sample_shape dictates the shape of the sample that can be set."""
+
     class Test(object):
         dp = dists.DistOrArrayParam(
             'dp', default=None, sample_shape=['d1', 10])

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -6,7 +6,7 @@ import nengo.utils.numpy as npext
 from nengo.dists import Choice, Gaussian, UniformHypersphere
 from nengo.exceptions import BuildError, NengoWarning
 from nengo.processes import WhiteNoise, FilteredNoise
-from nengo.utils.testing import allclose
+from nengo.utils.testing import signals_allclose
 
 
 def test_missing_attribute():
@@ -129,8 +129,9 @@ def test_scalar(Simulator, nl, plt, seed):
     t = sim.trange()
     target = f(t)
 
-    assert allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5)
-    assert allclose(t, target, sim.data[A_p], atol=0.1, delay=0.03, plt=plt)
+    assert signals_allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5)
+    assert signals_allclose(t, target, sim.data[A_p], atol=0.1, delay=0.03,
+                            plt=plt)
 
 
 def test_vector(Simulator, nl, plt, seed):
@@ -152,9 +153,9 @@ def test_vector(Simulator, nl, plt, seed):
     t = sim.trange()
     target = np.vstack(f(t)).T
 
-    assert allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5)
-    assert allclose(t, target, sim.data[A_p],
-                    plt=plt, atol=0.1, delay=0.03, buf=0.1)
+    assert signals_allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5)
+    assert signals_allclose(t, target, sim.data[A_p],
+                            plt=plt, atol=0.1, delay=0.03, buf=0.1)
 
 
 def test_product(Simulator, nl, plt, seed):

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -110,7 +110,7 @@ def test_constant_vector(Simulator, nl, plt, seed, allclose):
     assert allclose(sim.data[A_p][-10:], vals, atol=.1, rtol=.01)
 
 
-def test_scalar(Simulator, nl, plt, seed):
+def test_scalar(Simulator, nl, plt, seed, allclose):
     """A network that represents sin(t)."""
     N = 40
     f = lambda t: np.sin(2 * np.pi * t)
@@ -129,12 +129,13 @@ def test_scalar(Simulator, nl, plt, seed):
     t = sim.trange()
     target = f(t)
 
-    assert signals_allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5)
+    assert signals_allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5,
+                            allclose=allclose)
     assert signals_allclose(t, target, sim.data[A_p], atol=0.1, delay=0.03,
-                            plt=plt)
+                            plt=plt, allclose=allclose)
 
 
-def test_vector(Simulator, nl, plt, seed):
+def test_vector(Simulator, nl, plt, seed, allclose):
     """A network that represents sin(t), cos(t), cos(t)**2."""
     N = 100
     f = lambda t: [np.sin(6.3 * t), np.cos(6.3 * t), np.cos(6.3 * t) ** 2]
@@ -153,9 +154,11 @@ def test_vector(Simulator, nl, plt, seed):
     t = sim.trange()
     target = np.vstack(f(t)).T
 
-    assert signals_allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5)
+    assert signals_allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5,
+                            allclose=allclose)
     assert signals_allclose(t, target, sim.data[A_p],
-                            plt=plt, atol=0.1, delay=0.03, buf=0.1)
+                            plt=plt, atol=0.1, delay=0.03, buf=0.1,
+                            allclose=allclose)
 
 
 def test_product(Simulator, nl, plt, seed):

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -18,7 +18,8 @@ def test_missing_attribute():
 
 
 @pytest.mark.parametrize("dimensions", [1, 200])
-def test_encoders(RefSimulator, dimensions, seed, n_neurons=10, encoders=None):
+def test_encoders(RefSimulator, dimensions, seed, allclose, n_neurons=10,
+                  encoders=None):
     if encoders is None:
         encoders = np.random.normal(size=(n_neurons, dimensions))
         encoders = npext.array(encoders, min_dims=2, dtype=np.float64)
@@ -32,27 +33,29 @@ def test_encoders(RefSimulator, dimensions, seed, n_neurons=10, encoders=None):
                              label="A")
 
     with RefSimulator(model) as sim:
-        assert np.allclose(encoders, sim.data[ens].encoders)
+        assert allclose(encoders, sim.data[ens].encoders)
 
 
-def test_encoders_wrong_shape(RefSimulator, seed):
+def test_encoders_wrong_shape(RefSimulator, seed, allclose):
     dimensions = 3
     encoders = np.random.normal(size=dimensions)
     with pytest.raises(ValueError):
-        test_encoders(RefSimulator, dimensions, seed=seed, encoders=encoders)
+        test_encoders(RefSimulator, dimensions, seed=seed, encoders=encoders,
+                      allclose=allclose)
 
 
-def test_encoders_negative_neurons(RefSimulator, seed):
+def test_encoders_negative_neurons(RefSimulator, seed, allclose):
     with pytest.raises(ValueError):
-        test_encoders(RefSimulator, 1, seed=seed, n_neurons=-1)
+        test_encoders(RefSimulator, 1, seed=seed, n_neurons=-1,
+                      allclose=allclose)
 
 
-def test_encoders_no_dimensions(RefSimulator, seed):
+def test_encoders_no_dimensions(RefSimulator, seed, allclose):
     with pytest.raises(ValueError):
-        test_encoders(RefSimulator, 0, seed=seed)
+        test_encoders(RefSimulator, 0, seed=seed, allclose=allclose)
 
 
-def test_constant_scalar(Simulator, nl, plt, seed):
+def test_constant_scalar(Simulator, nl, plt, seed, allclose):
     """A Network that represents a constant value."""
     N = 30
     val = 0.5
@@ -76,11 +79,11 @@ def test_constant_scalar(Simulator, nl, plt, seed):
     plt.xlim(right=t[-1])
     plt.legend(loc=0)
 
-    assert np.allclose(sim.data[in_p], val, atol=.1, rtol=.01)
-    assert np.allclose(sim.data[A_p][-10:], val, atol=.1, rtol=.01)
+    assert allclose(sim.data[in_p], val, atol=.1, rtol=.01)
+    assert allclose(sim.data[A_p][-10:], val, atol=.1, rtol=.01)
 
 
-def test_constant_vector(Simulator, nl, plt, seed):
+def test_constant_vector(Simulator, nl, plt, seed, allclose):
     """A network that represents a constant 3D vector."""
     N = 30
     vals = [0.6, 0.1, -0.5]
@@ -103,8 +106,8 @@ def test_constant_vector(Simulator, nl, plt, seed):
     plt.legend(loc='best', fontsize='small')
     plt.xlim(right=t[-1])
 
-    assert np.allclose(sim.data[in_p][-10:], vals, atol=.1, rtol=.01)
-    assert np.allclose(sim.data[A_p][-10:], vals, atol=.1, rtol=.01)
+    assert allclose(sim.data[in_p][-10:], vals, atol=.1, rtol=.01)
+    assert allclose(sim.data[A_p][-10:], vals, atol=.1, rtol=.01)
 
 
 def test_scalar(Simulator, nl, plt, seed):
@@ -133,7 +136,7 @@ def test_scalar(Simulator, nl, plt, seed):
 def test_vector(Simulator, nl, plt, seed):
     """A network that represents sin(t), cos(t), cos(t)**2."""
     N = 100
-    f = lambda t: [np.sin(6.3*t), np.cos(6.3*t), np.cos(6.3*t)**2]
+    f = lambda t: [np.sin(6.3 * t), np.cos(6.3 * t), np.cos(6.3 * t) ** 2]
 
     m = nengo.Network(label='test_vector', seed=seed)
     with m:
@@ -203,7 +206,7 @@ def test_eval_points_number(Simulator, dims, points, seed):
         assert sim.data[A].eval_points.shape == (points, dims)
 
 
-def test_eval_points_number_warning(Simulator, seed):
+def test_eval_points_number_warning(Simulator, seed, allclose):
     model = nengo.Network(seed=seed)
     with model:
         A = nengo.Ensemble(5, 1, n_eval_points=10, eval_points=[[0.1], [0.2]])
@@ -213,7 +216,7 @@ def test_eval_points_number_warning(Simulator, seed):
         with Simulator(model) as sim:
             pass
 
-    assert np.allclose(sim.data[A].eval_points, [[0.1], [0.2]])
+    assert allclose(sim.data[A].eval_points, [[0.1], [0.2]])
 
 
 def test_gain_bias_warning(Simulator, seed):
@@ -304,7 +307,6 @@ def test_invalid_rates(Simulator):
 
 
 def test_gain_bias(Simulator):
-
     N = 17
     D = 2
 
@@ -322,7 +324,7 @@ def test_gain_bias(Simulator):
         assert np.array_equal(bias, sim.data[a].bias)
 
 
-def test_noise_gen(Simulator, nl_nodirect, seed, plt):
+def test_noise_gen(Simulator, nl_nodirect, seed, plt, allclose):
     """Ensure that setting Ensemble.noise generates noise."""
     with nengo.Network(seed=seed) as model:
         intercepts = -0.5
@@ -350,11 +352,11 @@ def test_noise_gen(Simulator, nl_nodirect, seed, plt):
 
     assert np.all(sim.data[pos_p] >= sim.data[normal_p])
     assert np.all(sim.data[normal_p] >= sim.data[neg_p])
-    assert not np.allclose(sim.data[normal_p], sim.data[pos_p])
-    assert not np.allclose(sim.data[normal_p], sim.data[neg_p])
+    assert not allclose(sim.data[normal_p], sim.data[pos_p])
+    assert not allclose(sim.data[normal_p], sim.data[neg_p])
 
 
-def test_noise_copies_ok(Simulator, nl_nodirect, seed, plt):
+def test_noise_copies_ok(Simulator, nl_nodirect, seed, plt, allclose):
     """Make sure the same noise process works in multiple ensembles.
 
     We test this both with the default system and without.
@@ -391,11 +393,11 @@ def test_noise_copies_ok(Simulator, nl_nodirect, seed, plt):
     plt.plot(*nengo.utils.ensemble.tuning_curves(b, sim), lw=2)
     plt.plot(*nengo.utils.ensemble.tuning_curves(c, sim))
 
-    assert np.allclose(sim.data[ap], sim.data[bp])
-    assert np.allclose(sim.data[bp], sim.data[cp])
+    assert allclose(sim.data[ap], sim.data[bp])
+    assert allclose(sim.data[bp], sim.data[cp])
 
 
-def test_no_norm_encoders(Simulator):
+def test_no_norm_encoders(Simulator, allclose):
     """Confirm encoders are not normalized"""
 
     enc_weight = 5
@@ -408,8 +410,8 @@ def test_no_norm_encoders(Simulator):
     with Simulator(model) as sim:
         pass
 
-    assert np.allclose(sim.data[norm].encoders, 1)
-    assert np.allclose(sim.data[no_norm].encoders, enc_weight)
+    assert allclose(sim.data[norm].encoders, 1)
+    assert allclose(sim.data[no_norm].encoders, enc_weight)
 
 
 @pytest.mark.parametrize('intercept', [1.0, 1.1])

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -16,11 +16,10 @@ def best_weights(weight_data):
     return np.argmax(np.sum(np.var(weight_data, axis=0), axis=0))
 
 
-def _test_pes(Simulator, nl, plt, seed,
+def _test_pes(Simulator, nl, plt, seed, allclose,
               pre_neurons=False, post_neurons=False, weight_solver=False,
               vin=np.array([0.5, -0.5]), vout=None, n=200,
               function=None, transform=np.array(1.), rate=1e-3):
-
     vout = np.array(vin) if vout is None else vout
 
     model = nengo.Network(seed=seed)
@@ -72,48 +71,48 @@ def _test_pes(Simulator, nl, plt, seed,
     plt.xlabel("Time (s)")
 
     tend = t > 0.4
-    assert np.allclose(sim.data[b_p][tend], vout, atol=0.05)
-    assert np.allclose(sim.data[e_p][tend], 0, atol=0.05)
-    assert np.allclose(sim.data[corr_p][tend] / rate, 0, atol=0.05)
-    assert not np.allclose(weights[0], weights[-1], atol=1e-5)
+    assert allclose(sim.data[b_p][tend], vout, atol=0.05)
+    assert allclose(sim.data[e_p][tend], 0, atol=0.05)
+    assert allclose(sim.data[corr_p][tend] / rate, 0, atol=0.05)
+    assert not allclose(weights[0], weights[-1], atol=1e-5)
 
 
-def test_pes_ens_ens(Simulator, nl_nodirect, plt, seed):
+def test_pes_ens_ens(Simulator, nl_nodirect, plt, seed, allclose):
     function = lambda x: [x[1], x[0]]
-    _test_pes(Simulator, nl_nodirect, plt, seed, function=function)
+    _test_pes(Simulator, nl_nodirect, plt, seed, allclose, function=function)
 
 
-def test_pes_weight_solver(Simulator, plt, seed):
+def test_pes_weight_solver(Simulator, plt, seed, allclose):
     function = lambda x: [x[1], x[0]]
-    _test_pes(Simulator, nengo.LIF, plt, seed, function=function,
+    _test_pes(Simulator, nengo.LIF, plt, seed, allclose, function=function,
               weight_solver=True)
 
 
-def test_pes_ens_slice(Simulator, plt, seed):
+def test_pes_ens_slice(Simulator, plt, seed, allclose):
     vin = [0.5, -0.5]
-    vout = [vin[0]**2 + vin[1]**2]
+    vout = [vin[0] ** 2 + vin[1] ** 2]
     function = lambda x: [x[0] - x[1]]
-    _test_pes(Simulator, nengo.LIF, plt, seed, vin=vin, vout=vout,
+    _test_pes(Simulator, nengo.LIF, plt, seed, allclose, vin=vin, vout=vout,
               function=function)
 
 
-def test_pes_neuron_neuron(Simulator, plt, seed, rng):
+def test_pes_neuron_neuron(Simulator, plt, seed, rng, allclose):
     n = 200
     initial_weights = rng.uniform(high=4e-4, size=(n, n))
-    _test_pes(Simulator, nengo.LIF, plt, seed,
+    _test_pes(Simulator, nengo.LIF, plt, seed, allclose,
               pre_neurons=True, post_neurons=True,
               n=n, transform=initial_weights)
 
 
-def test_pes_neuron_ens(Simulator, plt, seed, rng):
+def test_pes_neuron_ens(Simulator, plt, seed, rng, allclose):
     n = 200
     initial_weights = rng.uniform(high=1e-4, size=(2, n))
-    _test_pes(Simulator, nengo.LIF, plt, seed,
+    _test_pes(Simulator, nengo.LIF, plt, seed, allclose,
               pre_neurons=True, post_neurons=False,
               n=n, transform=initial_weights)
 
 
-def test_pes_transform(Simulator, seed):
+def test_pes_transform(Simulator, seed, allclose):
     """Test behaviour of PES when function and transform both defined."""
     n = 200
     # error must be with respect to transformed vector (conn.size_out)
@@ -144,7 +143,7 @@ def test_pes_transform(Simulator, seed):
         sim.run(1.0)
     tend = sim.trange() > 0.7
 
-    assert np.allclose(sim.data[p_b][tend], [1, -1], atol=1e-2)
+    assert allclose(sim.data[p_b][tend], [1, -1], atol=1e-2)
 
 
 def test_pes_multidim_error(Simulator, seed):
@@ -183,7 +182,7 @@ def test_pes_multidim_error(Simulator, seed):
 
 @pytest.mark.parametrize('pre_synapse', [
     0, Lowpass(tau=0.05), Alpha(tau=0.005)])
-def test_pes_synapse(Simulator, seed, pre_synapse):
+def test_pes_synapse(Simulator, seed, pre_synapse, allclose):
     rule = PES(pre_synapse=pre_synapse)
 
     with nengo.Network(seed=seed) as model:
@@ -199,8 +198,8 @@ def test_pes_synapse(Simulator, seed, pre_synapse):
     with Simulator(model) as sim:
         sim.run(0.5)
 
-    assert np.allclose(sim.data[p_neurons][1:, :],
-                       sim.data[p_pes][:-1, :])
+    assert allclose(sim.data[p_neurons][1:, :],
+                    sim.data[p_pes][:-1, :])
 
 
 @pytest.mark.parametrize("weights", [False, True])
@@ -235,14 +234,14 @@ def test_pes_recurrent_slice(Simulator, seed, weights):
     ([Oja(learning_rate=1e-5), BCM(learning_rate=1e-8)], False),
     ([Oja(learning_rate=1e-5), BCM(learning_rate=1e-8)], True),
 ])
-def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt):
+def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt, allclose):
     n = 200
 
     m = nengo.Network(seed=seed)
     with m:
         u = nengo.Node(WhiteSignal(0.5, high=10), size_out=2)
         a = nengo.Ensemble(n, dimensions=2)
-        b = nengo.Ensemble(n+1, dimensions=2)
+        b = nengo.Ensemble(n + 1, dimensions=2)
         nengo.Connection(u, a)
 
         if solver:
@@ -261,7 +260,7 @@ def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt):
         ap = nengo.Probe(a, synapse=0.03)
         up = nengo.Probe(b, synapse=0.03)
 
-    with Simulator(m, seed=seed+1) as sim:
+    with Simulator(m, seed=seed + 1) as sim:
         sim.run(0.5)
     t = sim.trange()
 
@@ -276,7 +275,7 @@ def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt):
     plt.xlabel("Time (s)")
     plt.ylabel("Weights")
 
-    assert not np.allclose(sim.data[weights_p][0], sim.data[weights_p][-1])
+    assert not allclose(sim.data[weights_p][0], sim.data[weights_p][-1])
 
 
 def learning_net(learning_rule=nengo.PES, net=None, rng=np.random):
@@ -307,7 +306,7 @@ def learning_net(learning_rule=nengo.PES, net=None, rng=np.random):
 
 
 @pytest.mark.parametrize('learning_rule', [nengo.PES, nengo.BCM, nengo.Oja])
-def test_dt_dependence(Simulator, plt, learning_rule, seed, rng):
+def test_dt_dependence(Simulator, plt, learning_rule, seed, rng, allclose):
     """Learning rules should work the same regardless of dt."""
     m = learning_net(learning_rule, nengo.Network(seed=seed), rng)
 
@@ -333,12 +332,12 @@ def test_dt_dependence(Simulator, plt, learning_rule, seed, rng):
     ax2.set_xlim(right=sim.trange()[-1])
     ax2.set_ylabel("Presynaptic activity")
 
-    assert np.allclose(trans_data[0], trans_data[1], atol=3e-3)
-    assert not np.allclose(sim.data[m.weights_p][0], sim.data[m.weights_p][-1])
+    assert allclose(trans_data[0], trans_data[1], atol=3e-3)
+    assert not allclose(sim.data[m.weights_p][0], sim.data[m.weights_p][-1])
 
 
 @pytest.mark.parametrize('learning_rule', [nengo.PES, nengo.BCM, nengo.Oja])
-def test_reset(Simulator, learning_rule, plt, seed, rng):
+def test_reset(Simulator, learning_rule, plt, seed, rng, allclose):
     """Make sure resetting learning rules resets all state."""
     m = learning_net(learning_rule, nengo.Network(seed=seed), rng)
 
@@ -366,14 +365,15 @@ def test_reset(Simulator, learning_rule, plt, seed, rng):
              sim.data[m.weights_p][..., best_ix],
              c='g')
 
-    assert np.allclose(sim.trange(), first_t)
-    assert np.allclose(sim.trange(sample_every=0.01), first_t_trans)
-    assert np.allclose(sim.data[m.activity_p], first_activity_p)
-    assert np.allclose(sim.data[m.weights_p], first_weights_p)
+    assert allclose(sim.trange(), first_t)
+    assert allclose(sim.trange(sample_every=0.01), first_t_trans)
+    assert allclose(sim.data[m.activity_p], first_activity_p)
+    assert allclose(sim.data[m.weights_p], first_weights_p)
 
 
 def test_learningruletypeparam():
     """LearningRuleTypeParam must be one or many learning rules."""
+
     class Test(object):
         lrp = LearningRuleTypeParam('lrp', default=None)
 
@@ -394,6 +394,7 @@ def test_learningruletypeparam():
 
 def test_learningrule_attr(seed):
     """Test learning_rule attribute on Connection"""
+
     def check_rule(rule, conn, rule_type):
         assert rule.connection is conn and rule.learning_rule_type is rule_type
 
@@ -421,7 +422,7 @@ def test_learningrule_attr(seed):
             check_rule(c3.learning_rule[key], c3, r3[key])
 
 
-def test_voja_encoders(Simulator, nl_nodirect, rng, seed):
+def test_voja_encoders(Simulator, nl_nodirect, rng, seed, allclose):
     """Tests that voja changes active encoders to the input."""
     n = 200
     learned_vector = np.asarray([0.3, -0.4, 0.6])
@@ -430,7 +431,7 @@ def test_voja_encoders(Simulator, nl_nodirect, rng, seed):
 
     # Set the first half to always fire with random encoders, and the
     # remainder to never fire due to their encoder's dot product with the input
-    intercepts = np.asarray([-1]*n_change + [0.99]*(n - n_change))
+    intercepts = np.asarray([-1] * n_change + [0.99] * (n - n_change))
     rand_encoders = UniformHypersphere(surface=True).sample(
         n_change, len(learned_vector), rng=rng)
     encoders = np.append(
@@ -460,26 +461,26 @@ def test_voja_encoders(Simulator, nl_nodirect, rng, seed):
     # proportional to this factor. Therefore, we should check that its
     # assumption actually holds.
     encoder_scale = (sim.data[x].gain / x.radius)[:, np.newaxis]
-    assert np.allclose(sim.data[x].encoders,
-                       sim.data[x].scaled_encoders / encoder_scale)
+    assert allclose(sim.data[x].encoders,
+                    sim.data[x].scaled_encoders / encoder_scale)
 
     # Check that the last half kept the same encoders throughout the simulation
-    assert np.allclose(
+    assert allclose(
         sim.data[p_enc][0, n_change:], sim.data[p_enc][:, n_change:])
     # and that they are also equal to their originally assigned value
-    assert np.allclose(
+    assert allclose(
         sim.data[p_enc][0, n_change:] / encoder_scale[n_change:],
         -learned_vector)
 
     # Check that the first half converged to the input
-    assert np.allclose(
+    assert allclose(
         sim.data[p_enc][tend, :n_change] / encoder_scale[:n_change],
         learned_vector, atol=0.01)
     # Check that encoders probed from ensemble equal encoders probed from Voja
-    assert np.allclose(sim.data[p_enc], sim.data[p_enc_ens])
+    assert allclose(sim.data[p_enc], sim.data[p_enc_ens])
 
 
-def test_voja_modulate(Simulator, nl_nodirect, seed):
+def test_voja_modulate(Simulator, nl_nodirect, seed, allclose):
     """Tests that voja's rule can be modulated on/off."""
     n = 200
     learned_vector = np.asarray([0.5])
@@ -506,11 +507,11 @@ def test_voja_modulate(Simulator, nl_nodirect, seed):
     tend = sim.trange() > 0.5
 
     # Check that encoders stop changing after 0.5s
-    assert np.allclose(sim.data[p_enc][tend], sim.data[p_enc][-1])
+    assert allclose(sim.data[p_enc][tend], sim.data[p_enc][-1])
 
     # Check that encoders changed during first 0.5s
     i = np.where(tend)[0][0]  # first time point after changeover
-    assert not np.allclose(sim.data[p_enc][0], sim.data[p_enc][i])
+    assert not allclose(sim.data[p_enc][0], sim.data[p_enc][i])
 
 
 def test_frozen():
@@ -544,7 +545,7 @@ def test_pes_direct_errors():
             conn.learning_rule_type = nengo.PES()
 
 
-def test_custom_type(Simulator):
+def test_custom_type(Simulator, allclose):
     """Test with custom learning rule type.
 
     A custom learning type may have ``size_in`` not equal to 0, 1, or None.
@@ -578,9 +579,9 @@ def test_custom_type(Simulator):
     with Simulator(net) as sim:
         sim.run(sim.dt * 5)
 
-    assert np.allclose(sim.data[p][:, 0, :3],
-                       np.outer(np.arange(1, 6), np.arange(1, 4)))
-    assert np.allclose(sim.data[p][:, :, 3:], 0)
+    assert allclose(sim.data[p][:, 0, :3],
+                    np.outer(np.arange(1, 6), np.arange(1, 4)))
+    assert allclose(sim.data[p][:, :, 3:], 0)
 
 
 @pytest.mark.parametrize(
@@ -603,7 +604,7 @@ def test_tau_deprecation(LearningRule):
             assert getattr(l_rule, p1) == Lowpass(i)
 
 
-def test_slicing(Simulator, seed):
+def test_slicing(Simulator, seed, allclose):
     with nengo.Network(seed=seed) as model:
         a = nengo.Ensemble(30, 1)
         b = nengo.Ensemble(30, 2)
@@ -621,9 +622,9 @@ def test_slicing(Simulator, seed):
 
         p = nengo.Probe(b, synapse=0.03)
 
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim.run(1.)
 
     t = sim.trange() > 0.8
-    assert np.allclose(sim.data[p][t, 0], 0.75, atol=0.15)
-    assert np.allclose(sim.data[p][t, 1], -0.5, atol=0.15)
+    assert allclose(sim.data[p][t, 0], 0.75, atol=0.15)
+    assert allclose(sim.data[p][t, 1], -0.5, atol=0.15)

--- a/nengo/tests/test_presets.py
+++ b/nengo/tests/test_presets.py
@@ -3,7 +3,7 @@ import numpy as np
 import nengo
 
 
-def test_thresholding_preset(Simulator, seed, plt):
+def test_thresholding_preset(Simulator, seed, plt, allclose):
     threshold = 0.3
     with nengo.Network(seed=seed) as model:
         with nengo.presets.ThresholdingEnsembles(threshold):
@@ -24,7 +24,7 @@ def test_thresholding_preset(Simulator, seed, plt):
 
     se = np.square(np.squeeze(sim.data[p]) - sim.trange())
 
-    assert np.allclose(sim.data[p][sim.trange() < threshold], 0.0)
+    assert allclose(sim.data[p][sim.trange() < threshold], 0.0)
     assert np.sqrt(np.mean(se[sim.trange() > 0.5])) < 0.05
 
 

--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -7,7 +7,7 @@ from nengo.utils.compat import range
 from nengo.utils.stdlib import Timer
 
 
-def test_multirun(Simulator, rng):
+def test_multirun(Simulator, rng, allclose):
     """Test probing the time on multiple runs"""
 
     # set rtol a bit higher, since OCL model.t accumulates error over time
@@ -24,10 +24,10 @@ def test_multirun(Simulator, rng):
             sim.run(ti)
             sim_t = sim.trange()
             t = sim.dt * np.arange(1, len(sim_t) + 1)
-            assert np.allclose(sim_t, t, rtol=rtol)
+            assert allclose(sim_t, t, rtol=rtol)
 
             t_sum += ti
-            assert np.allclose(sim_t[-1], t_sum, rtol=rtol)
+            assert allclose(sim_t[-1], t_sum, rtol=rtol)
 
 
 def test_dts(Simulator, seed, rng):
@@ -35,7 +35,7 @@ def test_dts(Simulator, seed, rng):
 
     for i in range(100):
         dt = rng.uniform(0.001, 0.1)  # simulator dt
-        dt2 = rng.uniform(dt, 0.15)   # probe dt
+        dt2 = rng.uniform(dt, 0.15)  # probe dt
         tend = rng.uniform(0.2, 0.3)  # simulator runtime
 
         with nengo.Network(seed=seed) as model:
@@ -51,7 +51,7 @@ def test_dts(Simulator, seed, rng):
             dt, dt2, tend, len(t), len(x))
 
 
-def test_large(Simulator, seed, logger):
+def test_large(Simulator, seed, logger, allclose):
     """Test with a lot of big probes. Can also be used for speed."""
 
     n = 10
@@ -78,7 +78,7 @@ def test_large(Simulator, seed, logger):
     x = np.asarray([input_fn(ti) for ti in t])
     for p in probes:
         y = sim.data[p]
-        assert np.allclose(y[1:], x[:-1])  # 1-step delay
+        assert allclose(y[1:], x[:-1])  # 1-step delay
 
 
 def test_defaults(Simulator):
@@ -112,7 +112,7 @@ def test_simulator_dt(Simulator):
     assert sim.data[bp].shape == (100, 1)
 
 
-def test_multiple_probes(Simulator):
+def test_multiple_probes(Simulator, allclose):
     """Make sure we can probe the same object multiple times."""
     dt = 1e-3
     f = 10
@@ -120,15 +120,15 @@ def test_multiple_probes(Simulator):
         ens = nengo.Ensemble(10, 1)
         p_001 = nengo.Probe(ens, sample_every=dt)
         p_01 = nengo.Probe(ens, sample_every=f * dt)
-        p_1 = nengo.Probe(ens, sample_every=f**2 * dt)
+        p_1 = nengo.Probe(ens, sample_every=f ** 2 * dt)
 
     with Simulator(model, dt=dt) as sim:
         sim.run(1.)
-    assert np.allclose(sim.data[p_001][f - 1::f], sim.data[p_01])
-    assert np.allclose(sim.data[p_01][f - 1::f], sim.data[p_1])
+    assert allclose(sim.data[p_001][f - 1::f], sim.data[p_01])
+    assert allclose(sim.data[p_01][f - 1::f], sim.data[p_1])
 
 
-def test_input_probe(Simulator):
+def test_input_probe(Simulator, allclose):
     """Make sure we can probe the input to an ensemble."""
     with nengo.Network() as model:
         ens = nengo.Ensemble(100, 1)
@@ -141,10 +141,10 @@ def test_input_probe(Simulator):
     with Simulator(model) as sim:
         sim.run(1.)
     t = sim.trange()
-    assert np.allclose(sim.data[input_probe][:, 0], np.sin(t) + 0.5)
+    assert allclose(sim.data[input_probe][:, 0], np.sin(t) + 0.5)
 
 
-def test_conn_output(Simulator):
+def test_conn_output(Simulator, allclose):
     """Make sure we can get individual connection outputs."""
     model = nengo.Network()
     with model:
@@ -159,11 +159,11 @@ def test_conn_output(Simulator):
     with Simulator(model) as sim:
         sim.run(0.2)
     t = sim.trange()
-    assert np.allclose(sim.data[p1][:, 0], -1. * np.sin(t))
-    assert np.allclose(sim.data[p2][:, 0], 0.5 ** 2)
+    assert allclose(sim.data[p1][:, 0], -1. * np.sin(t))
+    assert allclose(sim.data[p2][:, 0], 0.5 ** 2)
 
 
-def test_slice(Simulator):
+def test_slice(Simulator, allclose):
     with nengo.Network() as model:
         a = nengo.Node(output=lambda t: [np.cos(t), np.sin(t)])
         b = nengo.Ensemble(100, 2)
@@ -177,10 +177,10 @@ def test_slice(Simulator):
 
     with Simulator(model) as sim:
         sim.run(0.5)
-    assert np.allclose(sim.data[bp][:, 0], sim.data[bp0a][:, 0])
-    assert np.allclose(sim.data[bp][:, 0], sim.data[bp0b][:, 0])
-    assert np.allclose(sim.data[bp][:, 1], sim.data[bp1a][:, 0])
-    assert np.allclose(sim.data[bp][:, 1], sim.data[bp1b][:, 0])
+    assert allclose(sim.data[bp][:, 0], sim.data[bp0a][:, 0])
+    assert allclose(sim.data[bp][:, 0], sim.data[bp0b][:, 0])
+    assert allclose(sim.data[bp][:, 1], sim.data[bp1a][:, 0])
+    assert allclose(sim.data[bp][:, 1], sim.data[bp1b][:, 0])
 
 
 def test_solver_defaults():
@@ -216,7 +216,7 @@ def test_solver_defaults():
     assert f.solver is solver3
 
 
-def test_ensemble_encoders(Simulator):
+def test_ensemble_encoders(Simulator, allclose):
     """Check that encoders probed from ensemble are correct."""
     with nengo.Network() as model:
         ens = nengo.Ensemble(n_neurons=10, dimensions=2, radius=1.5)
@@ -228,8 +228,8 @@ def test_ensemble_encoders(Simulator):
     ens_data = sim.data[ens]
     from_probe = sim.data[p_enc] / (ens_data.gain / ens.radius)[:, np.newaxis]
     from_data = ens_data.encoders
-    assert np.allclose(from_probe, from_data)
-    assert np.allclose(sim.data[p_enc], ens_data.scaled_encoders)
+    assert allclose(from_probe, from_data)
+    assert allclose(sim.data[p_enc], ens_data.scaled_encoders)
 
 
 def test_obsolete_probes():
@@ -243,7 +243,7 @@ def test_obsolete_probes():
             nengo.Probe(conn, "transform")
 
 
-def test_update_timing(Simulator):
+def test_update_timing(Simulator, allclose):
     with nengo.Network() as net:
         inp = nengo.Node([1])
         ens = nengo.Ensemble(10, 1, encoders=np.ones((10, 1)),
@@ -255,5 +255,5 @@ def test_update_timing(Simulator):
     with Simulator(net) as sim:
         sim.run(0.003)
 
-    assert np.allclose(sim.data[sig_p][0], 0)
-    assert np.allclose(sim.data[sig_p][1:], 2)
+    assert allclose(sim.data[sig_p][0], 0)
+    assert allclose(sim.data[sig_p][1:], 2)

--- a/nengo/tests/test_pytest.py
+++ b/nengo/tests/test_pytest.py
@@ -13,3 +13,9 @@ def test_allclose(allclose):
     assert allclose(0, 0.9, atol=0)
     assert allclose(0, 0.9, atol=0)
     assert not allclose(0, 1.9)
+
+
+def test_unsupported():
+    # if the nengo_test_unsupported config is working properly then this
+    # test will be marked as xfail
+    assert False

--- a/nengo/tests/test_pytest.py
+++ b/nengo/tests/test_pytest.py
@@ -1,3 +1,5 @@
+import pytest
+
 import nengo.utils.numpy as npext
 from nengo.conftest import TestConfig
 
@@ -8,9 +10,15 @@ def test_seed_fixture(seed):
     assert i == 1832276344
 
 
-def test_allclose(allclose):
+@pytest.mark.parametrize("param", (True, False))
+def test_allclose(param, allclose):
     # if the nengo_test_tolerances in setup.cfg are working properly, then
     # atol will be set such that all these assertions pass
+
+    if param:
+        assert allclose(0, 0.5, atol=0)
+    else:
+        assert allclose(0, 0.25, atol=0)
     assert allclose(0, 1.9, atol=0)
     assert allclose(0, 0.9, atol=0)
     assert allclose(0, 0.9, atol=0)

--- a/nengo/tests/test_pytest.py
+++ b/nengo/tests/test_pytest.py
@@ -6,3 +6,10 @@ def test_seed_fixture(seed):
     """The seed should be the same on all machines"""
     i = (seed - TestConfig.test_seed) % npext.maxint
     assert i == 1832276344
+
+
+def test_allclose(allclose):
+    assert allclose(0, 1.9, atol=0)
+    assert allclose(0, 0.9, atol=0)
+    assert allclose(0, 0.9, atol=0)
+    assert not allclose(0, 1.9)

--- a/nengo/tests/test_pytest.py
+++ b/nengo/tests/test_pytest.py
@@ -9,6 +9,8 @@ def test_seed_fixture(seed):
 
 
 def test_allclose(allclose):
+    # if the nengo_test_tolerances in setup.cfg are working properly, then
+    # atol will be set such that all these assertions pass
     assert allclose(0, 1.9, atol=0)
     assert allclose(0, 0.9, atol=0)
     assert allclose(0, 0.9, atol=0)

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -14,28 +14,28 @@ from nengo.utils.compat import range, ResourceWarning
 from nengo.utils.progress import ProgressBar
 
 
-def test_steps(RefSimulator):
+def test_steps(RefSimulator, allclose):
     dt = 0.001
     m = nengo.Network(label="test_steps")
     with RefSimulator(m, dt=dt) as sim:
         assert sim.n_steps == 0
-        assert np.allclose(sim.time, 0 * dt)
+        assert allclose(sim.time, 0 * dt)
         sim.step()
         assert sim.n_steps == 1
-        assert np.allclose(sim.time, 1 * dt)
+        assert allclose(sim.time, 1 * dt)
         sim.step()
         assert sim.n_steps == 2
-        assert np.allclose(sim.time, 2 * dt)
+        assert allclose(sim.time, 2 * dt)
 
         assert np.isscalar(sim.n_steps)
         assert np.isscalar(sim.time)
 
 
-def test_time_absolute(Simulator):
+def test_time_absolute(Simulator, allclose):
     m = nengo.Network()
     with Simulator(m) as sim:
         sim.run(0.003)
-    assert np.allclose(sim.trange(), [0.001, 0.002, 0.003])
+    assert allclose(sim.trange(), [0.001, 0.002, 0.003])
 
 
 def test_trange_with_probes(Simulator):
@@ -164,7 +164,7 @@ def test_signal_init_values(RefSimulator):
         assert np.all(np.array([1, 2, 3]) == sim.signals[array])
 
 
-def test_seeding(RefSimulator, logger):
+def test_seeding(RefSimulator, logger, allclose):
     """Test that setting the model seed fixes everything"""
 
     #  TODO: this really just checks random parameters in ensembles.
@@ -190,7 +190,7 @@ def test_seeding(RefSimulator, logger):
 
     def compare_objs(obj1, obj2, attrs, equal=True):
         for attr in attrs:
-            check = (np.allclose(getattr(obj1, attr), getattr(obj2, attr)) ==
+            check = (allclose(getattr(obj1, attr), getattr(obj2, attr)) ==
                      equal)
             if not check:
                 logger.info("%s: %s", attr, getattr(obj1, attr))
@@ -264,7 +264,7 @@ def test_obsolete_params(RefSimulator):
         sim.data[c].decoders
 
 
-def test_probe_cache(Simulator):
+def test_probe_cache(Simulator, allclose):
     with nengo.Network() as model:
         u = nengo.Node(nengo.processes.WhiteNoise())
         up = nengo.Probe(u)
@@ -277,7 +277,7 @@ def test_probe_cache(Simulator):
         sim.run_steps(10)
         ub = np.array(sim.data[up])
 
-    assert not np.allclose(ua, ub, atol=1e-1)
+    assert not allclose(ua, ub, atol=1e-1)
 
 
 def test_invalid_run_time(Simulator):
@@ -337,7 +337,7 @@ def test_simulator_progress_bars(RefSimulator):
 
 
 @pytest.mark.parametrize('sample_every', (0.001, 0.0005, 0.002, 0.0015))
-def test_sample_every_trange(Simulator, sample_every):
+def test_sample_every_trange(Simulator, sample_every, allclose):
     with nengo.Network() as model:
         t = nengo.Node(lambda t: t)
         p = nengo.Probe(t, sample_every=sample_every)
@@ -348,7 +348,7 @@ def test_sample_every_trange(Simulator, sample_every):
     with pytest.raises(ValidationError):
         sim.trange(dt=sample_every, sample_every=sample_every)
     with pytest.warns(UserWarning):
-        assert np.allclose(
+        assert allclose(
             sim.trange(dt=sample_every), np.squeeze(sim.data[p]))
-    assert np.allclose(
+    assert allclose(
         sim.trange(sample_every=sample_every), np.squeeze(sim.data[p]))

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -263,7 +263,7 @@ def test_subsolvers_L1(rng, logger):
 
 
 @pytest.mark.slow
-def test_compare_solvers(Simulator, plt, seed):
+def test_compare_solvers(Simulator, plt, seed, allclose):
     pytest.importorskip('sklearn')
 
     N = 70
@@ -305,7 +305,7 @@ def test_compare_solvers(Simulator, plt, seed):
     close = signals_allclose(
         t, ref, outputs_f,
         atol=0.07, rtol=0, buf=0.1, delay=0.007,
-        plt=plt, labels=names, individual_results=True)
+        plt=plt, labels=names, individual_results=True, allclose=allclose)
 
     for name, c in zip(names, close):
         assert c, "Solver '%s' does not meet tolerances" % name

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -12,7 +12,7 @@ from nengo.exceptions import ValidationError
 from nengo.utils.compat import iteritems, range
 from nengo.utils.numpy import rms, norm
 from nengo.utils.stdlib import Timer
-from nengo.utils.testing import allclose
+from nengo.utils.testing import signals_allclose
 from nengo.solvers import (
     lstsq, Lstsq, LstsqNoise, LstsqL2, LstsqL2nz,
     LstsqL1, LstsqDrop, Nnls, NnlsL2, NnlsL2nz, NoSolver)
@@ -263,7 +263,7 @@ def test_subsolvers_L1(rng, logger):
 
 
 @pytest.mark.slow
-def test_compare_solvers(Simulator, plt, seed, allclose):
+def test_compare_solvers(Simulator, plt, seed):
     pytest.importorskip('sklearn')
 
     N = 70
@@ -302,9 +302,10 @@ def test_compare_solvers(Simulator, plt, seed, allclose):
     outputs = np.array([sim.data[probe][:, 0] for probe in probes]).T
     outputs_f = nengo.Lowpass(0.02).filtfilt(outputs, dt=sim.dt)
 
-    close = allclose(t, ref, outputs_f,
-                     atol=0.07, rtol=0, buf=0.1, delay=0.007,
-                     plt=plt, labels=names, individual_results=True)
+    close = signals_allclose(
+        t, ref, outputs_f,
+        atol=0.07, rtol=0, buf=0.1, delay=0.007,
+        plt=plt, labels=names, individual_results=True)
 
     for name, c in zip(names, close):
         assert c, "Solver '%s' does not meet tolerances" % name

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -5,7 +5,7 @@ import nengo
 from nengo.processes import WhiteSignal
 from nengo.synapses import (
     Alpha, LinearFilter, Lowpass, SynapseParam, Triangle)
-from nengo.utils.testing import allclose
+from nengo.utils.testing import signals_allclose
 
 
 def run_synapse(Simulator, seed, synapse, dt=1e-3, runtime=1., n_neurons=None):
@@ -36,7 +36,7 @@ def test_lowpass(Simulator, plt, seed):
     t, x, yhat = run_synapse(Simulator, seed, Lowpass(tau), dt=dt)
     y = Lowpass(tau).filt(x, dt=dt, y0=0)
 
-    assert allclose(t, y, yhat, delay=dt, plt=plt)
+    assert signals_allclose(t, y, yhat, delay=dt, plt=plt)
 
 
 def test_alpha(Simulator, plt, seed):
@@ -47,7 +47,7 @@ def test_alpha(Simulator, plt, seed):
     t, x, yhat = run_synapse(Simulator, seed, Alpha(tau), dt=dt)
     y = LinearFilter(num, den).filt(x, dt=dt, y0=0)
 
-    assert allclose(t, y, yhat, delay=dt, atol=5e-6, plt=plt)
+    assert signals_allclose(t, y, yhat, delay=dt, atol=5e-6, plt=plt)
 
 
 def test_triangle(Simulator, plt, seed, allclose):
@@ -65,7 +65,7 @@ def test_triangle(Simulator, plt, seed, allclose):
     y.shape = (-1, 1)
 
     assert allclose(y, yfilt, rtol=0)
-    assert allclose(t, y, ysim, delay=dt, rtol=0, plt=plt)
+    assert signals_allclose(t, y, ysim, delay=dt, rtol=0, plt=plt)
 
 
 def test_decoders(Simulator, plt, seed):
@@ -76,7 +76,7 @@ def test_decoders(Simulator, plt, seed):
         Simulator, seed, Lowpass(tau), dt=dt, n_neurons=100)
 
     y = Lowpass(tau).filt(x, dt=dt, y0=0)
-    assert allclose(t, y, yhat, delay=dt, plt=plt)
+    assert signals_allclose(t, y, yhat, delay=dt, plt=plt)
 
 
 def test_linearfilter(Simulator, plt, seed):
@@ -92,7 +92,7 @@ def test_linearfilter(Simulator, plt, seed):
     t, x, yhat = run_synapse(Simulator, seed, synapse, dt=dt)
     y = synapse.filt(x, dt=dt, y0=0)
 
-    assert allclose(t, y, yhat, delay=dt, plt=plt)
+    assert signals_allclose(t, y, yhat, delay=dt, plt=plt)
 
 
 def test_step_errors():

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -29,17 +29,17 @@ def run_synapse(Simulator, seed, synapse, dt=1e-3, runtime=1., n_neurons=None):
     return sim.trange(), sim.data[ref], sim.data[filtered]
 
 
-def test_lowpass(Simulator, plt, seed):
+def test_lowpass(Simulator, plt, seed, allclose):
     dt = 1e-3
     tau = 0.03
 
     t, x, yhat = run_synapse(Simulator, seed, Lowpass(tau), dt=dt)
     y = Lowpass(tau).filt(x, dt=dt, y0=0)
 
-    assert signals_allclose(t, y, yhat, delay=dt, plt=plt)
+    assert signals_allclose(t, y, yhat, delay=dt, plt=plt, allclose=allclose)
 
 
-def test_alpha(Simulator, plt, seed):
+def test_alpha(Simulator, plt, seed, allclose):
     dt = 1e-3
     tau = 0.03
     num, den = [1], [tau ** 2, 2 * tau, 1]
@@ -47,7 +47,8 @@ def test_alpha(Simulator, plt, seed):
     t, x, yhat = run_synapse(Simulator, seed, Alpha(tau), dt=dt)
     y = LinearFilter(num, den).filt(x, dt=dt, y0=0)
 
-    assert signals_allclose(t, y, yhat, delay=dt, atol=5e-6, plt=plt)
+    assert signals_allclose(t, y, yhat, delay=dt, atol=5e-6, plt=plt,
+                            allclose=allclose)
 
 
 def test_triangle(Simulator, plt, seed, allclose):
@@ -65,10 +66,11 @@ def test_triangle(Simulator, plt, seed, allclose):
     y.shape = (-1, 1)
 
     assert allclose(y, yfilt, rtol=0)
-    assert signals_allclose(t, y, ysim, delay=dt, rtol=0, plt=plt)
+    assert signals_allclose(t, y, ysim, delay=dt, rtol=0, plt=plt,
+                            allclose=allclose)
 
 
-def test_decoders(Simulator, plt, seed):
+def test_decoders(Simulator, plt, seed, allclose):
     dt = 1e-3
     tau = 0.01
 
@@ -76,10 +78,11 @@ def test_decoders(Simulator, plt, seed):
         Simulator, seed, Lowpass(tau), dt=dt, n_neurons=100)
 
     y = Lowpass(tau).filt(x, dt=dt, y0=0)
-    assert signals_allclose(t, y, yhat, delay=dt, plt=plt)
+    assert signals_allclose(t, y, yhat, delay=dt, plt=plt,
+                            allclose=allclose)
 
 
-def test_linearfilter(Simulator, plt, seed):
+def test_linearfilter(Simulator, plt, seed, allclose):
     dt = 1e-3
 
     # The following num, den are for a 4th order analog Butterworth filter,
@@ -92,7 +95,7 @@ def test_linearfilter(Simulator, plt, seed):
     t, x, yhat = run_synapse(Simulator, seed, synapse, dt=dt)
     y = synapse.filt(x, dt=dt, y0=0)
 
-    assert signals_allclose(t, y, yhat, delay=dt, plt=plt)
+    assert signals_allclose(t, y, yhat, delay=dt, plt=plt, allclose=allclose)
 
 
 def test_step_errors():

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -23,7 +23,7 @@ def run_synapse(Simulator, seed, synapse, dt=1e-3, runtime=1., n_neurons=None):
         ref = nengo.Probe(target)
         filtered = nengo.Probe(target, synapse=synapse)
 
-    with Simulator(model, dt=dt, seed=seed+1) as sim:
+    with Simulator(model, dt=dt, seed=seed + 1) as sim:
         sim.run(runtime)
 
     return sim.trange(), sim.data[ref], sim.data[filtered]
@@ -42,7 +42,7 @@ def test_lowpass(Simulator, plt, seed):
 def test_alpha(Simulator, plt, seed):
     dt = 1e-3
     tau = 0.03
-    num, den = [1], [tau**2, 2*tau, 1]
+    num, den = [1], [tau ** 2, 2 * tau, 1]
 
     t, x, yhat = run_synapse(Simulator, seed, Alpha(tau), dt=dt)
     y = LinearFilter(num, den).filt(x, dt=dt, y0=0)
@@ -50,7 +50,7 @@ def test_alpha(Simulator, plt, seed):
     assert allclose(t, y, yhat, delay=dt, atol=5e-6, plt=plt)
 
 
-def test_triangle(Simulator, plt, seed):
+def test_triangle(Simulator, plt, seed, allclose):
     dt = 1e-3
     tau = 0.03
 
@@ -64,7 +64,7 @@ def test_triangle(Simulator, plt, seed):
     y = np.convolve(x.ravel(), num)[:len(t)]
     y.shape = (-1, 1)
 
-    assert np.allclose(y, yfilt, rtol=0)
+    assert allclose(y, yfilt, rtol=0)
     assert allclose(t, y, ysim, delay=dt, rtol=0, plt=plt)
 
 
@@ -105,7 +105,7 @@ def test_step_errors():
         LinearFilter.Simple([1], [1, 2], output)
 
 
-def test_filt(plt, rng):
+def test_filt(plt, rng, allclose):
     dt = 1e-3
     tend = 3.
     t = dt * np.arange(tend / dt)
@@ -125,10 +125,10 @@ def test_filt(plt, rng):
     plt.plot(t, x)
     plt.plot(t, y, '--')
 
-    assert np.allclose(x, y, atol=1e-3, rtol=1e-2)
+    assert allclose(x, y, atol=1e-3, rtol=1e-2)
 
 
-def test_filtfilt(plt, rng):
+def test_filtfilt(plt, rng, allclose):
     dt = 1e-3
     tend = 3.
     t = dt * np.arange(tend / dt)
@@ -144,10 +144,10 @@ def test_filtfilt(plt, rng):
     plt.plot(t, x)
     plt.plot(t, y, '--')
 
-    assert np.allclose(x, y)
+    assert allclose(x, y)
 
 
-def test_lti_lowpass(rng, plt):
+def test_lti_lowpass(rng, plt, allclose):
     dt = 1e-3
     tend = 3.
     t = dt * np.arange(tend / dt)
@@ -164,20 +164,21 @@ def test_lti_lowpass(rng, plt):
     plt.plot(t, y[:, 0], label="LTI")
     plt.legend(loc="best")
 
-    assert np.allclose(x, y)
+    assert allclose(x, y)
 
 
-def test_linearfilter_combine(rng):
+def test_linearfilter_combine(rng, allclose):
     nt = 3000
     tau0, tau1 = 0.01, 0.02
     u = rng.normal(size=(nt, 10))
-    x = LinearFilter([1], [tau0*tau1, tau0+tau1, 1]).filt(u, y0=0)
+    x = LinearFilter([1], [tau0 * tau1, tau0 + tau1, 1]).filt(u, y0=0)
     y = Lowpass(tau0).combine(Lowpass(tau1)).filt(u, y0=0)
-    assert np.allclose(x, y)
+    assert allclose(x, y)
 
 
 def test_synapseparam():
     """SynapseParam must be a Synapse, and converts numbers to LowPass."""
+
     class Test(object):
         sp = SynapseParam('sp', default=Lowpass(0.1))
 

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -138,7 +138,7 @@ def norm(x, axis=None, keepdims=False):
         If True, the reduced axes are left in the result. See `np.sum` in
         newer versions of Numpy (>= 1.7).
     """
-    return np.sqrt(np.sum(x**2, axis=axis, keepdims=keepdims))
+    return np.sqrt(np.sum(x ** 2, axis=axis, keepdims=keepdims))
 
 
 def meshgrid_nd(*args):
@@ -161,7 +161,9 @@ def rms(x, axis=None, keepdims=False):
         If True, the reduced axes are left in the result. See `np.sum` in
         newer versions of Numpy (>= 1.7).
     """
-    return np.sqrt(np.mean(x**2, axis=axis, keepdims=keepdims))
+
+    x = np.asarray(x)
+    return np.sqrt(np.mean(x ** 2, axis=axis, keepdims=keepdims))
 
 
 def rmse(x, y, axis=None, keepdims=False):
@@ -179,6 +181,9 @@ def rmse(x, y, axis=None, keepdims=False):
         If True, the reduced axes are left in the result. See `np.sum` in
         newer versions of Numpy (>= 1.7).
     """
+
+    x = np.asarray(x)
+    y = np.asarray(y)
     return rms(x - y, axis=axis, keepdims=keepdims)
 
 

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -3,6 +3,8 @@ Extra functions to extend the capabilities of Numpy.
 """
 from __future__ import absolute_import
 
+import warnings
+
 import numpy as np
 
 from .compat import PY2, is_integer, is_iterable
@@ -182,6 +184,9 @@ def rmse(x, y, axis=None, keepdims=False):
         If True, the reduced axes are left in the result. See `np.sum` in
         newer versions of Numpy (>= 1.7).
     """
+    warnings.warn(
+        "The 'rmse' function is deprecated and will be removed in a future "
+        "version. Please use `rms(x - y)` instead.", DeprecationWarning)
 
     x = np.asarray(x)
     y = np.asarray(y)

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -138,6 +138,7 @@ def norm(x, axis=None, keepdims=False):
         If True, the reduced axes are left in the result. See `np.sum` in
         newer versions of Numpy (>= 1.7).
     """
+    x = np.array(x)
     return np.sqrt(np.sum(x ** 2, axis=axis, keepdims=keepdims))
 
 

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -190,7 +190,8 @@ class Logger(Recorder):
 def signals_allclose(  # noqa: C901
         t, targets, signals,
         atol=1e-8, rtol=1e-5, buf=0, delay=0,
-        plt=None, show=False, labels=None, individual_results=False):
+        plt=None, show=False, labels=None, individual_results=False,
+        allclose=np.allclose):
     """Ensure all signal elements are within tolerances.
 
     Allows for delay, removing the beginning of the signal, and plotting.
@@ -217,11 +218,13 @@ def signals_allclose(  # noqa: C901
         Labels of each signal to use when plotting.
     individual_results : bool
         If True, returns a separate `allclose` result for each signal.
+    allclose : callable
+        Function to compare two arrays for similarity
     """
     t = np.asarray(t)
     dt = t[1] - t[0]
     assert t.ndim == 1
-    assert np.allclose(np.diff(t), dt)
+    assert np.allclose(np.diff(t), dt)  # always use default allclose here
 
     targets = np.asarray(targets)
     signals = np.asarray(signals)
@@ -292,14 +295,14 @@ def signals_allclose(  # noqa: C901
 
     if individual_results:
         if targets.shape[1] == 1:
-            return [np.allclose(y[slice2], targets[slice1, 0],
-                                atol=atol, rtol=rtol) for y in signals.T]
+            return [allclose(y[slice2], targets[slice1, 0],
+                             atol=atol, rtol=rtol) for y in signals.T]
         else:
-            return [np.allclose(y[slice2], x[slice1], atol=atol, rtol=rtol)
+            return [allclose(y[slice2], x[slice1], atol=atol, rtol=rtol)
                     for x, y in zip(targets.T, signals.T)]
     else:
-        return np.allclose(signals[slice2, :], targets[slice1, :],
-                           atol=atol, rtol=rtol)
+        return allclose(signals[slice2, :], targets[slice1, :],
+                        atol=atol, rtol=rtol)
 
 
 def find_modules(root_path, prefix=None, pattern='^test_.*\\.py$'):

--- a/nengo/utils/testing.py
+++ b/nengo/utils/testing.py
@@ -187,9 +187,10 @@ class Logger(Recorder):
             del self.handler
 
 
-def allclose(t, targets, signals,  # noqa: C901
-             atol=1e-8, rtol=1e-5, buf=0, delay=0,
-             plt=None, show=False, labels=None, individual_results=False):
+def signals_allclose(  # noqa: C901
+        t, targets, signals,
+        atol=1e-8, rtol=1e-5, buf=0, delay=0,
+        plt=None, show=False, labels=None, individual_results=False):
     """Ensure all signal elements are within tolerances.
 
     Allows for delay, removing the beginning of the signal, and plotting.

--- a/nengo/utils/tests/test_connection.py
+++ b/nengo/utils/tests/test_connection.py
@@ -12,7 +12,7 @@ from nengo.utils.numpy import rms
 @pytest.mark.parametrize("radius", [1, 2.0])
 @pytest.mark.filterwarnings("ignore:'targets' can be passed directly")
 def test_target_function(Simulator, nl_nodirect, plt, dimensions, radius,
-                         seed, rng):
+                         seed, rng, allclose):
     eval_points = UniformHypersphere().sample(1000, dimensions, rng=rng)
     eval_points *= radius
     f = lambda x: x ** 2
@@ -44,7 +44,7 @@ def test_target_function(Simulator, nl_nodirect, plt, dimensions, radius,
     plt.plot(sim.trange(), sim.data[probe2])
     plt.title('Square by passing in function to connection')
 
-    assert np.allclose(sim.data[probe1], sim.data[probe2], atol=0.2 * radius)
+    assert allclose(sim.data[probe1], sim.data[probe2], atol=0.2 * radius)
 
 
 def test_eval_point_decoding(Simulator, nl_nodirect, plt, seed):

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -55,7 +55,7 @@ def test_tuning_curves(Simulator, nl_nodirect, plt, seed, dimensions):
 
 
 @pytest.mark.parametrize('dimensions', [1, 2])
-def test_tuning_curves_direct_mode(Simulator, plt, seed, dimensions):
+def test_tuning_curves_direct_mode(Simulator, plt, seed, dimensions, allclose):
     model = nengo.Network(seed=seed)
     with model:
         ens = nengo.Ensemble(10, dimensions, neuron_type=nengo.Direct())
@@ -66,7 +66,7 @@ def test_tuning_curves_direct_mode(Simulator, plt, seed, dimensions):
     plot_tuning_curves(plt, eval_points, activities)
 
     # eval_points is passed through in direct mode neurons
-    assert np.allclose(eval_points, activities)
+    assert allclose(eval_points, activities)
 
 
 def test_response_curves(Simulator, nl_nodirect, plt, seed):
@@ -92,7 +92,8 @@ def test_response_curves(Simulator, nl_nodirect, plt, seed):
 
 
 @pytest.mark.parametrize('dimensions', [1, 2])
-def test_response_curves_direct_mode(Simulator, plt, seed, dimensions):
+def test_response_curves_direct_mode(Simulator, plt, seed, dimensions,
+                                     allclose):
     model = nengo.Network(seed=seed)
     with model:
         ens = nengo.Ensemble(
@@ -106,4 +107,4 @@ def test_response_curves_direct_mode(Simulator, plt, seed, dimensions):
     assert eval_points.ndim == 1 and eval_points.size > 0
     assert np.all(eval_points >= -1.0) and np.all(eval_points <= 1.0)
     # eval_points is passed through in direct mode neurons
-    assert np.allclose(eval_points, activities)
+    assert allclose(eval_points, activities)

--- a/nengo/utils/tests/test_filter_design.py
+++ b/nengo/utils/tests/test_filter_design.py
@@ -4,15 +4,15 @@ import pytest
 from nengo.utils.filter_design import expm, cont2discrete
 
 
-def test_expm(rng):
+def test_expm(rng, allclose):
     pytest.importorskip('scipy')
     import scipy.linalg as linalg
     for a in [np.eye(3), rng.randn(10, 10)]:
-        assert np.allclose(linalg.expm(a), expm(a))
+        assert allclose(linalg.expm(a), expm(a))
 
 
 @pytest.mark.parametrize('dt', [1e-3, 1e-2, 1e-1])
-def test_cont2discrete_zoh(dt):
+def test_cont2discrete_zoh(dt, allclose):
     taus = np.logspace(-np.log10(dt) - 1, np.log10(dt) + 3, 30)
 
     # test with lowpass filter, using analytic solution
@@ -21,23 +21,23 @@ def test_cont2discrete_zoh(dt):
         d = -np.expm1(-dt / tau)
         num0, den0 = [0, d], [1, d - 1]
         num1, den1, _ = cont2discrete((num, den), dt)
-        assert np.allclose(num0, num1)
-        assert np.allclose(den0, den1)
+        assert allclose(num0, num1)
+        assert allclose(den0, den1)
 
     # test with alpha filter, using analytic solution
     for tau in taus:
-        num, den = [1], [tau**2, 2*tau, 1]
+        num, den = [1], [tau ** 2, 2 * tau, 1]
         a = dt / tau
         ea = np.exp(-a)
-        num0 = [0, -a*ea + (1 - ea), ea*(a + ea - 1)]
-        den0 = [1, -2 * ea, ea**2]
+        num0 = [0, -a * ea + (1 - ea), ea * (a + ea - 1)]
+        den0 = [1, -2 * ea, ea ** 2]
         num1, den1, _ = cont2discrete((num, den), dt)
-        assert np.allclose(num0, num1)
-        assert np.allclose(den0, den1)
+        assert allclose(num0, num1)
+        assert allclose(den0, den1)
 
     # test integrative filter, using analytic solution
     num, den = [1], [1, 0]
     num0, den0 = [0, dt], [1, -1]
     num1, den1, _ = cont2discrete((num, den), dt)
-    assert np.allclose(num0, num1)
-    assert np.allclose(den0, den1)
+    assert allclose(num0, num1)
+    assert allclose(den0, den1)

--- a/nengo/utils/tests/test_functions_piecewise.py
+++ b/nengo/utils/tests/test_functions_piecewise.py
@@ -6,29 +6,29 @@ from nengo.utils.functions import piecewise
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_basic():
+def test_basic(allclose):
     f = piecewise({0.5: 1, 1.0: 0})
-    assert np.allclose(f(-10), [0])
-    assert np.allclose(f(0), [0])
-    assert np.allclose(f(0.25), [0])
-    assert np.allclose(f(0.5), [1])
-    assert np.allclose(f(0.75), [1])
-    assert np.allclose(f(1.0), [0])
-    assert np.allclose(f(1.5), [0])
-    assert np.allclose(f(100), [0])
+    assert allclose(f(-10), [0])
+    assert allclose(f(0), [0])
+    assert allclose(f(0.25), [0])
+    assert allclose(f(0.5), [1])
+    assert allclose(f(0.75), [1])
+    assert allclose(f(1.0), [0])
+    assert allclose(f(1.5), [0])
+    assert allclose(f(100), [0])
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_lists():
+def test_lists(allclose):
     f = piecewise({0.5: [1, 0], 1.0: [0, 1]})
-    assert np.allclose(f(-10), [0, 0])
-    assert np.allclose(f(0), [0, 0])
-    assert np.allclose(f(0.25), [0, 0])
-    assert np.allclose(f(0.5), [1, 0])
-    assert np.allclose(f(0.75), [1, 0])
-    assert np.allclose(f(1.0), [0, 1])
-    assert np.allclose(f(1.5), [0, 1])
-    assert np.allclose(f(100), [0, 1])
+    assert allclose(f(-10), [0, 0])
+    assert allclose(f(0), [0, 0])
+    assert allclose(f(0.25), [0, 0])
+    assert allclose(f(0.5), [1, 0])
+    assert allclose(f(0.75), [1, 0])
+    assert allclose(f(1.0), [0, 1])
+    assert allclose(f(1.5), [0, 1])
+    assert allclose(f(100), [0, 1])
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
@@ -53,29 +53,28 @@ def test_invalid_function_length():
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_function():
+def test_function(allclose):
     f = piecewise({0: np.sin, 0.5: np.cos})
-    assert np.allclose(f(0), [np.sin(0)])
-    assert np.allclose(f(0.25), [np.sin(0.25)])
-    assert np.allclose(f(0.4999), [np.sin(0.4999)])
-    assert np.allclose(f(0.5), [np.cos(0.5)])
-    assert np.allclose(f(0.75), [np.cos(0.75)])
-    assert np.allclose(f(1.0), [np.cos(1.0)])
+    assert allclose(f(0), [np.sin(0)])
+    assert allclose(f(0.25), [np.sin(0.25)])
+    assert allclose(f(0.4999), [np.sin(0.4999)])
+    assert allclose(f(0.5), [np.cos(0.5)])
+    assert allclose(f(0.75), [np.cos(0.75)])
+    assert allclose(f(1.0), [np.cos(1.0)])
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_function_list():
-
+def test_function_list(allclose):
     def func1(t):
-        return t, t**2, t**3
+        return t, t ** 2, t ** 3
 
     def func2(t):
-        return t**4, t**5, t**6
+        return t ** 4, t ** 5, t ** 6
 
     f = piecewise({0: func1, 0.5: func2})
-    assert np.allclose(f(0), func1(0))
-    assert np.allclose(f(0.25), func1(0.25))
-    assert np.allclose(f(0.4999), func1(0.4999))
-    assert np.allclose(f(0.5), func2(0.5))
-    assert np.allclose(f(0.75), func2(0.75))
-    assert np.allclose(f(1.0), func2(1.0))
+    assert allclose(f(0), func1(0))
+    assert allclose(f(0.25), func1(0.25))
+    assert allclose(f(0.4999), func1(0.4999))
+    assert allclose(f(0.5), func2(0.5))
+    assert allclose(f(0.75), func2(0.75))
+    assert allclose(f(1.0), func2(1.0))

--- a/nengo/utils/tests/test_numpy.py
+++ b/nengo/utils/tests/test_numpy.py
@@ -5,7 +5,7 @@ import numpy as np
 from nengo.utils.numpy import meshgrid_nd
 
 
-def test_meshgrid_nd():
+def test_meshgrid_nd(allclose):
     a = [0, 0, 1]
     b = [1, 2, 3]
     c = [23, 42]
@@ -20,4 +20,4 @@ def test_meshgrid_nd():
                   [[23, 42], [23, 42], [23, 42]],
                   [[23, 42], [23, 42], [23, 42]]])]
     actual = meshgrid_nd(a, b, c)
-    assert np.allclose(expected, actual)
+    assert allclose(expected, actual)

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,3 +45,6 @@ filterwarnings =
     ignore:Skipping some optimization steps
     ignore:SciPy is not installed
     ignore:numpy.(dtype|ufunc) size changed
+nengo_test_tolerances =
+    nengo/tests/test_pytest.py:test_allclose rtol=0 atol=2
+    nengo/tests/test_pytest.py:test_allclose atol=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,10 @@ filterwarnings =
     ignore:SciPy is not installed
     ignore:numpy.(dtype|ufunc) size changed
 nengo_test_tolerances =
-    nengo/tests/test_pytest.py:test_allclose rtol=0 atol=2
-    nengo/tests/test_pytest.py:test_allclose atol=1
+    nengo/tests/test_pytest.py:test_allclose[True] atol=0.6
+    nengo/tests/test_pytest.py:test_allclose[False] atol=0.3
+    nengo/tests/test_pytest.py:test_allclose* rtol=0 atol=2
+    nengo/tests/test_pytest.py:test_allclose* atol=1
 nengo_test_unsupported =
     nengo/tests/test_pytest.py:test_unsupported
         "Test intentionally fails to check

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,7 @@ filterwarnings =
 nengo_test_tolerances =
     nengo/tests/test_pytest.py:test_allclose rtol=0 atol=2
     nengo/tests/test_pytest.py:test_allclose atol=1
+nengo_test_unsupported =
+    nengo/tests/test_pytest.py:test_unsupported
+        "Test intentionally fails to check
+         unsupported config"


### PR DESCRIPTION
**Motivation and context:**

Other backends often want to use Nengo's unit tests.  However, different platforms may expect different levels of accuracy (e.g., custom neuromorphic hardware with discretized weights).  The idea here is to make it easy for backends to modify the tolerances on Nengo's unit tests, through the pytest config system.

**How has this been tested?**

All current unit tests continue to pass, and added some new tests to check the new pytest config options.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Where should a reviewer start?**

I'd recommend going through commit-by-commit.  The diff looks pretty big, but a lot of it is just renaming variables.  I've tried to separate the functional changes from the refactoring in the commit history.

**Types of changes:**

- New feature (non-breaking change which adds functionality)

Note: technically some breaking changes in here, but only with respect to the test suite.

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
