### PR TITLE
Add SpikingRectifiedLinear to cache whitelist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -190,6 +190,8 @@ Release History
 - Some higher-order ``LinearFilter`` synapses had unnecessary delays
   that have now been removed.
   (`#1535 <https://github.com/nengo/nengo/pull/1535>`__)
+- Models using the ``SpikingRectifiedLinear`` neuron type now have their
+  decoders cached. (`#1550 <https://github.com/nengo/nengo/pull/1550>`__)
 
 2.8.0 (June 9, 2018)
 ====================

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -29,6 +29,7 @@ from nengo.neurons import (
     LIFRate,
     RectifiedLinear,
     Sigmoid,
+    SpikingRectifiedLinear,
 )
 from nengo.rc import rc
 from nengo.solvers import (
@@ -172,10 +173,11 @@ class Fingerprint:
         LIFRate,
         RectifiedLinear,
         Sigmoid,
+        SpikingRectifiedLinear,
     )
 
     WHITELIST = set(
-        (bool, float, complex, bytes, list, tuple, np.ndarray, int, str)
+        (type(None), bool, float, complex, bytes, list, tuple, np.ndarray, int, str)
         + SOLVERS
         + LSTSQ_METHODS
         + NEURON_TYPES


### PR DESCRIPTION
Previously ensembles with this neuron type would not have its decoders cached.

**Motivation and context:**
Closes #1549.

**How has this been tested?**
Added a unit test for this isolated incident as a short-term solution.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [N/A] I have updated the documentation accordingly.
- [N/A] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.