### PR TITLE
Add support for convolutional transformations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   include:
     - env: PYTHON="2.7" STATIC="true"
     - env: PYTHON="2.7" COVERAGE="true"
-    - env: PYTHON="2.7" NUMPY="1.10"
     - env: PYTHON="2.7" NUMPY="1.11"
     - env: PYTHON="2.7" NUMPY="1.12"
     - env: PYTHON="2.7" NUMPY="1.13"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,22 @@ Release History
   ``dt`` is now an alias for ``sample_every`` and will be removed in the future.
   (`#1368 <https://github.com/nengo/nengo/issues/1368>`_,
   `#1384 <https://github.com/nengo/nengo/pull/1384>`_)
+- Dense connection transforms (this includes all previously supported values
+  for ``Connection.transform``) will now be represented internally as
+  ``nengo.Dense`` objects. Arrays/scalars can still be passed as ``transform``
+  values, and they will be automatically converted to the equivalent
+  ``nengo.Dense`` object. Retrieving the value of ``my_conn.transform`` will
+  return that ``Dense`` object. The original input array can be retrieved
+  through ``my_conn.transform.init``.
+  (`#1481 <https://github.com/nengo/nengo/pull/1481>`__)
+- ``nengo.solvers.NoSolver(w, weights=True)`` now expects ``w`` to have shape
+  ``(pre.n_neurons, function_d)``,
+  rather than ``pre.n_neurons, post.n_neurons)``. That is, with ``NoSolver``
+  you are always specifying the values for the decoders, and encoders/transform
+  will be applied automatically to those decoders (as occurs with
+  all other solvers). Note that this does not affect
+  ``NoSolver(..., weights=False)`` (the default).
+  (`#1481 <https://github.com/nengo/nengo/pull/1481>`__)
 
 2.8.0 (June 9, 2018)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Release History
 - We now warn that the progress bar is not supported in Jupyter Notebook <5.
   (`#1428 <https://github.com/nengo/nengo/pull/1428>`__,
   `#1426 <https://github.com/nengo/nengo/issues/1426>`__)
+- Added support for convolutional connections.
+  (`#1481 <https://github.com/nengo/nengo/pull/1481>`__)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,11 @@ Release History
   all other solvers). Note that this does not affect
   ``NoSolver(..., weights=False)`` (the default).
   (`#1481 <https://github.com/nengo/nengo/pull/1481>`__)
+- Increased minimum NumPy version to 1.11.0. See our
+  `instructions for installing NumPy
+  <https://www.nengo.ai/nengo/getting_started.html#installing-numpy>`__
+  if you need to upgrade.
+  (`#1481 <https://github.com/nengo/nengo/pull/1481>`__)
 
 2.8.0 (June 9, 2018)
 ====================

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -85,20 +85,20 @@ Transforms
    :nosignatures:
 
    nengo.transforms.Transform
-   nengo.transforms.get_transform
+   nengo.transforms.Dense
    nengo.transforms.Convolution
-   nengo.transforms.ConvShape
+   nengo.transforms.ChannelShape
 
 .. autoclass:: nengo.transforms.Transform
    :exclude-members: sample
 
    .. automethod:: nengo.transforms.Transform.sample(rng=np.random)
 
-.. autofunction:: nengo.transforms.get_transform(transform, shape, rng=np.random)
+.. autoclass:: nengo.transforms.Dense
 
 .. autoclass:: nengo.transforms.Convolution
 
-.. autoclass:: nengo.transforms.ConvShape
+.. autoclass:: nengo.transforms.ChannelShape
 
 Neuron types
 ============

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -78,6 +78,28 @@ Distributions
 
 .. autoclass:: nengo.dists.CosineSimilarity
 
+Transforms
+==========
+
+.. autosummary::
+   :nosignatures:
+
+   nengo.transforms.Transform
+   nengo.transforms.get_transform
+   nengo.transforms.Convolution
+   nengo.transforms.ConvShape
+
+.. autoclass:: nengo.transforms.Transform
+   :exclude-members: sample
+
+   .. automethod:: nengo.transforms.Transform.sample(rng=np.random)
+
+.. autofunction:: nengo.transforms.get_transform(transform, shape, rng=np.random)
+
+.. autoclass:: nengo.transforms.Convolution
+
+.. autoclass:: nengo.transforms.ConvShape
+
 Neuron types
 ============
 

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -29,6 +29,7 @@ from .probe import Probe
 from .rc import rc, RC_DEFAULTS
 from .simulator import Simulator
 from .synapses import Alpha, LinearFilter, Lowpass, Triangle
+from .transforms import Convolution
 from .utils.logging import log
 from . import dists, exceptions, networks, presets, processes, spa, utils
 

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -29,7 +29,7 @@ from .probe import Probe
 from .rc import rc, RC_DEFAULTS
 from .simulator import Simulator
 from .synapses import Alpha, LinearFilter, Lowpass, Triangle
-from .transforms import Convolution
+from .transforms import Dense, Convolution
 from .utils.logging import log
 from . import dists, exceptions, networks, presets, processes, spa, utils
 

