### PR TITLE
Add version markers for 3.0 changes

### DIFF
--- a/nengo/base.py
+++ b/nengo/base.py
@@ -335,6 +335,8 @@ class Process(FrozenObject):
         The builder uses this to allocate memory for the process state, so
         that the state can be represented as part of the whole simulator state.
 
+        .. versionadded:: 3.0.0
+
         Parameters
         ----------
         shape_in : tuple
@@ -376,6 +378,8 @@ class Process(FrozenObject):
             A dictionary mapping keys to signals, where the signals fully
             represent the state of the process. The signals are initialized
             by `.Process.make_state`.
+
+            .. versionadded:: 3.0.0
         """
         raise NotImplementedError("Process must implement `make_step` method.")
 

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -23,6 +23,8 @@ class SimPES(Operator):
     * :math:`e_j` is the error for the jth output dimension, and
     * :math:`a_i` is the activity of a presynaptic neuron.
 
+    .. versionadded:: 3.0.0
+
     Parameters
     ----------
     pre_filtered : Signal

--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -114,6 +114,8 @@ def seed_network(network, seeds, seeded, base_rng=np.random):
 
     This includes all subnetworks.
 
+    .. versionadded:: 3.0.0
+
     Parameters
     ----------
     network : Network

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -628,7 +628,10 @@ class DotInc(Operator):
 
 
 class SparseDotInc(DotInc):
-    """Like `.DotInc` but ``A`` is a sparse matrix."""
+    """Like `.DotInc` but ``A`` is a sparse matrix.
+
+    .. versionadded:: 3.0.0
+    """
 
     def __init__(self, A, X, Y, tag=None):
         if not A.sparse:

--- a/nengo/builder/transforms.py
+++ b/nengo/builder/transforms.py
@@ -105,6 +105,8 @@ def build_convolution(
 class ConvInc(Operator):
     """Apply convolutional weights to input signal.
 
+    .. versionadded:: 3.0.0
+
     Parameters
     ----------
     W : Signal

--- a/nengo/exceptions.py
+++ b/nengo/exceptions.py
@@ -62,7 +62,10 @@ class ObsoleteError(NengoException):
 
 
 class MovedError(NengoException):
-    """A feature that has been moved elsewhere."""
+    """A feature that has been moved elsewhere.
+
+    .. versionadded:: 3.0.0
+    """
 
     def __init__(self, location=None):
         self.location = location

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -30,6 +30,9 @@ class SimulationData(Mapping):
     This is like a view on the raw simulation data manipulated by the Simulator,
     which allows the raw simulation data to be optimized for speed while this
     provides a more user-friendly interface.
+
+    .. versionchanged:: 3.0.0
+        Renamed from ProbeDict to SimulationData
     """
 
     def __init__(self, raw):
@@ -266,7 +269,10 @@ class Simulator:
         return self._time
 
     def clear_probes(self):
-        """Clear all probe histories."""
+        """Clear all probe histories.
+
+        .. versionadded:: 3.0.0
+        """
         for probe in self.model.probes:
             self._sim_data[probe] = []
         self.data.reset()  # clear probe cache
@@ -421,6 +427,9 @@ class Simulator:
         sample_every : float, optional
             The sampling period of the probe to create a range for.
             If None, a time value for every ``dt`` will be produced.
+
+            .. versionchanged:: 3.0.0
+                Renamed from dt to sample_every
         """
         if dt is not None:
             if sample_every is not None:

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -75,6 +75,8 @@ class SPA(nengo.Network):
 
                 self.bg = spa.BasalGanglia(actions=actions)
                 self.thal = spa.Thalamus(self.bg)
+
+    .. deprecated:: 3.0.0
     """
 
     def __init__(self, label=None, seed=None, add_to_container=None, vocabs=None):

--- a/nengo/synapses.py
+++ b/nengo/synapses.py
@@ -138,6 +138,11 @@ class LinearFilter(Synapse):
         Whether the synapse coefficients are analog (i.e. continuous-time),
         or discrete. Analog coefficients will be converted to discrete for
         simulation using the simulator ``dt``.
+    method : string
+        The method to use for discretization (if ``analog`` is True). See
+        `scipy.signal.cont2discrete` for information about the options.
+
+        .. versionadded:: 3.0.0
 
     Attributes
     ----------

--- a/nengo/transforms.py
+++ b/nengo/transforms.py
@@ -19,7 +19,10 @@ from nengo.utils.numpy import is_array_like, scipy_sparse
 
 
 class Transform(FrozenObject):
-    """A base class for connection transforms."""
+    """A base class for connection transforms.
+
+    .. versionadded:: 3.0.0
+    """
 
     def sample(self, rng=np.random):
         """Returns concrete weights to implement the specified transform.
@@ -48,7 +51,10 @@ class Transform(FrozenObject):
 
 
 class ChannelShapeParam(ShapeParam):
-    """A parameter where the value must be a shape with channels."""
+    """A parameter where the value must be a shape with channels.
+
+    .. versionadded:: 3.0.0
+    """
 
     def coerce(self, transform, shape):
         if isinstance(shape, ChannelShape):
@@ -68,6 +74,8 @@ class ChannelShapeParam(ShapeParam):
 
 class Dense(Transform):
     """A dense matrix transformation between an input and output signal.
+
+    .. versionadded:: 3.0.0
 
     Parameters
     ----------
@@ -152,6 +160,8 @@ class SparseInitParam(Parameter):
 
 class SparseMatrix(FrozenObject):
     """Represents a sparse matrix.
+
+    .. versionadded:: 3.0.0
 
     Parameters
     ----------
@@ -273,6 +283,8 @@ class SparseMatrix(FrozenObject):
 class Sparse(Transform):
     """A sparse matrix transformation between an input and output signal.
 
+    .. versionadded:: 3.0.0
+
     Parameters
     ----------
     shape : tuple of int
@@ -331,6 +343,8 @@ class Convolution(Transform):
     """An N-dimensional convolutional transform.
 
     The dimensionality of the convolution is determined by the input shape.
+
+    .. versionadded:: 3.0.0
 
     Parameters
     ----------
@@ -485,6 +499,8 @@ class Convolution(Transform):
 
 class ChannelShape:
     """Represents shape information with variable channel position.
+
+    .. versionadded:: 3.0.0
 
     Parameters
     ----------

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -274,6 +274,8 @@ class VdomProgressBar(ProgressBar):  # pragma: no cover
     """A progress bar using a virtual DOM representation.
 
     This HTML representation can be used in Jupyter lab (>=0.32) environments.
+
+    .. versionadded: 3.0.0
     """
 
     def __init__(self):
@@ -548,6 +550,8 @@ class VdomOrHtmlProgressBar(ProgressBar):  # pragma: no cover
     bundle and it is up to the Jupyter client to pick the preferred version.
     Usually this will be the VDOM if supported, and the HMTL version where VDOM
     is not supported.
+
+    .. versionadded: 3.0.0
     """
 
     def __init__(self):


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Adds markers in the docs for major new objects in Nengo 3.0. There are definitely more places where we could use these (e.g. adding more ``.. versionchanged`` markers for things that aren't necessarily new but have changed in some way). But I limited it, roughly speaking, to new top-level classes/functions in any module.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Based on https://github.com/nengo/nengo/pull/1574, since that contains some updates that are also needed here.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Built the docs and looked at the markers to make sure they were rendering correctly.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.