### PR TITLE
Fix __eq__ functions for disparate types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" < "3.6" ]]; then
         echo "Skipping bones-check because Python $TRAVIS_PYTHON_VERSION < 3.6";
     else
-        bones-check;
+        bones-check --verbose;
     fi
   # display environment info
   - pip freeze

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@ Release history
 - Added a new example notebook for Legendre Memory Units.
   (`#1589 <https://github.com/nengo/nengo/pull/1589>`__)
 
+**Fixed**
+
+- Fixed a bug when comparing equality with ``Ensemble.neurons`` or
+  ``Connection.learning_rule`` objects.
+  (`#1588 <https://github.com/nengo/nengo/pull/1588>`__)
+
 3.0.0 (November 18, 2019)
 =========================
 

--- a/nengo/connection.py
+++ b/nengo/connection.py
@@ -653,7 +653,8 @@ class LearningRule:
 
     def __eq__(self, other):
         return (
-            self._connection is other._connection
+            type(self) == type(other)
+            and self._connection is other._connection
             and self.learning_rule_type == other.learning_rule_type
         )
 

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -229,7 +229,7 @@ class Neurons:
         return "<Neurons of %s>" % self.ensemble
 
     def __eq__(self, other):
-        return self.ensemble is other.ensemble
+        return type(self) == type(other) and self.ensemble is other.ensemble
 
     def __hash__(self):
         return hash(self.ensemble) + 1  # +1 to avoid collision with ensemble

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -1101,3 +1101,17 @@ def test_neuron_advanced_indexing(Simulator):
     with Simulator(net) as sim:
         sim.run(0.001)
         assert np.allclose(sim.data[p], [2, 0, 1, 0, 0])
+
+
+def test_learning_rule_equality():
+    with nengo.Network():
+        ens = nengo.Ensemble(10, 1)
+        lr = nengo.PES()
+        conn0 = nengo.Connection(ens, ens, learning_rule_type=lr)
+        assert conn0.learning_rule == conn0.learning_rule
+        assert conn0.learning_rule != lr
+
+        conn1 = nengo.Connection(ens, ens, learning_rule_type=[lr, nengo.PES()])
+        assert conn0.learning_rule[0] != conn1.learning_rule
+        assert conn1.learning_rule_type[0] == conn0.learning_rule_type
+        assert conn1.learning_rule[0] == conn1.learning_rule[1]

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -445,3 +445,23 @@ def test_raises_exception_for_invalid_intercepts(Simulator, intercept):
     with pytest.raises(BuildError):
         with Simulator(model):
             pass
+
+
+def test_neurons_equality():
+    with nengo.Network():
+        neuron_type = nengo.LIF()
+        ens0 = nengo.Ensemble(10, 1, neuron_type=neuron_type)
+        assert ens0.neurons == ens0.neurons
+        assert ens0.neurons != neuron_type
+
+        ens1 = nengo.Ensemble(10, 1, neuron_type=neuron_type)
+        assert ens0.neurons != ens1.neurons
+        assert ens0.neuron_type == ens1.neuron_type
+
+        # this is the only way you could ever have two neurons objects that are
+        # equal but have different type
+        old_neurons = ens1.neurons
+        old_neuron_type = ens1.neuron_type
+        ens1.neuron_type = nengo.RectifiedLinear()
+        assert ens1.neurons == old_neurons
+        assert ens1.neuron_type != old_neuron_type


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Bug in our `__eq__` functions for `Neurons` and `LearningRule` meant that if you tried to compare it with another type, it would result in an error (because it wouldn't have the attributes we use to do the check). So just check the type first.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Tested that this fixed the problem in the situation that it came up.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