--- a/nengo/_vendor/npconv2d/conv2d.py
+++ b/nengo/_vendor/npconv2d/conv2d.py
@@ -1,0 +1,132 @@
+"""
+Vendorized from https://github.com/renmengye/np-conv2d
+
+MIT License
+
+Copyright (c) 2017 Mengye Ren
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+from __future__ import division
+
+import numpy as np
+from nengo.utils.numpy import array_offset
+
+
+def calc_pad(pad, in_siz, out_siz, stride, ksize):
+    """Calculate padding width.
+    Args:
+        pad: padding method, "SAME", "VALID", or manually speicified.
+        ksize: kernel size [I, J].
+    Returns:
+        pad_: Actual padding width.
+    """
+    if pad == 'SAME':
+        return (out_siz - 1) * stride + ksize - in_siz
+    elif pad == 'VALID':
+        return 0
+    else:
+        return pad
+
+
+def calc_size(h, kh, pad, sh):
+    """Calculate output image size on one dimension.
+    Args:
+        h: input image size.
+        kh: kernel size.
+        pad: padding strategy.
+        sh: stride.
+    Returns:
+        s: output size.
+    """
+
+    if pad == 'VALID':
+        return np.ceil((h - kh + 1) / sh)
+    elif pad == 'SAME':
+        return np.ceil(h / sh)
+    else:
+        return int(np.ceil((h - kh + pad + 1) / sh))
+
+
+def extract_sliding_windows(x, ksize, pad, stride, floor_first=True):
+    """Converts a tensor to sliding windows.
+    Args:
+        x: [N, H, W, C]
+        k: [KH, KW]
+        pad: [PH, PW]
+        stride: [SH, SW]
+    Returns:
+        y: [N, (H-KH+PH+1)/SH, (W-KW+PW+1)/SW, KH * KW, C]
+    """
+    n = x.shape[0]
+    h = x.shape[1]
+    w = x.shape[2]
+    c = x.shape[3]
+    kh = ksize[0]
+    kw = ksize[1]
+    sh = stride[0]
+    sw = stride[1]
+
+    h2 = int(calc_size(h, kh, pad, sh))
+    w2 = int(calc_size(w, kw, pad, sw))
+    ph = int(calc_pad(pad, h, h2, sh, kh))
+    pw = int(calc_pad(pad, w, w2, sw, kw))
+
+    ph0 = int(np.floor(ph / 2))
+    ph1 = int(np.ceil(ph / 2))
+    pw0 = int(np.floor(pw / 2))
+    pw1 = int(np.ceil(pw / 2))
+
+    if floor_first:
+        pph = (ph0, ph1)
+        ppw = (pw0, pw1)
+    else:
+        pph = (ph1, ph0)
+        ppw = (pw1, pw0)
+    x = np.pad(
+        x, ((0, 0), pph, ppw, (0, 0)),
+        mode='constant',
+        constant_values=(0.0,))
+
+    x_sn, x_sh, x_sw, x_sc = x.strides
+    y_strides = (x_sn, sh*x_sh, sw*x_sw, x_sh, x_sw, x_sc)
+    y = np.ndarray((n, h2, w2, kh, kw, c), dtype=x.dtype, buffer=x.data,
+                   offset=array_offset(x), strides=y_strides)
+    return y
+
+
+def conv2d(x, w, pad='SAME', stride=(1, 1)):
+    """2D convolution (technically speaking, correlation).
+    Args:
+        x: [N, H, W, C]
+        w: [I, J, C, K]
+        pad: [PH, PW]
+        stride: [SH, SW]
+    Returns:
+        y: [N, H', W', K]
+    """
+    ksize = w.shape[:2]
+    x = extract_sliding_windows(x, ksize, pad, stride)
+    ws = w.shape
+    w = w.reshape([ws[0] * ws[1] * ws[2], ws[3]])
+    xs = x.shape
+    x = x.reshape([xs[0] * xs[1] * xs[2], -1])
+    y = x.dot(w)
+    y = y.reshape([xs[0], xs[1], xs[2], -1])
+    return y

--- a/nengo/builder/__init__.py
+++ b/nengo/builder/__init__.py
@@ -12,5 +12,6 @@ from . import (
     neurons,
     node,
     probe,
-    processes
+    processes,
+    transforms
 )

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -52,10 +52,11 @@ class Signal(object):
             assert name
         self._name = name
 
-        if not np.isscalar(initial_value) and base is None:
+        initial_value = np.asarray(initial_value)
+        if initial_value.ndim > 0 and base is None:
             self._initial_value = np.ascontiguousarray(initial_value).view()
         else:
-            self._initial_value = np.asarray(initial_value).view()
+            self._initial_value = initial_value.view()
         self._initial_value.setflags(write=False)
 
         if base is not None:

--- a/nengo/builder/tests/test_transforms.py
+++ b/nengo/builder/tests/test_transforms.py
@@ -1,0 +1,71 @@
+from __future__ import division
+
+import numpy as np
+import pytest
+
+from nengo.transforms import Convolution
+from nengo.builder.signal import Signal
+from nengo.builder.transforms import ConvInc
+
+
+@pytest.mark.parametrize("channels_last", (True, False))
+@pytest.mark.parametrize("stride0", (1, 2))
+@pytest.mark.parametrize("stride1", (1, 2))
+@pytest.mark.parametrize("kernel0", (4, 5))
+@pytest.mark.parametrize("kernel1", (4, 5))
+@pytest.mark.parametrize("padding", ("same", "valid"))
+def test_convinc_2d(
+        channels_last, stride0, stride1, kernel0, kernel1, padding, rng):
+    correlate2d = pytest.importorskip("scipy.signal").correlate2d
+
+    shape0 = 16
+    shape1 = 17
+    in_channels = 32
+    out_channels = 64
+    x_shape = (shape0, shape1, in_channels) if channels_last else (
+        in_channels, shape0, shape1)
+    x = Signal(rng.randn(*x_shape))
+    w = Signal(rng.randn(kernel0, kernel1, in_channels, out_channels))
+
+    conv = Convolution(out_channels,
+                       x_shape,
+                       kernel_size=(kernel0, kernel1),
+                       strides=(stride0, stride1),
+                       padding=padding,
+                       channels_last=channels_last)
+
+    y = Signal(np.zeros(conv.output_shape.shape))
+
+    signals = {sig: np.array(sig.initial_value) for sig in (x, w, y)}
+    step = ConvInc(w, x, y, conv).make_step(signals, None, None)
+
+    step()
+
+    x0 = x.initial_value
+
+    if not channels_last:
+        x0 = np.moveaxis(x0, 0, -1)
+
+    if padding == "same":
+        strides = np.asarray([stride0, stride1])
+        padding = np.ceil(np.asarray([shape0, shape1]) / strides)
+        padding = np.maximum(
+            (padding - 1) * strides + (kernel0, kernel1) - (shape0, shape1),
+            0).astype(np.int64)
+        x0 = np.pad(x0, [
+            (padding[0] // 2, padding[0] - padding[0] // 2),
+            (padding[1] // 2, padding[1] - padding[1] // 2),
+            (0, 0),
+        ], "constant")
+
+    y0 = np.stack([
+        np.sum([
+            correlate2d(x0[..., j], w.initial_value[..., j, i], mode="valid")
+            for j in range(in_channels)
+        ], axis=0) for i in range(out_channels)
+    ], axis=-1)
+    y0 = y0[::stride0, ::stride1, :]
+    if not channels_last:
+        y0 = np.moveaxis(y0, -1, 0)
+
+    assert np.allclose(signals[y], y0)

--- a/nengo/builder/transforms.py
+++ b/nengo/builder/transforms.py
@@ -1,7 +1,68 @@
 import numpy as np
 
-from nengo.builder import Operator
+from nengo.builder import Operator, Builder, Signal
+from nengo.builder.operator import Reset, ElementwiseInc, DotInc
+from nengo.exceptions import BuildError
+from nengo.transforms import Dense, Convolution
 from nengo._vendor.npconv2d import conv2d
+
+
+def multiply(x, y):
+    if x.ndim <= 2 and y.ndim < 2:
+        return x * y
+    elif x.ndim < 2 and y.ndim == 2:
+        return x.reshape(-1, 1) * y
+    elif x.ndim == 2 and y.ndim == 2:
+        return np.dot(x, y)
+    else:
+        raise BuildError(
+            "Tensors not supported (x.ndim=%d, y.ndim=%d)" % (x.ndim, y.ndim))
+
+
+@Builder.register(Dense)
+def build_dense(model, transform, sig_in,
+                decoders=None, encoders=None, rng=np.random):
+    weights = transform.sample(rng=rng)
+
+    if decoders is not None:
+        weights = multiply(weights, decoders)
+    if encoders is not None:
+        weights = multiply(encoders.T, weights)
+
+    # Add operator for applying weights
+    weight_sig = Signal(weights, name="%s.weights" % transform, readonly=True)
+    weighted = Signal(
+        np.zeros(transform.size_out if encoders is None else weights.shape[0]),
+        name="%s.weighted" % transform)
+    model.add_op(Reset(weighted))
+
+    op = ElementwiseInc if weights.ndim < 2 else DotInc
+    model.add_op(op(weight_sig, sig_in, weighted,
+                    tag="%s.weights_elementwiseinc" % transform))
+
+    return weighted, weight_sig
+
+
+@Builder.register(Convolution)
+def build_convolution(model, transform, sig_in,
+                      decoders=None, encoders=None, rng=np.random):
+    if decoders is not None:
+        raise BuildError("Applying a convolution transform to a decoded "
+                         "connection is not supported")
+    if encoders is not None:
+        raise BuildError(
+            "Applying encoders to a convolution transform is not supported")
+
+    weights = transform.sample(rng=rng)
+    weight_sig = Signal(weights, name="%s.weights" % transform, readonly=True)
+    weighted = Signal(
+        np.zeros(transform.size_out), name="%s.weighted" % transform)
+    model.add_op(Reset(weighted))
+
+    model.add_op(ConvInc(weight_sig, sig_in, weighted, transform,
+                         tag="%s.weights_convinc" % transform))
+
+    return weighted, weight_sig
 
 
 class ConvInc(Operator):

--- a/nengo/builder/transforms.py
+++ b/nengo/builder/transforms.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from nengo.builder import Operator
+from nengo._vendor.npconv2d import conv2d
+
+
+class ConvInc(Operator):
+    def __init__(self, W, X, Y, conv, tag=None):
+        super(ConvInc, self).__init__(tag=tag)
+
+        self.conv = conv
+
+        self.sets = []
+        self.incs = [Y]
+        self.reads = [W, X]
+        self.updates = []
+
+    @property
+    def W(self):
+        return self.reads[0]
+
+    @property
+    def X(self):
+        return self.reads[1]
+
+    @property
+    def Y(self):
+        return self.incs[0]
+
+    def _descstr(self):
+        return 'conv2d(%s, %s) -> %s' % (self.W, self.X, self.Y)
+
+    def make_step(self, signals, dt, rng):
+        if self.conv.dimensions > 2:
+            # note: we raise the error here, rather than earlier, because
+            # other backends might support different convolutions
+            raise NotImplementedError("Convolution > 2D not supported")
+
+        W = signals[self.W]
+        X = signals[self.X]
+        Y = signals[self.Y]
+        pad = self.conv.padding.upper()
+        stride = self.conv.strides
+
+        X = X.reshape(self.conv.input_shape.shape)
+        Y = Y.reshape(self.conv.output_shape.shape)
+
+        if not self.conv.channels_last:
+            X = np.moveaxis(X, 0, -1)
+            Y = np.moveaxis(Y, 0, -1)
+
+        if self.conv.dimensions == 1:
+            # add extra dimension to make it a 2D convolution
+            X = X[None, :, :]
+            W = W[None, :, :, :]
+            Y = Y[None, :, :]
+            stride = (1,) + stride
+
+        # add empty batch dimension
+        X = X[None, ...]
+
+        def step_conv():
+            Y[...] += conv2d.conv2d(X, W, pad=pad, stride=stride)[0]
+
+        return step_conv

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -13,7 +13,7 @@ from nengo.params import (Default, Unconfigurable, ObsoleteParam,
                           BoolParam, FunctionInfo, Parameter)
 from nengo.solvers import LstsqL2, SolverParam
 from nengo.synapses import Lowpass, SynapseParam
-from nengo.transforms import Transform
+from nengo.transforms import Dense, Transform
 from nengo.utils.compat import is_array_like, is_iterable, iteritems
 from nengo.utils.functions import function_name
 from nengo.utils.stdlib import checked_call
@@ -166,32 +166,6 @@ class ConnectionFunctionParam(Parameter):
                     "Cannot apply functions to passthrough nodes",
                     attr=self.name, obj=conn)
 
-        size_mid = conn.size_in if size is None else size
-        transform = conn.transform
-
-        if isinstance(transform, (np.ndarray, Transform)):
-            if isinstance(transform, np.ndarray):
-                transform_size = (transform.shape[1] if transform.ndim == 2
-                                  else conn.size_out)
-            else:
-                transform_size = transform.size_in
-
-            # check input dimensionality matches transform
-            if size_mid != transform_size:
-                if isinstance(transform, np.ndarray) and transform.ndim < 2:
-                    # we provide a different error message in this case;
-                    # the transform is not changing the dimensionality of the
-                    # signal, so the blame most likely lies with the function
-                    raise ValidationError(
-                        "function output size is incorrect; should return a "
-                        "vector of size %d" % conn.size_out,
-                        attr=self.name, obj=conn)
-
-                raise ValidationError(
-                    "%s output size (%d) not equal to transform input size "
-                    "(%d)" % (type_pre, size_mid, transform_size),
-                    attr=self.name, obj=conn)
-
     def coerce(self, conn, function):
         function = super(ConnectionFunctionParam, self).coerce(conn, function)
 
@@ -233,59 +207,55 @@ class ConnectionFunctionParam(Parameter):
         return (x,)
 
 
-class TransformParam(DistOrArrayParam):
-    """The transform additionally validates size_out."""
+class ConnectionTransformParam(Parameter):
+    """Connection-specific validation for transforms."""
 
     coerce_defaults = False
 
-    def __init__(self, name, default, optional=False, readonly=False):
-        super(TransformParam, self).__init__(
-            name, default, (), optional, readonly)
-
     def coerce(self, conn, transform):
-        if isinstance(transform, Transform):
-            # note: input_size checked in function param
-            if transform.size_out != conn.size_out:
+        if not isinstance(transform, Transform):
+            transform = Dense((conn.size_out, conn.size_mid), transform)
+
+        if transform.size_in != conn.size_mid:
+            if isinstance(transform, Dense) and transform.ndim < 2:
+                # we provide a different error message in this case;
+                # the transform is not changing the dimensionality of the
+                # signal, so the blame most likely lies with the function
                 raise ValidationError(
-                    "Transform output size (%d) does not match connection "
-                    "output size (%d)" % (transform.size_out, conn.size_out),
-                    attr="transform", obj=conn)
-
-            # bypass `DistOrArray` checks
-            return Parameter.coerce(self, conn, transform)
-        elif is_array_like(transform):
-            # if transform is an array, figure out what the correct shape
-            # should be
-
-            transform = np.asarray(transform, dtype=np.float64)
-            if transform.ndim == 0:
-                self.shape = ()
-            elif transform.ndim == 1:
-                self.shape = ('size_out',)
-            elif transform.ndim == 2:
-                # Actually (size_out, size_mid) but Function handles size_mid
-                self.shape = ('size_out', '*')
-
-                # check for repeated dimensions in lists, as these don't work
-                # for two-dimensional transforms
-                def repeated_inds(x):
-                    return (not isinstance(x, slice)
-                            and np.unique(x).size != len(x))
-
-                if repeated_inds(conn.pre_slice):
-                    raise ValidationError(
-                        "Input object selection has repeated indices",
-                        attr=self.name, obj=conn)
-                if repeated_inds(conn.post_slice):
-                    raise ValidationError(
-                        "Output object selection has repeated indices",
-                        attr=self.name, obj=conn)
+                    "Function output size is incorrect; should return a "
+                    "vector of size %d" % conn.size_mid,
+                    attr=self.name, obj=conn)
             else:
                 raise ValidationError(
-                    "Cannot handle transforms with dimensions > 2",
+                    "Transform input size (%d) not equal to %s output size "
+                    "(%d)" % (transform.size_in, type(conn.pre_obj).__name__,
+                              conn.size_mid), attr=self.name, obj=conn)
+
+        if transform.size_out != conn.size_out:
+            raise ValidationError(
+                "Transform output size (%d) not equal to connection "
+                "output size (%d)" % (transform.size_out, conn.size_out),
+                attr=self.name, obj=conn)
+
+        # we don't support repeated indices on 2D transforms because it makes
+        # the matrix multiplication more complicated (we'd need to expand
+        # the weight matrix for the duplicated rows/columns). it could be done
+        # if there were a demand at some point.
+        if isinstance(transform, Dense) and len(transform.init_shape) == 2:
+            def repeated_inds(x):
+                return (not isinstance(x, slice)
+                        and np.unique(x).size != len(x))
+
+            if repeated_inds(conn.pre_slice):
+                raise ValidationError(
+                    "Input object selection has repeated indices",
+                    attr=self.name, obj=conn)
+            if repeated_inds(conn.post_slice):
+                raise ValidationError(
+                    "Output object selection has repeated indices",
                     attr=self.name, obj=conn)
 
-        return super(TransformParam, self).coerce(conn, transform)
+        return super(ConnectionTransformParam, self).coerce(conn, transform)
 
 
 class Connection(NengoObject):
@@ -421,7 +391,7 @@ class Connection(NengoObject):
     synapse = SynapseParam('synapse', default=Lowpass(tau=0.005))
     function_info = ConnectionFunctionParam(
         'function', default=None, optional=True)
-    transform = TransformParam('transform', default=np.array(1.0))
+    transform = ConnectionTransformParam('transform', default=1.0)
     solver = ConnectionSolverParam('solver', default=LstsqL2())
     learning_rule_type = ConnectionLearningRuleTypeParam(
         'learning_rule_type', default=None, optional=True)
@@ -438,7 +408,7 @@ class Connection(NengoObject):
         url="https://github.com/nengo/nengo/issues/632#issuecomment-71663849")
 
     _param_init_order = [
-        'pre', 'post', 'synapse', 'transform', 'eval_points', 'function_info',
+        'pre', 'post', 'synapse', 'eval_points', 'function_info', 'transform',
         'solver', 'learning_rule_type']
 
     def __init__(self, pre, post, synapse=Default, function=Default,
@@ -451,10 +421,10 @@ class Connection(NengoObject):
         self.post = post
 
         self.synapse = synapse
-        self.transform = transform
-        self.scale_eval_points = scale_eval_points
         self.eval_points = eval_points  # Must be set before function
-        self.function_info = function  # Must be set after transform
+        self.scale_eval_points = scale_eval_points
+        self.function_info = function
+        self.transform = transform  # Must be set after function
         self.solver = solver  # Must be set before learning rule
         self.learning_rule_type = learning_rule_type  # set after transform
         self.modulatory = modulatory

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -14,8 +14,8 @@ class Distribution(FrozenObject):
     """A base class for probability distributions.
 
     The only thing that a probabilities distribution need to define is a
