### PR TITLE
Solver documentation fixup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,8 +102,8 @@ Release History
   when solving for weights.
   (`#1507 <https://github.com/nengo/nengo/pull/1507>`__)
 - Solvers no longer take encoders as an argument. Instead, encoders will
-  be applied to the targets before the solve function for compositional solvers
-  and applied by the Transform builder for non-compositional solvers.
+  be applied to the targets before the solve function for non-compositional
+  solvers and applied by the Transform builder for compositional solvers.
   (`#1507 <https://github.com/nengo/nengo/pull/1507>`__)
 - Example Jupyter notebooks have been upgraded to notebook format 4.
   (`#1440 <https://github.com/nengo/nengo/pull/1440>`_)

--- a/docs/frontend_api.rst
+++ b/docs/frontend_api.rst
@@ -247,6 +247,7 @@ Decoder and connection weight solvers
    nengo.utils.least_squares_solvers.RandomizedSVD
 
 .. automodule:: nengo.solvers
+   :no-members:
 
 .. autoclass:: nengo.solvers.Solver
    :special-members: __call__

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -157,19 +157,6 @@ def solve_for_decoders(conn, gain, bias, x, targets, rng):
     return decoders, solver_info
 
 
-def multiply(x, y):
-    if x.ndim <= 2 and y.ndim < 2:
-        return x * y
-    elif x.ndim < 2 and y.ndim == 2:
-        return x.reshape(-1, 1) * y
-    elif x.ndim == 2 and y.ndim == 2:
-        return np.dot(x, y)
-    else:
-        raise BuildError(
-            "Tensors not supported (x.ndim = %d, y.ndim = %d)" % (x.ndim, y.ndim)
-        )
-
-
 def slice_signal(model, signal, sl):
     assert signal.ndim == 1
     if isinstance(sl, slice) and (sl.step is None or sl.step == 1):


### PR DESCRIPTION
**Motivation and context:**
Fixes changelog and improves documentation of base solver class (confused me while I was looking into https://github.com/nengo/nengo/issues/1539).

**Interactions with other PRs:**
None

**How has this been tested?**
N/A

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [N/A] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Todo:**
 - [x] I think the solver docstring can be improved. In particular, `non-compositional` solvers don't necessarily work with neuron-to-neuron weight matrices if `weights=False`? This docstring makes the case sound different: https://github.com/nengo/nengo/blob/18c13fb417748630c9f07d329031de59b7d8353a/nengo/solvers.py#L21-L26