### PR TITLE
utils.numpy.array_hash: Fix Numpy warning

### DIFF
--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -75,7 +75,7 @@ def array_hash(a, n=100):
     else:
         # pick random elements to hash
         rng = np.random.RandomState(a.size)
-        inds = [rng.randint(0, a.shape[i], size=n) for i in range(a.ndim)]
+        inds = tuple(rng.randint(0, a.shape[i], size=n) for i in range(a.ndim))
         v = a[inds]
         v.setflags(write=False)
         return hash(v.data if PY2 else v.data.tobytes())


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

This warning came from using list of lists for multidimensional array
indexing, which is now deprecated. Updated with the proper method
of using a tuple of lists.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Saw that warning disappears in Numpy 1.15.1

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.