-    `.sample` method. This base class ensures that all distributions
-    accept the same arguments for the sample function.
+    `.Distribution.sample` method. This base class ensures that all
+    distributions accept the same arguments for the sample function.
     """
 
     def _sample_shape(self, n, d=None):
@@ -331,14 +331,15 @@ class Samples(Distribution):
     """A set of samples.
 
     This class is a subclass of `.Distribution` so that it can be used in any
-    situation that calls for a  `.Distribution`. However, the call to `.sample`
-    must match the dimensions of the samples or a `.ValidationError`
-    will be raised.
+    situation that calls for a  `.Distribution`. However, the call to
+    `.Distribution.sample` must match the dimensions of the samples or
+    a `.ValidationError` will be raised.
 
     Parameters
     ----------
     samples : (n, d) array_like
-        ``n`` and ``d`` must match what is eventually passed to `.sample`.
+        ``n`` and ``d`` must match what is eventually passed to
+         `.Distribution.sample`.
     """
 
     samples = NdarrayParam('samples', shape=('...',))

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -375,13 +375,16 @@ class NdarrayParam(Parameter):
 
     def __init__(self, name, default=Unconfigurable, shape=None,
                  optional=False, readonly=None):
-        assert shape is not None
-        assert shape.count('...') <= 1, "Cannot have more than one ellipsis"
+        if shape is not None:
+            assert shape.count('...') <= 1, (
+                "Cannot have more than one ellipsis")
         self.shape = shape
         super(NdarrayParam, self).__init__(name, default, optional, readonly)
 
     @property
     def coerce_defaults(self):
+        if self.shape is None:
+            return True
         return all(is_integer(dim) or dim in ('...', '*')
                    for dim in self.shape)
 
@@ -406,6 +409,9 @@ class NdarrayParam(Parameter):
 
         if self.readonly:
             ndarray.setflags(write=False)
+
+        if self.shape is None:
+            return ndarray
 
         if '...' in self.shape:
             # Convert '...' to the appropriate number of '*'s

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -72,9 +72,6 @@ class Solver(with_metaclass(DocstringInheritor, FrozenObject)):
         copy : bool, optional (Default: False)
             Whether a copy of ``Y`` should be returned if ``E`` is None.
         """
