### PR TITLE
Cache values in the RC system for speed

### DIFF
--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -91,7 +91,7 @@ RC_FILES = [
 ]
 
 
-class _RC(configparser.SafeConfigParser):
+class _RC(configparser.ConfigParser):
     """Allows reading from and writing to Nengo RC settings.
 
     This object is a :class:`configparser.ConfigParser`, which means that
@@ -115,8 +115,9 @@ class _RC(configparser.SafeConfigParser):
     """
 
     def __init__(self):
-        # configparser uses old-style classes without 'super' support
-        configparser.SafeConfigParser.__init__(self)
+        super().__init__()
+
+        self._cache = {}
         self.reload_rc()
 
     @property
@@ -130,6 +131,7 @@ class _RC(configparser.SafeConfigParser):
         return np.dtype("int%s" % bits)
 
     def _clear(self):
+        self._cache.clear()
         self.remove_section(configparser.DEFAULTSECT)
         for s in self.sections():
             self.remove_section(s)
@@ -139,6 +141,45 @@ class _RC(configparser.SafeConfigParser):
             self.add_section(section)
             for k, v in settings.items():
                 self.set(section, k, str(v))
+
+    def _get_cached(
+        self,
+        base_fn,
+        section,
+        option,
+        raw=False,
+        vars=None,
+        fallback=configparser._UNSET,
+    ):
+        if vars is not None:
+            return base_fn(section, option, raw=raw, fallback=fallback)
+
+        key0 = (section, option)
+        key1 = (base_fn.__name__, raw, str(fallback))
+        try:
+            return self._cache[key0][key1]
+        except KeyError:
+            value = base_fn(section, option, raw=raw, fallback=fallback)
+            self._cache.setdefault(key0, {})[key1] = value
+            return value
+
+    def get(self, section, option, **kwargs):
+        return self._get_cached(super().get, section, option, **kwargs)
+
+    def getint(self, section, option, **kwargs):
+        return self._get_cached(super().getint, section, option, **kwargs)
+
+    def getfloat(self, section, option, **kwargs):
+        return self._get_cached(super().getfloat, section, option, **kwargs)
+
+    def getboolean(self, section, option, **kwargs):
+        return self._get_cached(super().getboolean, section, option, **kwargs)
+
+    def set(self, section, option, value=None):
+        key0 = (section, option)
+        if key0 in self._cache:
+            del self._cache[key0]
+        super().set(section, option, value)
 
     def read_file(self, fp, filename=None):
         if filename is None:


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Previously, repeated `rc.get` calls could take significant time. I noticed this when profiling. However, I'm not sure where the particular calls are in our code (I know they're in the simulator `step` function somewhere, either here or in `nengo-loihi`).

My solution was to cache things in our `_RC` class when they're first used. I've also configured the cache to get cleared (for the specific value) when `rc.set` is called, or for all values if we clear/reload the RC file. This should ensure that users can still use `rc.set` or load their own RC file before making networks/simulators/etc., and the new settings will be used.

We should probably go through and make sure when we make operators for a simulator, they're not calling into `rc` repeatedly (they should load the `rc` value once when they make the operator, and then re-use the value). From what I can tell, the place where it is actually happening is in `SupportDefaultsMixin.__setattr__`, where we check if we're using simplified exceptions. It might be a little tricky to cache things there, because we don't want to cache to early (e.g. if some config setting is set when Nengo is imported) and have a later user change of the value not have an effect. This is why I've taken the current approach for now.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

I've ran the test suite. We'll need some unit testing to ensure full coverage.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [ ] Add unit tests; ensure full coverage.
