### PR TITLE
Add Trove classifier Framework :: Nengo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     },
     classifiers=[  # https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "Development Status :: 5 - Production/Stable",
+        "Framework :: Nengo",
         "Intended Audience :: Science/Research",
         "License :: Free for non-commercial use",
         "Operating System :: OS Independent",


### PR DESCRIPTION
The Trove classifier `Framework :: Nengo` has been added to https://pypi.org/classifiers/
via https://github.com/pypa/warehouse/issues/5628.

**Motivation and context:**
This solves the issue of adding the new Trove classifier `Framework :: Nengo` so that it will appear [here](https://pypi.org/search/?c=Framework+%3A%3A+Nengo) on the next release.

**Interactions with other PRs:**
May experience conflicts after #1514 and #1520 are merged in since they also touch `setup.py`.

**How has this been tested?**
Tested by going to https://pypi.org/classifiers/ and observing that `Framework :: Nengo` is in the list.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [N/A] I have updated the documentation accordingly.
- [N/A] I have included a changelog entry.
- [N/A] I have added tests to cover my changes.
- [N/A] I have run the test suite locally and all tests passed.