-        if self.weights and E is None:
-            raise ValidationError(
-                "Encoders must be provided for weight solver", attr='E')
         if not self.weights and E is not None:
             raise ValidationError(
                 "Encoders must be 'None' for decoder solver", attr='E')
@@ -539,7 +536,7 @@ class NoSolver(Solver):
     def __call__(self, A, Y, rng=None, E=None):
         if self.values is None:
             n_neurons = np.asarray(A).shape[1]
-            if self.weights:
+            if E is not None:
                 return np.zeros((n_neurons, np.asarray(E).shape[1])), {}
             else:
                 return np.zeros((n_neurons, np.asarray(Y).shape[1])), {}

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -144,9 +144,9 @@ def test_configstack():
             inhib[nengo.Connection].synapse = nengo.synapses.Lowpass(0.00848)
             inhibit = nengo.Connection(e1, e2)
     assert excite.synapse == nengo.Connection.synapse.default
-    assert excite.transform == -1
+    assert excite.transform.init == -1
     assert inhibit.synapse == inhib[nengo.Connection].synapse
-    assert inhibit.transform == -1
+    assert inhibit.transform.init == -1
 
 
 def test_config_property():

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -278,7 +278,7 @@ def test_dist_transform(Simulator, seed):
         conn5 = nengo.Connection(
             c, d, solver=nengo.solvers.LstsqL2(weights=True))
 
