### PR TITLE
Copy small arrays in array_hash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,10 @@ Release History
 - ``FrozenObjects`` can control parameter initialization order when copying,
   which fixed a bug encountered when copying convolutional connections.
   (`#1493 <https://github.com/nengo/nengo/pull/1493>`__)
+- ``nengo.utils.numpy.array_hash`` now supports ``numpy<1.13`` for smaller
+  arrays, which fixed a bug where older environments sometimes encountered
+  issues when using array views for model parameters.
+  (`#1494 <https://github.com/nengo/nengo/pull/1494>`__)
 
 2.8.0 (June 9, 2018)
 ====================

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -69,7 +69,7 @@ def array_hash(a, n=100):
 
     if a.size < n:
         # hash all elements
-        v = a.view()
+        v = np.array(a)  # copy for numpy<1.13 (issue #1122)
         v.setflags(write=False)
         return hash(v.data if PY2 else v.data.tobytes())
     else:

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -69,7 +69,7 @@ def array_hash(a, n=100):
 
     if a.size < n:
         # hash all elements
-        v = np.array(a)  # copy for numpy<1.13 (issue #1122)
+        v = a.copy()  # for Python 2.7 and numpy<1.13 (issue #1122)
         v.setflags(write=False)
         return hash(v.data if PY2 else v.data.tobytes())
     else:

--- a/nengo/utils/tests/test_numpy.py
+++ b/nengo/utils/tests/test_numpy.py
@@ -25,7 +25,7 @@ def test_meshgrid_nd():
     assert np.allclose(expected, actual)
 
 
-@pytest.mark.parametrize("shape", [(5,), (10, 5), (500, 2)])
+@pytest.mark.parametrize("shape", [(5,), (10, 5), (200,), (500, 2)])
 def test_array_hash(shape):
     n = 100  # explicitly pass in array_hash default
     flat = np.arange(np.prod(shape))

--- a/nengo/utils/tests/test_numpy.py
+++ b/nengo/utils/tests/test_numpy.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
+import pytest
+
 import numpy as np
 
-from nengo.utils.numpy import meshgrid_nd
+from nengo.utils.numpy import meshgrid_nd, array_hash
 
 
 def test_meshgrid_nd():
@@ -21,3 +23,23 @@ def test_meshgrid_nd():
                   [[23, 42], [23, 42], [23, 42]]])]
     actual = meshgrid_nd(a, b, c)
     assert np.allclose(expected, actual)
+
+
+@pytest.mark.parametrize("shape", [(50,), (500, 2)])
+def test_array_hash(shape):
+    flat = np.arange(np.prod(shape))
+    a1 = flat.reshape(shape)
+    a2 = np.array(a1)
+
+    # (a1, a2) have same hash but copies of each other
+    assert a1 is not a2
+    assert np.all(a1 == a2)
+    assert array_hash(a1) == array_hash(a2)
+    assert not np.shares_memory(a1, a2)
+
+    # (a1, a3) have different hashes but reversed view
+    a3 = flat[::-1].reshape(shape)
+    assert a1 is not a3
+    assert not np.all(a1 == a3)
+    assert array_hash(a1) != array_hash(a3)
+    assert np.shares_memory(a1, a3)

--- a/nengo/utils/tests/test_numpy.py
+++ b/nengo/utils/tests/test_numpy.py
@@ -25,21 +25,22 @@ def test_meshgrid_nd():
     assert np.allclose(expected, actual)
 
 
-@pytest.mark.parametrize("shape", [(50,), (500, 2)])
+@pytest.mark.parametrize("shape", [(5,), (10, 5), (500, 2)])
 def test_array_hash(shape):
+    n = 100  # explicitly pass in array_hash default
     flat = np.arange(np.prod(shape))
     a1 = flat.reshape(shape)
-    a2 = np.array(a1)
+    a2 = a1.copy()
 
     # (a1, a2) have same hash but copies of each other
     assert a1 is not a2
     assert np.all(a1 == a2)
-    assert array_hash(a1) == array_hash(a2)
+    assert array_hash(a1, n) == array_hash(a2, n)
     assert not np.shares_memory(a1, a2)
 
     # (a1, a3) have different hashes but reversed view
-    a3 = flat[::-1].reshape(shape)
+    a3 = flat[::-1].reshape(shape)  # trigger issue #1122
     assert a1 is not a3
     assert not np.all(a1 == a3)
-    assert array_hash(a1) != array_hash(a3)
+    assert array_hash(a1, n) != array_hash(a3, n)
     assert np.shares_memory(a1, a3)


### PR DESCRIPTION
**Motivation and context:**
Closes #1122 issue with numpy<1.13 and Python 2.7.

**How has this been tested?**
Tested both cases in the code (small array and big array), and ran locally on the conda environment that had this issue:

```
cd nengo
conda create --name=py27 python=2.7 numpy=1.10 scipy=0.17.0
conda activate py27
python setup.py -q install
```

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
By reading issue #1122 and then proceeding to the fix (array copy) and tests.

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- (N/A) I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
