### PR TITLE
Fix behaviour of non-compositional weight solvers

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -15,6 +15,7 @@ if [[ "$COMMAND" == "install" ]]; then
     conda install --quiet jupyter matplotlib numpy="$NUMPY"
     if [[ "$SCIPY" == "true" ]]; then
         conda install --quiet scipy
+        pip install scikit-learn
     fi
     pip install pytest
     pip install -e .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,10 @@ Release History
   <https://www.nengo.ai/nengo/getting_started.html#installing-numpy>`__
   if you need to upgrade.
   (`#1481 <https://github.com/nengo/nengo/pull/1481>`__)
+- Solvers are now explicitly marked as compositional or non-compositional
+  depending on whether they must act on full connection weight matrices
+  when solving for weights.
+  (`#1507 <https://github.com/nengo/nengo/pull/1507>`__)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,10 @@ Release History
   depending on whether they must act on full connection weight matrices
   when solving for weights.
   (`#1507 <https://github.com/nengo/nengo/pull/1507>`__)
+- Solvers no longer take encoders as an argument. Instead, encoders will
+  be applied to the targets before the solve function for compositional solvers
+  and applied by the Transform builder for non-compositional solvers.
+  (`#1507 <https://github.com/nengo/nengo/pull/1507>`__)
 
 **Fixed**
 

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -129,7 +129,7 @@ def build_decoders(model, conn, rng):
     return eval_points, decoders.T, solver_info
 
 
-def solve_for_decoders(conn, gain, bias, x, targets, rng, E=None):
+def solve_for_decoders(conn, gain, bias, x, targets, rng):
     activities = conn.pre_obj.neuron_type.rates(x, gain, bias)
     if np.count_nonzero(activities) == 0:
         raise BuildError(
@@ -137,7 +137,7 @@ def solve_for_decoders(conn, gain, bias, x, targets, rng, E=None):
             "This is because no evaluation points fall in the firing "
             "ranges of any neurons." % (conn, conn.pre_obj))
 
-    decoders, solver_info = conn.solver(activities, targets, rng=rng, E=E)
+    decoders, solver_info = conn.solver(activities, targets, rng=rng)
     return decoders, solver_info
 
 

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -486,30 +486,34 @@ class NoSolver(Solver):
 
     Parameters
     ----------
-    values : (n_neurons, n_weights) array_like, optional (Default: None)
-        The array of decoders or weights to use.
-        If ``weights`` is ``False``, ``n_weights`` is the expected
-        output dimensionality. If ``weights`` is ``True``,
-        ``n_weights`` is the number of neurons in the post ensemble.
+    values : (n_neurons, size_out) array_like, optional (Default: None)
+        The array of decoders to use.
+        ``size_out`` is the dimensionality of the decoded signal (determined
+        by the connection function).
         If ``None``, which is the default, the solver will return an
         appropriately sized array of zeros.
     weights : bool, optional (Default: False)
-        If False, ``values`` is interpreted as decoders.
-        If True, ``values`` is interpreted as weights.
+        If False, connection will use factored weights (decoders from this
+        solver, transform, and encoders).
+        If True, connection will use a full weight matrix (created by
+        linearly combining decoder, transform, and encoders).
 
     Attributes
     ----------
-    values : (n_neurons, n_weights) array_like, optional (Default: None)
-        The array of decoders or weights to use.
-        If ``weights`` is ``False``, ``n_weights`` is the expected
-        output dimensionality. If ``weights`` is ``True``,
-        ``n_weights`` is the number of neurons in the post ensemble.
+    values : (n_neurons, size_out) array_like, optional (Default: None)
+        The array of decoders to use.
+        ``size_out`` is the dimensionality of the decoded signal (determined
+        by the connection function).
         If ``None``, which is the default, the solver will return an
         appropriately sized array of zeros.
     weights : bool, optional (Default: False)
