### PR TITLE
Fixes for pytest 4.1

### DIFF
--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -292,15 +292,15 @@ def pytest_generate_tests(metafunc):
 def pytest_collection_modifyitems(session, config, items):
     if config.getvalue('noexamples'):
         deselect_by_condition(
-            lambda item: getattr(item.obj, 'example', None), items, config)
+            lambda item: item.get_closest_marker("example"), items, config)
     if not config.getvalue('slow'):
         skip_slow = pytest.mark.skip("slow tests not requested")
         for item in items:
-            if getattr(item.obj, 'slow', None):
+            if item.get_closest_marker("slow"):
                 item.add_marker(skip_slow)
     if not TestConfig.compare_requested:
         deselect_by_condition(
-            lambda item: getattr(item.obj, 'compare', None), items, config)
+            lambda item: item.get_closest_marker("compare"), items, config)
 
     uses_sim = lambda item: 'Simulator' in item.fixturenames
     uses_refsim = lambda item: 'RefSimulator' in item.fixturenames
@@ -318,7 +318,7 @@ def pytest_collection_modifyitems(session, config, items):
             items, config)
 
     deselect_by_condition(
-        lambda item: getattr(item.obj, 'noassertions', None)
+        lambda item: item.get_closest_marker("noassertions")
         and not any(
             fixture in item.fixturenames and config.getvalue(option)
             for fixture, option in [


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

The 4.1.0 release of pytest broke some of our testing infrastructure, this fixes it.

Note that https://github.com/nengo/nengo/commit/35b213383a4e6385f186e5e5a48067a036936d2b is kind of a workaround fix.  Something in more recent pytest versions causes PermissionErrors when renaming the cache file (non-deterministically).  But my thinking is that if pytest can trigger that somehow, then users might be able to as well (and we already knew that this part of the code was error-prone, based on the comments in the code).  So rather than trying to avoid the problem on the pytest side, I just handled this additional PermissionError case.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Ran all the unit tests (with `--plots --logs --analytics --slow`) on pytest 4.1.0, everything passed.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
