### PR TITLE
Guard against zero-length encoders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -163,6 +163,11 @@ Release History
 - The ``nengo_test_unsupported`` option now uses pytest nodeids for the test names
   (the main change is that this means a double ``::`` between file and function names).
   (`#1566 <https://github.com/nengo/nengo/pull/1566>`__)
+- ``Signals`` will now raise an error if their initial value contains NaNs.
+  (`#1571 <https://github.com/nengo/nengo/pull/1571>`__)
+- The builder will now raise an error if any encoders are NaN,
+  which can occur if an encoder has length zero.
+  (`#1571 <https://github.com/nengo/nengo/pull/1571>`__)
 
 **Deprecated**
 

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -189,6 +189,12 @@ def build_ensemble(model, ens):
         encoders = npext.array(ens.encoders, min_dims=2, dtype=rc.float_dtype)
     if ens.normalize_encoders:
         encoders /= npext.norm(encoders, axis=1, keepdims=True)
+    if np.any(np.isnan(encoders)):
+        raise BuildError(
+            "NaNs detected in %r encoders. This usually means that you had zero-length "
+            "encoders that were normalized, resulting in NaNs. Ensure all encoders "
+            "have non-zero length, or set `normalize_encoders=False`." % ens
+        )
 
     # Build the neurons
     gain, bias, max_rates, intercepts = get_gain_bias(ens, rng, dtype=rc.float_dtype)

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -692,7 +692,7 @@ class BsrDotInc(DotInc):
     """
 
     def __init__(self, A, X, Y, indices, indptr, reshape=None, tag=None):
-        from scipy.sparse import bsr_matrix
+        from scipy.sparse import bsr_matrix  # pylint: disable=import-outside-toplevel
 
         self.bsr_matrix = bsr_matrix
 

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -671,7 +671,9 @@ class DotIncMerger(Merger):
                 base=A,
                 offset=i * A.itemsize * np.prod(A.shape[1:]),
             )
-            assert np.all(s.initial_value == A_sigr[s].initial_value)
+            assert np.allclose(
+                s.initial_value, A_sigr[s].initial_value, atol=0, rtol=0, equal_nan=True
+            )
             assert s.shape == A_sigr[s].shape or (
                 s.shape == () and A_sigr[s].shape == (1, 1)
             )

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -617,7 +617,9 @@ class DotIncMerger(Merger):
         try:
             # Not using check() for A, because A must not be a view.
             SigMerger.check_signals([op1.A, op2.A])
-            from scipy.sparse import bsr_matrix
+            from scipy.sparse import (  # pylint: disable=import-outside-toplevel
+                bsr_matrix,
+            )
 
             assert bsr_matrix
         except ImportError:

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -61,7 +61,7 @@ class Signal:
         offset=0,
     ):
         if self.assert_named_signals:
-            assert name
+            assert name is not None
         self._name = name
 
         if initial_value is None:

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -71,6 +71,11 @@ class Signal:
             assert initial_value.shape == shape
 
         self._initial_value = initial_value
+        if np.any(
+            np.isnan(self._initial_value.data if self.sparse else self._initial_value)
+        ):
+            raise SignalError("%r contains NaNs." % self)
+
         if self.sparse:
             assert initial_value.ndim == 2
             assert offset == 0

--- a/nengo/builder/tests/test_optimizer.py
+++ b/nengo/builder/tests/test_optimizer.py
@@ -22,24 +22,22 @@ def test_sigmerger_check():
     assert not SigMerger.check([Signal(0), Signal(1)])
 
     # compatible along first axis
-    assert SigMerger.check([Signal(np.empty((1, 2))), Signal(np.empty((2, 2)))])
+    assert SigMerger.check([Signal(shape=(1, 2)), Signal(shape=(2, 2))])
 
     # compatible along second axis
-    assert SigMerger.check([Signal(np.empty((2, 1))), Signal(np.empty((2, 2)))], axis=1)
-    assert not SigMerger.check(
-        [Signal(np.empty((2, 1))), Signal(np.empty((2, 2)))], axis=0
-    )
+    assert SigMerger.check([Signal(shape=(2, 1)), Signal(shape=(2, 2))], axis=1)
+    assert not SigMerger.check([Signal(shape=(2, 1)), Signal(shape=(2, 2))], axis=0)
 
     # shape mismatch
-    assert not SigMerger.check([Signal(np.empty((2,))), Signal(np.empty((2, 2)))])
+    assert not SigMerger.check([Signal(shape=(2,)), Signal(shape=(2, 2))])
 
     # mixed dtype
     assert not SigMerger.check(
-        [Signal(np.empty(2, dtype=int)), Signal(np.empty(2, dtype=float))]
+        [Signal(np.zeros(2, dtype=int)), Signal(np.zeros(2, dtype=float))]
     )
 
-    s1 = Signal(np.empty(5))
-    s2 = Signal(np.empty(5))
+    s1 = Signal(shape=(5,))
+    s2 = Signal(shape=(5,))
 
     # mixed signal and view
     assert not SigMerger.check([s1, s1[:3]])
@@ -70,36 +68,32 @@ def test_sigmerger_check_signals():
         SigMerger.check_signals([Signal(0), Signal(1)])
 
     # compatible along first axis
-    SigMerger.check_signals([Signal(np.empty((1, 2))), Signal(np.empty((2, 2)))])
+    SigMerger.check_signals([Signal(shape=(1, 2)), Signal(shape=(2, 2))])
 
     # compatible along second axis
-    SigMerger.check_signals(
-        [Signal(np.empty((2, 1))), Signal(np.empty((2, 2)))], axis=1
-    )
+    SigMerger.check_signals([Signal(shape=(2, 1)), Signal(shape=(2, 2))], axis=1)
     with pytest.raises(ValueError):
-        SigMerger.check_signals(
-            [Signal(np.empty((2, 1))), Signal(np.empty((2, 2)))], axis=0
-        )
+        SigMerger.check_signals([Signal(shape=(2, 1)), Signal(shape=(2, 2))], axis=0)
 
     # shape mismatch
     with pytest.raises(ValueError):
-        SigMerger.check_signals([Signal(np.empty((2,))), Signal(np.empty((2, 2)))])
+        SigMerger.check_signals([Signal(shape=(2,)), Signal(shape=(2, 2))])
 
     # mixed dtype
     with pytest.raises(ValueError):
         SigMerger.check_signals(
-            [Signal(np.empty(2, dtype=int)), Signal(np.empty(2, dtype=float))]
+            [Signal(np.zeros(2, dtype=int)), Signal(np.zeros(2, dtype=float))]
         )
 
     # compatible views
-    s = Signal(np.empty(5))
+    s = Signal(shape=(5,))
     with pytest.raises(ValueError):
         SigMerger.check_signals([s[:2], s[2:]])
 
 
 def test_sigmerger_check_views():
-    s1 = Signal(np.empty((5, 5)))
-    s2 = Signal(np.empty((5, 5)))
+    s1 = Signal(shape=(5, 5))
+    s2 = Signal(shape=(5, 5))
 
     # compatible along first axis
     SigMerger.check_views([s1[:1], s1[1:]])

--- a/nengo/builder/tests/test_signal.py
+++ b/nengo/builder/tests/test_signal.py
@@ -376,3 +376,10 @@ def test_signal_shape():
     Signal(np.zeros(shape), shape=shape)
     with pytest.raises(AssertionError):
         Signal(np.zeros((2, 3)), shape=shape)
+
+
+def tests_signal_nan():
+    with_nan = np.ones(4)
+    with_nan[1] = np.nan
+    with pytest.raises(SignalError, match="contains NaNs"):
+        Signal(initial_value=with_nan)

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -423,7 +423,7 @@ class SqrtBeta(Distribution):
         cdf : array_like
             Probability that ``X <= x``.
         """