-        If False, ``values`` is interpreted as decoders.
-        If True, ``values`` is interpreted as weights.
+        If False, connection will use factored weights (decoders from this
+        solver, transform, and encoders).
+        If True, connection will use a full weight matrix (created by
+        linearly combining decoder, transform, and encoders).
     """
+
+    compositional = True
 
     values = NdarrayParam("values", optional=True, shape=("*", "*"))
 

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -23,7 +23,17 @@ logger = logging.getLogger(__name__)
 
 
 class Solver(with_metaclass(DocstringInheritor, FrozenObject)):
-    """Decoder or weight solver."""
+    """Decoder or weight solver.
+
+    A solver can be compositional or non-compositional. Non-compositional
+    solvers must operate on the whole neuron-to-neuron weight matrix, while
+    compositional solvers operate in the decoded state space, which is then
+    combined with transform/encoders to generate the full weight matrix.
+    See the solver's ``compositional`` class attribute to determine if it is
+    compositional.
+    """
+
+    compositional = True
 
     weights = BoolParam('weights')
 
@@ -242,6 +252,8 @@ class LstsqL1(Solver):
     This method is well suited for creating sparse decoders or weight matrices.
     """
 
+    compositional = False
+
     l1 = NumberParam('l1', low=0)
     l2 = NumberParam('l2', low=0)
 
@@ -311,6 +323,8 @@ class LstsqDrop(Solver):
     This solver first solves for coefficients (decoders/weights) with
     L2 regularization, drops those nearest to zero, and retrains remaining.
     """
+
+    compositional = False
 
     drop = NumberParam('drop', low=0, high=1)
     solver1 = SolverParam('solver1')
@@ -382,6 +396,8 @@ class Nnls(Solver):
     intercepts of the post-population are also non-negative, since neurons with
     negative intercepts will never be silent, affecting output accuracy.
     """
+
+    compositional = False
 
     def __init__(self, weights=False):
         """

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -14,7 +14,7 @@ from nengo.utils.numpy import rms, norm
 from nengo.utils.stdlib import Timer
 from nengo.utils.testing import allclose
 from nengo.solvers import (
-    lstsq, Lstsq, LstsqNoise, LstsqL2, LstsqL2nz,
+    lstsq, Lstsq, LstsqNoise, LstsqL2, LstsqL2nz, LstsqMultNoise,
     LstsqL1, LstsqDrop, Nnls, NnlsL2, NnlsL2nz, NoSolver)
 
 
@@ -96,7 +96,7 @@ def test_conjgrad(rng):
 
 
 @pytest.mark.parametrize('Solver', [
-    Lstsq, LstsqNoise, LstsqL2, LstsqL2nz, LstsqDrop])
+    Lstsq, LstsqNoise, LstsqL2, LstsqL2nz, LstsqDrop, LstsqMultNoise])
 def test_decoder_solver(Solver, plt, rng):
     solver = Solver()
 
@@ -121,7 +121,9 @@ def test_decoder_solver(Solver, plt, rng):
     plt.plot(test, test - est)
     plt.title("relative RMSE: %0.2e" % rel_rmse)
 
-    atol = 3.5e-2 if isinstance(solver, (LstsqNoise, LstsqDrop)) else 1.5e-2
+    atol = (4e-2
+            if isinstance(solver, (LstsqNoise, LstsqDrop, LstsqMultNoise))
+            else 1.5e-2)
     assert np.allclose(test, est, atol=atol, rtol=1e-3)
     assert rel_rmse < 0.02
 

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -171,7 +171,7 @@ def test_weight_solver(Solver, rng):
     W1 = np.dot(D, Eb)
 
     # find weights directly
-    W2, _ = Solver(weights=True)(Atrain, Xtrain, rng=rng, E=Eb)
+    W2, _ = Solver(weights=True)(Atrain, np.dot(Xtrain, Eb), rng=rng)
 
     # assert that post inputs are close on test points
     test = get_eval_points(n_points, dims, rng=rng)  # testing eval points


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

The pluggable transform builder approach assumes that the Transform build function is responsible for combining decoders, transform, and encoders to generate a full weight matrix.  However, certain solvers must operate on the full weight matrix, they cannot operate in the decoder space and then be linearly combined with transform/encoders.  So the new Transform API broke those solvers; this fixes the behaviour by adding a special case for these "non-compositional" solvers.

I also added a second commit that removes the encoders argument from all the solvers (since it isn't being used anymore).

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Alternate implementation of https://github.com/nengo/nengo/pull/1506

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Pulled in a slightly modified version of the test from https://github.com/nengo/nengo/pull/1506.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

The second commit is independent of the first (i.e., we could apply the non-compositional fix, but leave the encoder argument in as well).  So they can be treated relatively independently.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.