### PR TITLE
Fix missing import in linalg_onenormest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,14 +75,15 @@ jobs:
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: false
           condition: $TRAVIS_BRANCH =~ ^release-candidate-*
-          condition: $TRAVIS_TAG = ""
       - provider: pypi
         user: tbekolay
         password: $PYPI_TOKEN
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: true
           condition: $TRAVIS_TAG =~ ^v[0-9]*
 
 before_install:

--- a/nengo/_vendor/scipy/sparse/linalg_onenormest.py
+++ b/nengo/_vendor/scipy/sparse/linalg_onenormest.py
@@ -38,6 +38,8 @@ from __future__ import absolute_import, division
 
 import numpy as np
 
+from nengo._vendor.scipy.sparse.linalg_interface import aslinearoperator
+
 
 def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False):
     """


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Missing an import in this file, which is needed inside e.g. `onenormest`.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

I didn't add a test for this, since we don't really test any of the `_vendor` code. Confirmed that you can successfully use `onenormest` after this change though.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.