-        from scipy.special import betainc
+        from scipy.special import betainc  # pylint: disable=import-outside-toplevel
 
         sq_x = x * x
         return np.where(
@@ -445,7 +445,7 @@ class SqrtBeta(Distribution):
         pdf : array_like
             Probability density at ``x``.
         """
-        from scipy.special import beta
+        from scipy.special import beta  # pylint: disable=import-outside-toplevel
 
         return (
             2
@@ -469,7 +469,7 @@ class SqrtBeta(Distribution):
         ppf : array_like
             Evaluation points ``x`` in [0, 1] such that ``P(X <= x) = y``.
         """
-        from scipy.special import betaincinv
+        from scipy.special import betaincinv  # pylint: disable=import-outside-toplevel
 
         sq_x = betaincinv(self.m / 2.0, self.n / 2.0, y)
         return np.sqrt(sq_x)

--- a/nengo/spa/utils.py
+++ b/nengo/spa/utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import nengo
 import nengo.utils.numpy as npext
 from nengo.exceptions import ValidationError
-from nengo.spa.vocab import VocabularyParam
+from nengo.spa.vocab import Vocabulary, VocabularyParam
 
 
 def enable_spa_params(model):
@@ -40,7 +40,6 @@ def similarity(data, vocab, normalize=False):
     normalize : bool, optional
         Whether to normalize all vectors, to compute the cosine similarity.
     """
-    from nengo.spa.vocab import Vocabulary
 
     if isinstance(vocab, Vocabulary):
         vectors = vocab.vectors

--- a/nengo/tests/test_builder.py
+++ b/nengo/tests/test_builder.py
@@ -138,5 +138,6 @@ def test_build_twice():
     model.build(ens)
     built_ens = model.params[ens]
 
-    assert model.build(ens) is None
+    with pytest.warns(UserWarning, match="has already been built"):
+        assert model.build(ens) is None
     assert model.params[ens] is built_ens

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -54,6 +54,14 @@ def test_encoders_no_dimensions(Simulator, seed, allclose):
         test_encoders(Simulator, 0, seed=seed, allclose=allclose)
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
+def test_encoder_all_zero(Simulator, seed, allclose):
+    with pytest.raises(BuildError, match="zero-length encoders"):
+        test_encoders(
+            Simulator, 1, seed=seed, allclose=allclose, encoders=np.zeros((10, 1))
+        )
+
+
 def test_constant_scalar(Simulator, nl, plt, seed, allclose):
     """A Network that represents a constant value."""
     N = 30

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -99,6 +99,8 @@ def eval_point_decoding(conn, sim, eval_points=None):
     decoded : ndarray (N, D)
         The decoded function value at each evaluation point.
     """
+    # pylint: disable=import-outside-toplevel
+    # note: these are imported here to avoid circular imports
     from nengo.builder.ensemble import get_activities
     from nengo.builder.connection import get_targets
 

--- a/nengo/utils/ensemble.py
+++ b/nengo/utils/ensemble.py
@@ -40,7 +40,10 @@ def tuning_curves(ens, sim, inputs=None):
     --------
     response_curves
     """
-    from nengo.builder.ensemble import get_activities
+    # note: imported here to avoid circular imports
+    from nengo.builder.ensemble import (  # pylint: disable=import-outside-toplevel
+        get_activities,
+    )
 
     if inputs is None:
         inputs = np.linspace(-ens.radius, ens.radius)

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -329,7 +329,9 @@ class RandomizedSVD(LeastSquaresSolver):
     n_iter = IntParam("n_iter", low=0)
 
     def __init__(self, n_components=60, n_oversamples=10, n_iter=0):
-        from sklearn.utils.extmath import randomized_svd
+        from sklearn.utils.extmath import (  # pylint: disable=import-outside-toplevel
+            randomized_svd,
+        )
 
         assert randomized_svd
         super().__init__()
@@ -338,7 +340,9 @@ class RandomizedSVD(LeastSquaresSolver):
         self.n_iter = n_iter
 
     def __call__(self, A, Y, sigma, rng=np.random):
-        from sklearn.utils.extmath import randomized_svd
+        from sklearn.utils.extmath import (  # pylint: disable=import-outside-toplevel
+            randomized_svd,
+        )
 
         Y, m, n, _, matrix_in = format_system(A, Y)
         if min(m, n) <= self.n_components + self.n_oversamples:


### PR DESCRIPTION
**Motivation and context:**
Having NaN scaled encoders does not give a great error message. See #1543 for more details.

**How has this been tested?**
Added a few tests to ensure that the right error messages are being raised. The only thing not explicitly tested is that the check in the `DotIncMerger` succeeds if there are NaNs, but that situation should not be possible after the changes in this PR, so testing it seemed like overkill.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
