### PR TITLE
Fix bug with transform shape errors

### DIFF
--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -223,7 +223,8 @@ class ConnectionTransformParam(Parameter):
             transform = Dense((conn.size_out, conn.size_mid), transform)
 
         if transform.size_in != conn.size_mid:
-            if isinstance(transform, Dense) and transform.ndim < 2:
+            if isinstance(transform, Dense) and (
+                    transform.shape[0] == transform.shape[1]):
                 # we provide a different error message in this case;
                 # the transform is not changing the dimensionality of the
                 # signal, so the blame most likely lies with the function

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -6,10 +6,11 @@ import pytest
 import nengo
 import nengo.utils.numpy as npext
 from nengo.connection import ConnectionSolverParam
-from nengo.dists import UniformHypersphere
+from nengo.dists import Choice, UniformHypersphere
 from nengo.exceptions import BuildError, ObsoleteError, ValidationError
 from nengo.solvers import LstsqL2
 from nengo.processes import Piecewise
+from nengo.transforms import Dense
 from nengo.utils.testing import allclose
 
 
@@ -384,36 +385,49 @@ def test_dimensionality_errors(nl_nodirect, seed, rng):
         nengo.Connection(e2, e2, transform=np.ones(2))
 
         # these should not work
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="Shape of initial value"):
             nengo.Connection(n02, e1)
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="Shape of initial value"):
             nengo.Connection(e1, e2)
+        with pytest.raises(ValidationError, match="Transform input size"):
+            nengo.Connection(e2.neurons, e1,
+                             transform=Dense((1, N+1), init=Choice([1.])))
+        with pytest.raises(ValidationError, match="Transform output size"):
+            nengo.Connection(e2.neurons, e1,
+                             transform=Dense((2, N), init=Choice([1.])))
+        with pytest.raises(ValidationError, match=""):
+            nengo.Connection(e2, e1, function=lambda x: x,
+                             transform=Dense((1, 1)))
         with pytest.raises(ValidationError):
-            nengo.Connection(e2.neurons, e1, transform=rng.randn(1, N+1))
-        with pytest.raises(ValidationError):
-            nengo.Connection(e2.neurons, e1, transform=rng.randn(2, N))
-        with pytest.raises(ValidationError):
-            nengo.Connection(e2, e1, function=lambda x: x, transform=[[1]])
-        with pytest.raises(ValidationError):
-            nengo.Connection(e2, e1, function=lambda: 0, transform=[[1]])
-        with pytest.raises(ValidationError):
-            nengo.Connection(n21, e2, transform=np.ones((2, 2)))
-        with pytest.raises(ValidationError):
+            nengo.Connection(e2, e1, function=lambda: 0,
+                             transform=Dense((1, 1)))
+        with pytest.raises(ValidationError, match="Function output size"):
+            nengo.Connection(n21, e2, transform=Dense((2, 2)))
+        with pytest.raises(ValidationError, match="Shape of initial value"):
             nengo.Connection(e2, e2, transform=np.ones((2, 2, 2)))
-        with pytest.raises(ValidationError):
-            nengo.Connection(e2, e2, transform=np.ones(3))
+        with pytest.raises(ValidationError, match="Function output size"):
+            nengo.Connection(e1, e2, transform=Dense((3, 3), init=np.ones(3)))
 
         # these should not work because of indexing mismatches
-        with pytest.raises(ValidationError):
-            nengo.Connection(n02[0], e2)
-        with pytest.raises(ValidationError):
-            nengo.Connection(n02, e2[0])
-        with pytest.raises(ValidationError):
-            nengo.Connection(n02[1], e2[0], transform=[[1, 2], [3, 4]])
-        with pytest.raises(ValidationError):
-            nengo.Connection(n02, e2[0], transform=[[1], [2]])
-        with pytest.raises(ValidationError):
-            nengo.Connection(e2[0], e2, transform=[[1, 2]])
+        with pytest.raises(ValidationError, match="Function output size"):
+            nengo.Connection(n02[0], e2, transform=Dense((2, 2)))
+        with pytest.raises(ValidationError, match="Transform output size"):
+            nengo.Connection(n02, e2[0], transform=Dense((2, 2)))
+        with pytest.raises(ValidationError, match="Function output size"):
+            nengo.Connection(n02[1], e2[0], transform=Dense((2, 2)))
+        with pytest.raises(ValidationError, match="Transform input size"):
+            nengo.Connection(n02, e2[0],
+                             transform=Dense((2, 1), init=Choice([1.])))
+        with pytest.raises(ValidationError, match="Transform input size"):
+            nengo.Connection(e2[0], e2,
+                             transform=Dense((1, 2), init=Choice([1.])))
+
+        # these should not work because of repeated indices
+        dense22 = Dense((2, 2), init=np.ones((2, 2)))
+        with pytest.raises(ValidationError, match="Input.*repeated indices"):
+            nengo.Connection(n02[[0, 0]], e2, transform=dense22)
+        with pytest.raises(ValidationError, match="Output.*repeated indices"):
+            nengo.Connection(e2, e2[[1, 1]], transform=dense22)
 
 
 def test_slicing(Simulator, nl, plt, seed):


### PR DESCRIPTION
We were checking for the `ndim` attribute on Dense transforms,
which does not exist.

Also fixed up `test_connection.test_dimensionality_errors` to look
for specific exceptions, so that we don't miss errors like this
in the future.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Fixed up the tests so they should be checking all `ValidationErrors` in `ConnectionTransformParam` now.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
