### PR TITLE
Allow FrozenObjects to control param init order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,12 @@ Release History
   if you need to upgrade.
   (`#1481 <https://github.com/nengo/nengo/pull/1481>`__)
 
+**Fixed**
+
+- ``FrozenObjects`` can control parameter initialization order when copying,
+  which fixed a bug encountered when copying convolutional connections.
+  (`#1493 <https://github.com/nengo/nengo/pull/1493>`__)
+
 2.8.0 (June 9, 2018)
 ====================
 

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -378,3 +378,12 @@ def test_pickle_model(RefSimulator, seed):
     assert np.allclose(u1, u0, **tols)
     assert np.allclose(a1, a0, **tols)
     assert np.allclose(b1, b0, **tols)
+
+
+def test_copy_convolution():
+    x = nengo.Convolution(1, (2, 3, 4), channels_last=False)
+    y = copy(x)
+
+    assert x.n_filters == y.n_filters
+    assert x.input_shape == y.input_shape
+    assert x.channels_last == y.channels_last

--- a/nengo/tests/test_transforms.py
+++ b/nengo/tests/test_transforms.py
@@ -11,7 +11,13 @@ from nengo._vendor.npconv2d import conv2d
 @pytest.mark.parametrize("channels_last", (True, False))
 @pytest.mark.parametrize("fixed_kernel", (True, False))
 def test_convolution(
-        dimensions, padding, channels_last, fixed_kernel, Simulator, rng):
+        dimensions,
+        padding,
+        channels_last,
+        fixed_kernel,
+        Simulator,
+        rng,
+        seed):
     input_d = 4
     input_channels = 2
     output_channels = 5
@@ -32,7 +38,7 @@ def test_convolution(
         input_shape = tuple(np.roll(input_shape, 1))
         output_shape = tuple(np.roll(output_shape, 1))
 
-    with nengo.Network() as net:
+    with nengo.Network(seed=seed) as net:
         x = rng.randn(*input_shape)
         w = (rng.randn(*kernel_shape) if fixed_kernel
              else nengo.dists.Uniform(-0.1, 0.1))

--- a/nengo/transforms.py
+++ b/nengo/transforms.py
@@ -169,6 +169,8 @@ class Convolution(Transform):
     channels_last = BoolParam("channels_last")
     init = DistOrArrayParam("init")
 
+    _param_init_order = ["channels_last", "input_shape"]
+
     def __init__(self, n_filters, input_shape, kernel_size=(3, 3),
                  strides=(1, 1), padding="valid", channels_last=True,
                  init=nengo.dists.Uniform(-1, 1)):


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

With our Parameter validation system, sometimes parameters need to be initialized in a particular order.  When copying an object the order is random by default, so we need to impose an order on this.  We had this in place for ``NengoObjects``, but not for ``FrozenObjects``.  Previously this was fine because we didn't have any ``FrozenObjects`` where order mattered, but for the new ``Convolution`` object it does matter.

I also added a seed for the Convolution test.  I had a random test failure at some point that I wasn't able to reproduce again, so I'm not even 100% sure if it was real.  But adding a seed here doesn't hurt.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a new test that fails without this change and passes with it.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

