### PR TITLE
Fix spa deselection when running through pyargs

### DIFF
--- a/pytest_nengo.py
+++ b/pytest_nengo.py
@@ -171,7 +171,7 @@ def pytest_collection_modifyitems(session, config, items):
             if item.get_closest_marker("slow"):
                 item.add_marker(skip_slow)
     if not config.getvalue("spa"):
-        deselect_by_condition(lambda item: "/spa/tests" in item.nodeid, items, config)
+        deselect_by_condition(lambda item: "spa/tests" in item.nodeid, items, config)
 
 
 def pytest_report_collectionfinish(config, startdir, items):


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

When running the tests directly the `nodeid` is `nengo/a/folder/test.py`, but when running through `--pyargs nengo` the `nodeid` is `a/folder/test.py`. This may be a bug on pytest's end, or intended behaviour, it seems unclear (see https://github.com/pytest-dev/pytest/issues/3714).

Anyway, this meant that the `/spa/tests` condition wasn't working when running through `pyargs` (because there was no leading `/`).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Ran the tests through `--pyargs nengo`, confirmed that spa tests actually were deselected.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.