### PR TITLE
Use pytest config to specify unsupported tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,9 @@ Release History
 - The ``settled_firingrate`` function has been moved from
   ``nengo.utils.neurons`` to ``nengo.neurons``.
   (`#1187 <https://github.com/nengo/nengo/pull/1187>`_)
+- Added new pytest config option, ``nengo_test_unsupported`` (replacing the
+  previous ``Simulator.unsupported`` functionality).
+  (`#1521 <https://github.com/nengo/nengo/pull/1521>`_)
 
 **Deprecated**
 

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -130,15 +130,6 @@ class Simulator(object):
 
     """
 
-    # 'unsupported' defines features unsupported by a simulator.
-    # The format is a list of tuples of the form `(test, reason)` with `test`
-    # being a string with wildcards (*, ?, [abc], [!abc]) matched against Nengo
-    # test paths and names, and `reason` is a string describing why the feature
-    # is not supported by the backend. For example:
-    #     unsupported = [('test_pes*', 'PES rule not implemented')]
-    # would skip all test whose names start with 'test_pes'.
-    unsupported = []
-
     def __init__(
             self, network,
             dt=0.001, seed=None, model=None, progress_bar=True, optimize=True):

--- a/nengo/tests/options.py
+++ b/nengo/tests/options.py
@@ -1,3 +1,39 @@
+"""Nengo-specific pytest options.
+
+Unsupported tests
+-----------------
+The ``nengo_test_unsupported`` option allows you to specify Nengo tests
+unsupported by a particular simulator.
+This is used if you are writing a backend and want to ignore
+tests for functions that your backend currently does not support.
+
+Each line represents one test pattern to skip,
+and must be followed by a line containing a string in quotes
+denoting the reason for skipping the test(s).
+
+The pattern uses
+`Unix filename pattern matching
+<https://docs.python.org/3/library/fnmatch.html>`_,
+including wildcard characters ``?`` and ``*`` to match one or more characters.
+The pattern matches to the test name,
+which is the same as the pytest ``nodeid``
+seen when calling pytest with the ``-v`` argument,
+except that only one colon ``:`` is used between file path and function name
+rather than the two colons ``::`` used by ``nodeid``.
+
+.. code-block:: ini
+
+   nengo_test_unsupported =
+       nengo/tests/test_file_path.py:test_function_name
+           "This is a message giving the reason we skip this test"
+       nengo/tests/test_file_two.py:test_other_thing
+           "This is a test with a multi-line reason for skipping.
+           Make sure to use quotes around the whole string (and not inside)."
+       nengo/tests/test_file_two.py:test_parametrized_thing[param_value]
+           "This skips a parametrized test with a specific parameter value."
+"""
+
+
 def pytest_addoption(parser):
     parser.addoption('--simulator', nargs=1, type=str, default=None,
                      help='Specify simulator under test.')
@@ -26,5 +62,9 @@ def pytest_addoption(parser):
                      help="Specify offset of the seed values used in tests.")
     parser.addoption('--spa', action='store_true', default=False,
                      help='Run deprecated SPA tests')
-    parser.addoption('--unsupported', action='store_true', default=False,
-                     help='Run tests marked as unsupported by this backend.')
+    parser.addoption(
+        '--unsupported', action='store_true', default=False,
+        help='Run (with xfail) tests marked as unsupported by this backend.')
+    parser.addini("nengo_test_unsupported", type="linelist",
+                  help="List of unsupported unit tests with reason for "
+                       "exclusion")


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Currently when backends run the nengo test suite they can mark tests that they don't support through the `Simulator.unsupported` attribute.  This moves that setting to the pytest config file (e.g. `pytest.ini` or `setup.cfg`), instead of it being a Simulator attribute.  This keeps test-specific configuration together in one place, and doesn't clutter the Simulator source code with a large, non-obvious data structure.

We had originally talked about making this backwards compatible, but after thinking about it more I don't think that is necessary.  If backends want to be backwards compatible they will still need to support the `Simulator.unsupported` approach in any case, and if they don't want to be backwards compatible then there is no need to make Nengo backwards compatible.  In any case, I did it in a backwards compatible way so that people can see, and then the fixup commit removes that.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

This is based on a commit from https://github.com/nengo/nengo/pull/1477, so we can remove it from the history there after this is merged.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a test, and I also created a branch in `nengo-dl` to verify that backends can use this new approach to support Nengo master and Nengo <= 2.8.0.  Can see what that looks like in this commit https://github.com/nengo/nengo-dl/commit/9d2425663e5bf8dd3dcef4aa9f46f48db22eace8.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)=

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Breaking change (fix or feature that causes existing functionality to change)
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
