### PR TITLE
Seed backends

### DIFF
--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -99,6 +99,30 @@ def test_hierarchical_seeding():
         assert same1seeds[same1obj] == same2seeds[same2obj]
 
 
+def test_seed_override(seed):
+    """Test that seeds are not overwritten by the seeding function"""
+    with nengo.Network(seed=seed - 1) as net:
+        a = nengo.Ensemble(10, 1, seed=seed - 2)
+        b = nengo.Ensemble(10, 1, seed=seed + 2)
+
+    model = nengo.builder.Model()
+    model.seeds[net] = seed + 1
+    model.seeds[a] = seed + 2
+
+    # note: intentionally setting this to the 'wrong' value, to check that
+    # it isn't being overridden (things with seeds set should have seeded=True)
+    model.seeded[net] = False
+    model.seeded[a] = False
+
+    model.build(net)
+
+    assert model.seeds[net] == seed + 1
+    assert model.seeds[a] == seed + 2
+    assert not model.seeded[net]
+    assert not model.seeded[a]
+    assert np.allclose(model.params[a].gain, model.params[b].gain)
+
+
 def test_signal():
     """Make sure assert_named_signals works."""
     Signal(np.array(0.))


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

This makes seeding more accessible to backends. It separates out a seeding function for networks that backends can use. It respects existing values in the `model.seeds` and `model.seeded` dictionaries so that backends can set these for some (or all) objects and they won't be overwritten.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

This replaces #1476. 

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

There is a test making sure that values don't get overwritten. Otherwise, our current seeding tests cover this, and it's tested for backends in nengo/nengo-loihi#70.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
