### PR TITLE
Skip unsupported tests instead of xfail

### DIFF
--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -37,6 +37,7 @@ class TestConfig(object):
         Direct, LIF, LIFRate, RectifiedLinear, Sigmoid, SpikingRectifiedLinear
     ]
     compare_requested = False
+    run_unsupported = False
 
     @classmethod
     def is_sim_overridden(cls):
@@ -69,6 +70,7 @@ def pytest_configure(config):
         TestConfig.test_seed = config.getoption('seed_offset')[0]
 
     TestConfig.compare_requested = config.getvalue('compare') is not None
+    TestConfig.run_unsupported = config.getvalue('unsupported')
 
 
 def load_class(fully_qualified_name):
@@ -403,7 +405,10 @@ def pytest_runtest_setup(item):  # noqa: C901
             # We add a '*' before test to eliminate the surprise of needing
             # a '*' before the name of a test function.
             if fnmatch(item_name, '*' + test):
-                pytest.xfail(reason)
+                if TestConfig.run_unsupported:
+                    item.add_marker(pytest.mark.xfail)
+                else:
+                    pytest.skip(reason)
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/nengo/tests/options.py
+++ b/nengo/tests/options.py
@@ -26,3 +26,5 @@ def pytest_addoption(parser):
                      help="Specify offset of the seed values used in tests.")
     parser.addoption('--spa', action='store_true', default=False,
                      help='Run deprecated SPA tests')
+    parser.addoption('--unsupported', action='store_true', default=False,
+                     help='Run tests marked as unsupported by this backend.')

--- a/nengo/tests/test_pytest.py
+++ b/nengo/tests/test_pytest.py
@@ -1,8 +1,37 @@
 import nengo.utils.numpy as npext
 from nengo.conftest import TestConfig
 
+pytest_plugins = ["pytester"]
+
 
 def test_seed_fixture(seed):
     """The seed should be the same on all machines"""
     i = (seed - TestConfig.test_seed) % npext.maxint
     assert i == 1832276344
+
+
+def test_unsupported(testdir):
+    testdir.makeconftest(
+        """
+        import nengo.conftest
+
+        class MockSimulator(object):
+            unsupported = [('*', 'mock simulator')]
+
+        nengo.conftest.TestConfig.Simulator = MockSimulator
+        """)
+    outcomes = testdir.runpytest(
+        "-p", "nengo.tests.options", "--pyargs", "nengo",
+    ).parseoutcomes()
+    assert outcomes["skipped"] > 350
+    assert outcomes["deselected"] > 700
+    assert "passed" not in outcomes
+    assert "failed" not in outcomes
+
+    outcomes = testdir.runpytest(
+        "-p", "nengo.tests.options", "--pyargs", "nengo", "--unsupported",
+    ).parseoutcomes()
+    assert outcomes["xfailed"] > 350
+    assert outcomes["deselected"] > 700
+    assert "passed" not in outcomes
+    assert "failed" not in outcomes


### PR DESCRIPTION
When a simulator does not support a test, skip it instead of
xfailing. This does not actually change how the test is run,
because the way we were using xfail it would not actually
execute the test, so skip will do the same. Now tests will
be marked as skipped in the log, to differentiate them from
tests that are marked xfail and run (which could potentially xpass).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

When nengo_loihi is working with nengo master again, I will test it there.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- n/a I have updated the documentation accordingly.
- n/a I have included a changelog entry.
- n/a I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
- [x] test with nengo_loihi