### PR TITLE
Fix warnings raised in recent pytest versions

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -74,6 +74,9 @@ setup_cfg:
       - "ignore:Skipping some optimization steps"
       - "ignore:SciPy is not installed"
       - "ignore:numpy.(dtype|ufunc) size changed"
+      - "ignore:Object <BasalGanglia \"bg\"> has already been built"
+      - "ignore:Object <Thalamus \"thalamus\"> has already been built"
+      - "ignore:IPython.core.inputsplitter is deprecated"
     markers:
       example:
         Mark a test as an example.
@@ -82,6 +85,10 @@ setup_cfg:
         analytics data are produced.
       slow:
         Mark a test as slow to skip it per default.
+      benchmark:
+        Mark a test as running a small benchmark.
+      compare:
+        Mark a test as comparing previous test runs.
   pylint:
     ignore:
       - _vendor

--- a/docs/examples/advanced/matrix_multiplication.ipynb
+++ b/docs/examples/advanced/matrix_multiplication.ipynb
@@ -116,8 +116,8 @@
     "print(transformB)\n",
     "\n",
     "with model:\n",
-    "    nengo.Connection(A.output, C.A, transform=transformA)\n",
-    "    nengo.Connection(B.output, C.B, transform=transformB)\n",
+    "    nengo.Connection(A.output, C.input_a, transform=transformA)\n",
+    "    nengo.Connection(B.output, C.input_b, transform=transformB)\n",
     "    C_probe = nengo.Probe(C.output, sample_every=0.01, synapse=0.01)"
    ]
   },

--- a/nengo/conftest.py
+++ b/nengo/conftest.py
@@ -123,12 +123,12 @@ def recorder_dirname(request, name):
         return None
 
     simulator, nl = TestConfig.RefSimulator, None
-    if 'Simulator' in request.funcargnames:
+    if 'Simulator' in request.fixturenames:
         simulator = request.getfixturevalue('Simulator')
     # 'nl' stands for the non-linearity used in the neuron equation
-    if 'nl' in request.funcargnames:
+    if 'nl' in request.fixturenames:
         nl = request.getfixturevalue('nl')
-    elif 'nl_nodirect' in request.funcargnames:
+    elif 'nl_nodirect' in request.fixturenames:
         nl = request.getfixturevalue('nl_nodirect')
 
     dirname = "%s.%s" % (simulator.__module__, name)
@@ -290,10 +290,10 @@ def pytest_generate_tests(metafunc):
                 'ignore:overflow encountered in exp')] + marks)
         return nl
 
-    if "nl" in metafunc.funcargnames:
+    if "nl" in metafunc.fixturenames:
         metafunc.parametrize(
             "nl", [mark_nl(nl) for nl in TestConfig.neuron_types])
-    if "nl_nodirect" in metafunc.funcargnames:
+    if "nl_nodirect" in metafunc.fixturenames:
         nodirect = [mark_nl(n) for n in TestConfig.neuron_types
                     if n is not Direct]
         metafunc.parametrize("nl_nodirect", nodirect)

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -130,9 +130,6 @@ def export_py(nb, dest_path=None):
         ind1 = body.find("\n", ind0)
         body = body[:ind0] + body[(ind1 + 1):]
 
-    if "plt" in body:
-        body += "\nplt.show()\n"
-
     if dest_path is not None:
         with io.open(dest_path, 'w', encoding='utf-8') as f:
             f.write(body)

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -12,7 +12,7 @@ import time
 import weakref
 
 
-class WeakKeyDefaultDict(collections.MutableMapping):
+class WeakKeyDefaultDict(collections.abc.MutableMapping):
     """WeakKeyDictionary that allows to define a default."""
 
     def __init__(self, default_factory, items=None, **kwargs):
@@ -41,7 +41,7 @@ class WeakKeyDefaultDict(collections.MutableMapping):
         return len(self._data)
 
 
-class WeakKeyIDDictionary(collections.MutableMapping):
+class WeakKeyIDDictionary(collections.abc.MutableMapping):
     """WeakKeyDictionary that uses object ID to hash.
 
     This ignores the ``__eq__`` and ``__hash__`` functions on objects,
@@ -126,7 +126,7 @@ class WeakKeyIDDictionary(collections.MutableMapping):
             self.update(kwargs)
 
 
-class WeakSet(collections.MutableSet):
+class WeakSet(collections.abc.MutableSet):
     """Uses weak references to store the items in the set."""
 
     def __init__(self, items=None):
@@ -230,7 +230,7 @@ def groupby(objects, key, hashable=None, force_list=True):
         # get first item without advancing iterator, and see if key is hashable
         objects, objects2 = itertools.tee(iter(objects))
         item0 = next(objects2)
-        hashable = isinstance(key(item0), collections.Hashable)
+        hashable = isinstance(key(item0), collections.abc.Hashable)
 
     if hashable:
         # use a dictionary to sort by hash (faster)

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,12 +63,17 @@ markers =
     example: Mark a test as an example.
     noassertions: Mark a test without assertions. It will only be run if plots or analytics data are produced.
     slow: Mark a test as slow to skip it per default.
+    benchmark: Mark a test as running a small benchmark.
+    compare: Mark a test as comparing previous test runs.
 filterwarnings =
     ignore::ImportWarning
     ignore:(Buffer|Memory|The nengo\.spa):DeprecationWarning
     ignore:Skipping some optimization steps
     ignore:SciPy is not installed
     ignore:numpy.(dtype|ufunc) size changed
+    ignore:Object <BasalGanglia "bg"> has already been built
+    ignore:Object <Thalamus "thalamus"> has already been built
+    ignore:IPython.core.inputsplitter is deprecated
 
 [pylint]
 # note: pylint doesn't look in setup.cfg by default, need to call it with


### PR DESCRIPTION
**Motivation and context:**

While these come up as warnings for me locally, it seems as though they can be raised as errors on TravisCI (see [this build](https://travis-ci.org/nengo/nengo/jobs/556416311)).

The only warnings not fixed are in third party packages or SPA. Since nengo.SPA is deprecated and will be removed in the future, we will ignore these warnings for now.

**Interactions with other PRs:**
#1387 is blocked until this is merged.

**How has this been tested?**
Ran the tests, saw that no warnings were raised.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