-    assert isinstance(conn1.transform, nengo.dists.Gaussian)
+    assert isinstance(conn1.transform.init, nengo.dists.Gaussian)
 
     with Simulator(net) as sim:
         pass
@@ -506,7 +506,7 @@ def test_neuron_slicing(Simulator, plt, seed, rng):
 
     x = sim.data[ap]
     y = np.zeros((len(t), b.n_neurons))
-    y[:, sb] = np.dot(x[:, sa], c.transform.T)
+    y[:, sb] = np.dot(x[:, sa], c.transform.init.T)
     y = b.neuron_type.rates(y, sim.data[b].gain, sim.data[b].bias)
 
     plt.plot(t, y, 'k--')
@@ -747,17 +747,6 @@ def test_set_function(Simulator):
         # Can change to another function with correct dimensionality
         conn_2d.function = lambda x: x ** 2
         conn_1d.function = lambda x: x[0] + x[1]
-
-    with Simulator(model):
-        pass  # Builds fine
-
-    with model:
-        # Cannot change to a function with different dimensionality
-        # because that would require a change in transform
-        with pytest.raises(ValidationError):
-            conn_2d.function = lambda x: x[0] * x[1]
-        with pytest.raises(ValidationError):
-            conn_1d.function = None
 
     with Simulator(model):
         pass  # Builds fine

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -341,6 +341,7 @@ def test_configure_all_nengo_parameters():
         nengo.solvers.SolverParam: lambda attr: nengo.solvers.LstsqL2nz(
             weights=isinstance(attr, nengo.connection.ConnectionSolverParam)),
         nengo.connection.ConnectionFunctionParam: lambda attr: lambda x: x + 1,
+        nengo.connection.ConnectionTransformParam: lambda attr: 2.0,
         nengo.learning_rules.LearningRuleTypeParam: (
             lambda attr: nengo.learning_rules.PES()),
         nengo.neurons.NeuronTypeParam: lambda attr: nengo.AdaptiveLIF(),

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -511,9 +511,7 @@ def test_nosolver(values, weights, seed, Simulator):
         pre = nengo.Ensemble(10, 2)
         post = nengo.Ensemble(20, 2)
 
