### PR TITLE
Speed up node functions

### DIFF
--- a/nengo/builder/node.py
+++ b/nengo/builder/node.py
@@ -46,7 +46,8 @@ def build_node(model, node):
             if node.size_out > 0
             else None
         )
-        model.add_op(SimPyFunc(output=sig_out, fn=node.output, t=model.time, x=sig_in))
+        model.add_op(SimPyFunc(output=sig_out, fn=node.output, t=model.time, x=sig_in,
+                               check_output=node.check_output, tag="%s.sim" % node))
     elif is_array_like(node.output):
         sig_out = Signal(node.output.astype(rc.float_dtype), name="%s.out" % node)
     else:

--- a/nengo/node.py
+++ b/nengo/node.py
@@ -6,7 +6,7 @@ import numpy as np
 import nengo.utils.numpy as npext
 from nengo.base import NengoObject, ObjView
 from nengo.exceptions import ValidationError
-from nengo.params import Default, IntParam, Parameter
+from nengo.params import BoolParam, Default, IntParam, Parameter
 from nengo.processes import Process
 from nengo.rc import rc
 from nengo.utils.numpy import is_array_like
@@ -185,12 +185,14 @@ class Node(NengoObject):
     output = OutputParam("output", default=None)
     size_in = IntParam("size_in", default=None, low=0, optional=True)
     size_out = IntParam("size_out", default=None, low=0, optional=True)
+    check_output = BoolParam("check_output", default=True)
 
     def __init__(
         self,
         output=Default,
         size_in=Default,
         size_out=Default,
+        check_output=Default,
         label=Default,
         seed=Default,
     ):
@@ -200,6 +202,7 @@ class Node(NengoObject):
 
         self.size_in = size_in
         self.size_out = size_out
+        self.check_output = check_output
         self.output = output  # Must be set after size_out; may modify size_out
 
     def __getitem__(self, key):

--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -91,7 +91,7 @@ RC_FILES = [
 ]
 
 
-class _RC(configparser.SafeConfigParser):
+class _RC(configparser.ConfigParser):
     """Allows reading from and writing to Nengo RC settings.
 
     This object is a :class:`configparser.ConfigParser`, which means that
@@ -115,8 +115,9 @@ class _RC(configparser.SafeConfigParser):
     """
 
     def __init__(self):
-        # configparser uses old-style classes without 'super' support
-        configparser.SafeConfigParser.__init__(self)
+        super().__init__()
+
+        self._cache = {}
         self.reload_rc()
 
     @property
@@ -130,6 +131,7 @@ class _RC(configparser.SafeConfigParser):
         return np.dtype("int%s" % bits)
 
     def _clear(self):
+        self._cache.clear()
         self.remove_section(configparser.DEFAULTSECT)
         for s in self.sections():
             self.remove_section(s)
@@ -139,6 +141,45 @@ class _RC(configparser.SafeConfigParser):
             self.add_section(section)
             for k, v in settings.items():
                 self.set(section, k, str(v))
+
+    def _get_cached(
+        self,
+        base_fn,
+        section,
+        option,
+        raw=False,
+        vars=None,
+        fallback=configparser._UNSET,
+    ):
+        if vars is not None:
+            return base_fn(section, option, raw=raw, fallback=fallback)
+
+        key0 = (section, option)
+        key1 = (base_fn.__name__, raw, str(fallback))
+        try:
+            return self._cache[key0][key1]
+        except KeyError:
+            value = base_fn(section, option, raw=raw, fallback=fallback)
+            self._cache.setdefault(key0, {})[key1] = value
+            return value
+
+    def get(self, section, option, **kwargs):
+        return self._get_cached(super().get, section, option, **kwargs)
+
+    def getint(self, section, option, **kwargs):
+        return self._get_cached(super().getint, section, option, **kwargs)
+
+    def getfloat(self, section, option, **kwargs):
+        return self._get_cached(super().getfloat, section, option, **kwargs)
+
+    def getboolean(self, section, option, **kwargs):
+        return self._get_cached(super().getboolean, section, option, **kwargs)
+
+    def set(self, section, option, value=None):
+        key0 = (section, option)
+        if key0 in self._cache:
+            del self._cache[key0]
+        super().set(section, option, value)
 
     def read_file(self, fp, filename=None):
         if filename is None:


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Node functions have significant overhead, which can affect time-sensitive applications.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Based on #1579. Note that this is currently rebased to a point farther back in master, because `nengo-loihi` is not yet working with `master` and I needed this with `nengo-loihi`.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

I tested the speed improvements to a Loihi script using the `parallel_ensemble.py` benchmark in the private `nengo-loihi-sandbox`. I have not done any profiling in a general nengo script.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Performance improvement

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
