### PR TITLE
Numba LIF model reduces simulation time by 30% or more 

### DIFF
--- a/nengo/utils/__init__.py
+++ b/nengo/utils/__init__.py
@@ -12,6 +12,7 @@ from . import magic
 from . import nco
 from . import network
 from . import neurons
+from . import numba
 from . import numpy
 from . import paths
 from . import probe

--- a/nengo/utils/numba.py
+++ b/nengo/utils/numba.py
@@ -1,0 +1,27 @@
+"""
+Extra functions to extend the capabilities of Numba.
+"""
+
+from __future__ import absolute_import
+
+import numpy as np
+
+from numba.extending import overload
+
+
+@overload(np.clip)
+def np_clip(a, a_min, a_max):
+    """Numba-implementation of np.clip."""
+    # Does not support `out` argument, optional arguments, nor a.clip
+    # https://github.com/numba/numba/pull/3468
+    def np_clip_impl(a, a_min, a_max):
+        out = np.empty_like(a)
+        for index, val in np.ndenumerate(a):
+            if val < a_min:
+                out[index] = a_min
+            elif val > a_max:
+                out[index] = a_max
+            else:
+                out[index] = val
+        return out
+    return np_clip_impl


### PR DESCRIPTION
**Motivation and context:**
The neuron model is one of the inner-most loops within the reference backend. Speeding this code up with JIT compilation would offer a significant reduction in simulation times to virtually all Nengo models using the default simulator. 

To this end, `nengo.neurons.NumbaLIF` works as a drop-in replacement for `nengo.LIF`. This new neuron model uses Numba's `nopython` just-in-time compilation feature to execute optimized machine code (instead of using the Python interpreter). See details: http://numba.pydata.org/numba-doc/latest/user/performance-tips.html.

**How has this been tested?**
 - `pip install numba`
 - `py.test nengo/tests/test_neurons.py::test_numbalif_benchmark --plots=plots --slow`
 - `xdg-open plots/test_neurons.test_numbalif_benchmark.pdf`

![profile_numbalif](https://user-images.githubusercontent.com/5420057/47815883-f1809900-dd27-11e8-9e3f-186e448b03d8.png)

**How long should this take to review?**
- Lengthy (more than 150 lines changed or changes are complicated)

**Where should a reviewer start?**
This is a work in progress. How should this be exposed to the user? If `numba` is already installed, should a factory substitute this in for `LIF`? Should the config system use this as the default if available?

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
 - [x] Test for correctness / consistency
 - [ ] Test depends on `seaborn` and `pandas`
 - [ ] Extend to other models in Nengo, including synapse models
 - [x] Rerun existing Nengo test suite against `NumbaLIF`
 - [x] Refactor code to eliminate duplication of `LIF.step_math` code.
 - [x] ~~Move `custom_clip` to a utility file for numba-related functions?~~ Extended Numba to support `np.clip`