-        if values is not None and weights:
-            values = np.ones((pre.n_neurons, post.n_neurons))
-        elif values is not None:
+        if values is not None:
             values = np.ones((pre.n_neurons, post.dimensions))
 
         conn = nengo.Connection(
@@ -527,7 +525,12 @@ def test_nosolver(values, weights, seed, Simulator):
         assert np.all(built_weights == 0)
     else:
         assert np.all(conn.solver.values == values)
-        assert np.all(built_weights == 1)
+        if weights:
+            assert np.allclose(
+                built_weights,
+                np.dot(values, sim.data[post].scaled_encoders.T).T)
+        else:
+            assert np.all(built_weights == 1)
 
     if weights:
         assert built_weights.T.shape == (pre.n_neurons, post.n_neurons)

--- a/nengo/tests/test_transforms.py
+++ b/nengo/tests/test_transforms.py
@@ -45,7 +45,7 @@ def test_convolution(
             transform=nengo.Convolution(
                 output_channels,
                 input_shape,
-                kernel=w,
+                init=w,
                 padding=padding,
                 kernel_size=kernel_size,
                 strides=(1,) if dimensions == 1 else (1, 1),

--- a/nengo/tests/test_transforms.py
+++ b/nengo/tests/test_transforms.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+
+import nengo
+from nengo.exceptions import ValidationError
+from nengo._vendor.npconv2d import conv2d
+
+
+@pytest.mark.parametrize("dimensions", (1, 2))
+@pytest.mark.parametrize("padding", ("same", "valid"))
+@pytest.mark.parametrize("channels_last", (True, False))
+@pytest.mark.parametrize("fixed_kernel", (True, False))
+def test_convolution(
+        dimensions, padding, channels_last, fixed_kernel, Simulator, rng):
+    input_d = 4
+    input_channels = 2
+    output_channels = 5
+    kernel_d = 3
+    kernel_size = (kernel_d,) if dimensions == 1 else (kernel_d, kernel_d)
+    output_d = input_d - kernel_d // 2 * 2 if padding == "valid" else input_d
+
+    input_shape = (input_d, input_channels)
+    kernel_shape = (kernel_d, input_channels, output_channels)
+    output_shape = (output_d, output_channels)
+
+    if dimensions == 2:
+        input_shape = (input_d,) + input_shape
+        kernel_shape = (kernel_d,) + kernel_shape
+        output_shape = (output_d,) + output_shape
+
+    if not channels_last:
+        input_shape = tuple(np.roll(input_shape, 1))
+        output_shape = tuple(np.roll(output_shape, 1))
+
+    with nengo.Network() as net:
+        x = rng.randn(*input_shape)
+        w = (rng.randn(*kernel_shape) if fixed_kernel
+             else nengo.dists.Uniform(-0.1, 0.1))
+
+        a = nengo.Node(np.ravel(x))
+        b = nengo.Node(size_in=np.prod(output_shape))
+        conn = nengo.Connection(
+            a, b,
+            synapse=None,
+            transform=nengo.Convolution(
+                output_channels,
+                input_shape,
+                kernel=w,
+                padding=padding,
+                kernel_size=kernel_size,
+                strides=(1,) if dimensions == 1 else (1, 1),
+                channels_last=channels_last))
+        p = nengo.Probe(b)
+
+        # check error handling
+        bad_in = nengo.Node([0])
+        bad_out = nengo.Node(size_in=5)
+        with pytest.raises(ValidationError):
+            nengo.Connection(bad_in, b, transform=conn.transform)
+        with pytest.raises(ValidationError):
+            nengo.Connection(a, bad_out, transform=conn.transform)
+
+    assert conn.transform.output_shape.shape == output_shape
+    assert conn.transform.kernel_shape == kernel_shape
+
+    with Simulator(net) as sim:
+        sim.step()
+
+    weights = sim.data[conn].weights
+    if not channels_last:
+        x = np.moveaxis(x, 0, -1)
+    if dimensions == 1:
+        x = x[:, None, :]
+        weights = weights[:, None, :, :]
+    truth = conv2d.conv2d(x[None, ...], weights, pad=padding.upper())[0]
+    if not channels_last:
+        truth = np.moveaxis(truth, -1, 0)
+
+    assert np.allclose(sim.data[p][0], np.ravel(truth))

--- a/nengo/transforms.py
+++ b/nengo/transforms.py
@@ -1,0 +1,235 @@
+import numpy as np
+
+import nengo
+from nengo.base import FrozenObject
+from nengo.dists import Distribution
+from nengo.exceptions import ValidationError
+from nengo.utils.compat import range
+
+
+def get_transform(transform, shape, rng=np.random):
+    """Convenience function to sample a transform or return samples.
+
+    Use this function in situations where you accept an argument that could
+    be a transform, or could be an ``array_like`` of samples.
+
+    Parameters
+    ----------
+    transform : `.Transform` or `.Distribution` or array_like
+        Source of the transform to be returned.
+    shape : tuple of int
+        Desired shape of transform
+    rng : `numpy.random.RandomState`, optional (Default: np.random)
+        Random number generator.
+
+    Returns
+    -------
+    samples : array_like
+        Sampled array
+    """
+
+    if isinstance(transform, Transform):
+        return transform.sample(rng=rng)
+    elif isinstance(transform, Distribution):
+        assert len(shape) == 2
+        return transform.sample(*shape, rng=rng)
+    else:
+        assert (transform.shape == ()
+                or transform.shape == (shape[0],)
+                or transform.shape == shape)
+        return np.array(transform)
+
+
+class Transform(FrozenObject):
+    """A base class for connection transforms."""
+
+    def sample(self, rng=np.random):
+        """Returns concrete weights to implement the specified transform.
+
+        Parameters
+        ----------
+        rng : `numpy.random.RandomState`, optional
+            Random number generator state.
+
+        Returns
+        -------
+        array_like
+            Transform weights
+        """
+        raise NotImplementedError()
+
+    @property
+    def size_in(self):
+        """Expected size of input to transform"""
+        raise NotImplementedError()
+
+    @property
+    def size_out(self):
+        """Expected size of output from transform"""
+        raise NotImplementedError()
+
+
+class Convolution(Transform):
+    """An N-dimensional convolutional transform.
+
+    The dimensionality of the convolution is determined by the input shape.
+
+    Parameters
+    ----------
+    n_filters : int
+        The number of convolutional filters to apply
+    input_shape : tuple of int or `.ConvShape`
+        Shape of the input signal to the convolution; e.g.,
+        ``(height, width, channels)`` for a 2D convolution with
+        ``channels_last=True``.
+    kernel_size : tuple of int, optional (Default: (3, 3))
+        Size of the convolutional kernels (1 element for a 1D convolution,
+        2 for a 2D convolution, etc.).
+    strides : tuple of int, optional (Default: (1, 1))
+        Stride of the convolution (1 element for a 1D convolution, 2 for
+        a 2D convolution, etc.).
+    padding : ``"same"`` or ``"valid"``, optional (Default: "valid")
+        Padding method for input signal. "Valid" means no padding, and
+        convolution will only be applied to the fully-overlapping areas of the
+        input signal (meaning the output will be smaller). "Same" means that
+        the input signal is zero-padded so that the output is the same shape
+        as the input.
+    channels_last : bool, optional (Default: True)
+        If ``True`` (default), the channels are the last dimension in the input
+        signal (e.g., a 28x28 image with 3 channels would have shape
+        ``(28, 28, 3)``).  ``False`` means that channels are the first
+        dimension (e.g., ``(3, 28, 28)``).
+    kernel : `.Distribution` or `~numpy:numpy.ndarray`, optional \
+             (Default: Uniform(-1, 1))
+        A predefined kernel with shape
+        ``kernel_size + (input_channels, n_filters)``, or a ``Distribution``
+        that will be used to initialize the kernel.
+
+    Notes
+    -----
+    As is typical in neural networks, this is technically correlation rather
+    than convolution (because the kernel is not flipped).
+    """
+
+    def __init__(self, n_filters, input_shape, kernel_size=(3, 3),
+                 strides=(1, 1), padding="valid", channels_last=True,
+                 kernel=nengo.dists.Uniform(-1, 1)):
+        super(Convolution, self).__init__()
+
+        if isinstance(input_shape, ConvShape):
+            assert input_shape.channels_last == channels_last
+        else:
+            input_shape = ConvShape(input_shape, channels_last=channels_last)
+
+        self.n_filters = n_filters
+        self.input_shape = input_shape
+        self.kernel_size = kernel_size
+        self.strides = strides
+        self.padding = padding
+        self.channels_last = channels_last
+        self.kernel = kernel
+        self.dimensions = len(kernel_size)
+
+        if len(kernel_size) != input_shape.dimensions:
+            raise ValidationError(
+                "Kernel dimensions (%d) do not match input dimensions (%d)"
+                % (len(kernel_size), input_shape.dimensions),
+                attr="kernel_size")
+        if len(strides) != input_shape.dimensions:
+            raise ValidationError(
+                "Stride dimensions (%d) do not match input dimensions (%d)"
+                % (len(strides), input_shape.dimensions), attr="strides")
+        if not isinstance(kernel, Distribution):
+            if kernel.shape != self.kernel_shape:
+                raise ValidationError(
+                    "Kernel shape %s does not match expected shape %s"
+                    % (kernel.shape, self.kernel_shape), attr="kernel")
+
+        # compute output shape
+        output_shape = np.array(input_shape.spatial_shape, dtype=np.float64)
+        if self.padding == "valid":
+            output_shape -= kernel_size
+            output_shape += 1
+        output_shape /= strides
+        output_shape = tuple(np.ceil(output_shape).astype(np.int64))
+        output_shape = (output_shape + (n_filters,) if channels_last
+                        else (n_filters,) + output_shape)
+
+        self.output_shape = ConvShape(
+            output_shape, channels_last=channels_last)
+
+        self._paramdict = {
+            "n_filters": n_filters,
+            "input_shape": self.input_shape,
+            "kernel_size": self.kernel_size,
+            "strides": self.strides
+        }
+
+    @property
+    def kernel_shape(self):
+        return self.kernel_size + (self.input_shape.n_channels, self.n_filters)
+
+    def sample(self, rng=np.random):
+        if isinstance(self.kernel, Distribution):
+            # we sample this way so that any variancescaling distribution based
+            # on n/d is scaled appropriately
+            kernel = [
+                self.kernel.sample(
+                    self.input_shape.n_channels, self.n_filters, rng=rng)
+                for _ in range(np.prod(self.kernel_size))
+            ]
+            kernel = np.reshape(kernel, self.kernel_shape)
+        else:
+            kernel = np.array(self.kernel)
+        return kernel
+
+    @property
+    def size_in(self):
+        return self.input_shape.size
+
+    @property
+    def size_out(self):
+        return self.output_shape.size
+
+
+class ConvShape(object):
+    """Represents shape information with variable channel position.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Signal shape
+    channels_last : bool, optional (Default: True)
+        If True (default), the last item in ``shape`` represents the channels,
+        and the rest are spatial dimensions. Otherwise, the first item in
+        ``shape`` is the channel dimension.
+    """
+    def __init__(self, shape, channels_last=True):
+        self.shape = tuple(shape)
+        self.channels_last = channels_last
+
+    def __str__(self):
+        return "%s(shape=%s, ch_last=%d)" % (
+            type(self).__name__, self.shape, self.channels_last)
+
+    @property
+    def spatial_shape(self):
+        """The spatial part of the shape (omitting channels)."""
+        if self.channels_last:
+            return self.shape[:-1]
+        return self.shape[1:]
+
+    @property
+    def size(self):
+        """The total number of elements in the represented signal."""
+        return np.prod(self.shape)
+
+    @property
+    def n_channels(self):
+        """The number of channels in the represented signal."""
+        return self.shape[-1 if self.channels_last else 0]
+
+    @property
+    def dimensions(self):
+        """The spatial dimensionality of the represented signal."""
+        return len(self.shape) - 1

--- a/nengo/utils/builder.py
+++ b/nengo/utils/builder.py
@@ -12,7 +12,7 @@ from nengo.exceptions import Unconvertible, ValidationError
 
 
 def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
-    """Compute the full transform for a connection.
+    """Compute the full transform matrix for a Dense connection transform.
 
     Parameters
     ----------
@@ -27,7 +27,12 @@ def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
         not using slicing, since these work fine in the reference builder.
         If false, these scalars will be turned into scaled identity matrices.
     """
-    transform = conn.transform
+
+    if not isinstance(conn.transform, nengo.Dense):
+        raise ValidationError("full_transform can only be applied to Dense "
+                              "transforms", attr="transform", obj=conn)
+
+    transform = conn.transform.init
     pre_slice = (conn.pre_slice if slice_pre and conn.function is None else
                  slice(None))
     post_slice = conn.post_slice if slice_post else slice(None)

--- a/nengo/utils/tests/test_builder.py
+++ b/nengo/utils/tests/test_builder.py
@@ -18,39 +18,39 @@ def test_full_transform():
 
         # Pre slice with default transform -> 1x3 transform
         conn = nengo.Connection(node3[2], ens1)
-        assert np.all(conn.transform == np.array(1))
+        assert np.all(conn.transform.init == np.array(1))
         assert np.all(full_transform(conn) == np.array([[0, 0, 1]]))
 
         # Post slice with 1x1 transform -> 1x2 transform
         conn = nengo.Connection(node2[0], ens1, transform=-2)
-        assert np.all(conn.transform == np.array(-2))
+        assert np.all(conn.transform.init == np.array(-2))
         assert np.all(full_transform(conn) == np.array([[-2, 0]]))
 
         # Post slice with 2x1 tranfsorm -> 3x1 transform
         conn = nengo.Connection(node1, ens3[::2], transform=[[1], [2]])
-        assert np.all(conn.transform == np.array([[1], [2]]))
+        assert np.all(conn.transform.init == np.array([[1], [2]]))
         assert np.all(full_transform(conn) == np.array([[1], [0], [2]]))
 
         # Both slices with 2x1 transform -> 3x2 transform
         conn = nengo.Connection(ens2[-1], neurons3[1:], transform=[[1], [2]])
-        assert np.all(conn.transform == np.array([[1], [2]]))
+        assert np.all(conn.transform.init == np.array([[1], [2]]))
         assert np.all(full_transform(conn) == np.array(
             [[0, 0], [0, 1], [0, 2]]))
 
         # Full slices that can be optimized away
         conn = nengo.Connection(ens3[:], ens3, transform=2)
-        assert np.all(conn.transform == np.array(2))
+        assert np.all(conn.transform.init == np.array(2))
         assert np.all(full_transform(conn) == np.array(2))
 
         # Pre slice with 1x1 transform on 2x2 slices -> 2x3 transform
         conn = nengo.Connection(neurons3[:2], ens2, transform=-1)
-        assert np.all(conn.transform == np.array(-1))
+        assert np.all(conn.transform.init == np.array(-1))
         assert np.all(full_transform(conn) == np.array(
             [[-1, 0, 0], [0, -1, 0]]))
 
         # Both slices with 1x1 transform on 2x2 slices -> 3x3 transform
         conn = nengo.Connection(neurons3[1:], neurons3[::2], transform=-1)
-        assert np.all(conn.transform == np.array(-1))
+        assert np.all(conn.transform.init == np.array(-1))
         assert np.all(full_transform(conn) == np.array([[0, -1, 0],
                                                        [0, 0, 0],
                                                        [0, 0, -1]]))
@@ -58,7 +58,7 @@ def test_full_transform():
         # Both slices with 2x2 transform -> 3x3 transform
         conn = nengo.Connection(node3[[0, 2]], neurons3[1:],
                                 transform=[[1, 2], [3, 4]])
-        assert np.all(conn.transform == np.array([[1, 2], [3, 4]]))
+        assert np.all(conn.transform.init == np.array([[1, 2], [3, 4]]))
         assert np.all(full_transform(conn) == np.array([[0, 0, 0],
                                                        [1, 0, 2],
                                                        [3, 0, 4]]))
@@ -66,7 +66,7 @@ def test_full_transform():
         # Both slices with 2x3 transform -> 3x3 transform... IN REVERSE!
         conn = nengo.Connection(neurons3[::-1], neurons3[[2, 0]],
                                 transform=[[1, 2, 3], [4, 5, 6]])
-        assert np.all(conn.transform == np.array([[1, 2, 3], [4, 5, 6]]))
+        assert np.all(conn.transform.init == np.array([[1, 2, 3], [4, 5, 6]]))
         assert np.all(full_transform(conn) == np.array([[6, 5, 4],
                                                        [0, 0, 0],
                                                        [3, 2, 1]]))
@@ -74,7 +74,7 @@ def test_full_transform():
         # Both slices using lists
         conn = nengo.Connection(neurons3[[1, 0, 2]], neurons3[[2, 1]],
                                 transform=[[1, 2, 3], [4, 5, 6]])
-        assert np.all(conn.transform == np.array([[1, 2, 3], [4, 5, 6]]))
+        assert np.all(conn.transform.init == np.array([[1, 2, 3], [4, 5, 6]]))
         assert np.all(full_transform(conn) == np.array([[0, 0, 0],
                                                        [5, 4, 6],
                                                        [2, 1, 3]]))
@@ -82,7 +82,7 @@ def test_full_transform():
         # using vector
         conn = nengo.Connection(ens3[[1, 0, 2]], ens3[[2, 0, 1]],
                                 transform=[1, 2, 3])
-        assert np.all(conn.transform == np.array([1, 2, 3]))
+        assert np.all(conn.transform.init == np.array([1, 2, 3]))
         assert np.all(full_transform(conn) == np.array([[2, 0, 0],
                                                        [0, 0, 3],
                                                        [0, 1, 0]]))
@@ -95,7 +95,7 @@ def test_full_transform():
         # using vector and lists
         conn = nengo.Connection(ens3[[1, 0, 2]], ens3[[2, 0, 1]],
                                 transform=[1, 2, 3])
-        assert np.all(conn.transform == np.array([1, 2, 3]))
+        assert np.all(conn.transform.init == np.array([1, 2, 3]))
         assert np.all(full_transform(conn) == np.array([[2, 0, 0],
                                                        [0, 0, 3],
                                                        [0, 1, 0]]))

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version_module = imp.load_source(
     "version", os.path.join(root, "nengo", "version.py"))
 testing = "test" in sys.argv or "pytest" in sys.argv
 
-install_requires = ["numpy>=1.8"]
+install_requires = ["numpy>=1.11"]
 docs_require = [
     "sphinx<1.7",
     "jupyter",


### PR DESCRIPTION
**Motivation and context:**
It would be good to be able to represent transforms other than dense 2D weight matrices in a consistent way across the nengo ecosystem.  This focuses specifically on convolutional connections, although with the assumption that we will want to implement more of these (e.g. sparse weight matrices).

See https://github.com/nengo/enhancement-proposals/pull/14 for more detailed motivation/discussion.

Some discussion points:
- Do we want to add an example notebook demonstrating this new syntax?
- I added the ``Transforms`` superclass based on the assumption that we will want more than one of these kinds of things.  But right now we only have one, so perhaps this is premature.  We could just have everything refer directly to ``Convolution`` instead of ``Transform`` (but would then need to go and reintroduce some generality if we add other types of transforms).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added new tests in `test_transform.py` and `builder/tests/test_transform.py`.

**How long should this take to review?**

- Lengthy (more than 150 lines changed or changes are complicated)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

I'd start out by looking at the content in `transform.py`, as that is the main user-facing change.  Then take a look at the builder changes to see how that gets implemented.  The rest of the changes have to do with documentation/validation/testing.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
