### PR TITLE
Fix progress bar in Jupyter Lab.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,9 @@ Release History
 - Several objects had elements missing from their string representations.
   These strings are now automatically generated and tested to be complete.
   (`#1472 <https://github.com/nengo/nengo/pull/1472>`__)
+- Fixed the progress bar in recent Jupyter Lab versions.
+  (`#1499 <https://github.com/nengo/nengo/issues/1499>`_,
+  `#1500 <https://github.com/nengo/nengo/pull/1500>`_)
 
 2.8.0 (June 9, 2018)
 ====================

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -267,7 +267,7 @@ class TerminalProgressBar(ProgressBar):
         sys.stdout.flush()
 
 
-class VdomProgressBar(ProgressBar):
+class VdomProgressBar(ProgressBar):  # pragma: no cover
     """A progress bar using a virtual DOM representation.
 
     This HTML representation can be used in Jupyter lab (>=0.32) environments.
@@ -388,7 +388,7 @@ class VdomProgressBar(ProgressBar):
         }
 
 
-class HtmlProgressBar(ProgressBar):
+class HtmlProgressBar(ProgressBar):  # pragma: no cover
     """A progress bar using a HTML representation.
 
     This HTML representation can be used in Jupyter notebook environments
@@ -525,7 +525,7 @@ class HtmlProgressBar(ProgressBar):
         '''
 
 
-class VdomOrHtmlProgressBar(ProgressBar):
+class VdomOrHtmlProgressBar(ProgressBar):  # pragma: no cover
     """Progress bar using the VDOM or HTML progress bar.
 
     This progress bar will transmit both representations as part of a MIME
@@ -559,12 +559,12 @@ class VdomOrHtmlProgressBar(ProgressBar):
 
     def _get_update_bundle(self, progress):
         bundle = self._vdom._repr_mimebundle_([], [])
-        bundle['application/javascript'] = self._html._js_update(
-            progress)._repr_javascript_()
+        bundle['text/html'] = '<script>' + self._html._js_update(
+            progress)._repr_javascript_() + '</script>'
         return bundle
 
 
-class IPython5ProgressBar(ProgressBar):
+class IPython5ProgressBar(ProgressBar):  # pragma: no cover
     """ProgressBar for IPython>=5 environments.
 
     Provides a VDOM/HTML representation, except for in a pure terminal IPython


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->
The JavaScript renderer has a higher precedence than the vDOM renderer.
Thus the updates of VdomOrHtmlProgressBar were executing the JS updates
and not the vDOM updates in recent Jupyter Lab versions. By sending the
JavaScript embeded in HTML, the same renderers will be used for the
update as for the initial display which ensures consistency no matter
which renderer has precedence. (But the HTML renderer also has a lower
precedence than the vDOM renderer.)

Fixes #1499.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Manually in Jupyter Lab and Jupyter Notebook.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.