### PR TITLE
Change default transform to None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,13 +19,22 @@ Release history
    - Removed
    - Fixed
 
-3.0.1 (unreleased)
+3.1.0 (unreleased)
 ==================
 
 **Added**
 
 - Added a new example notebook for Legendre Memory Units.
   (`#1589 <https://github.com/nengo/nengo/pull/1589>`__)
+
+**Changed**
+
+- The default Connection transform is now ``None``, meaning that there will be
+  no transform applied. This only changes behavior when learning on a
+  neuron-neuron connection with the default scalar transform. In that situation
+  there are now no weights to apply learning to, so this will result in an
+  error. The old behaviour can be obtained by setting ``transform=1``.
+  (`#1591 <https://github.com/nengo/nengo/pull/1591>`__)
 
 **Fixed**
 

--- a/docs/frontend-api.rst
+++ b/docs/frontend-api.rst
@@ -178,7 +178,7 @@ Transforms
 
 .. Note: we don't use automodule/autoautosummary here because we want the
    canonical reference to these objects to be ``nengo.Class`` even though
-   they actually live in ``nengo.synapses.Class``.
+   they actually live in ``nengo.transforms.Class``.
 
 .. autosummary::
    :nosignatures:
@@ -189,6 +189,7 @@ Transforms
    nengo.transforms.SparseMatrix
    nengo.Convolution
    nengo.transforms.ChannelShape
+   nengo.transforms.NoTransform
 
 .. autoclass:: nengo.transforms.Transform
 
@@ -205,3 +206,5 @@ Transforms
 .. autoclass:: nengo.transforms.ChannelShape
 
 .. autoclass:: nengo.transforms.ChannelShapeParam
+
+.. autoclass:: nengo.transforms.NoTransform

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -7,7 +7,7 @@ from nengo.builder.ensemble import gen_eval_points, get_activities
 from nengo.builder.node import SimPyFunc
 from nengo.builder.operator import Copy, ElementwiseInc, Reset
 from nengo.connection import Connection
-from nengo.transforms import Dense
+from nengo.transforms import Dense, NoTransform
 from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError
 from nengo.neurons import Direct
@@ -341,10 +341,10 @@ def build_connection(model, conn):
     # Build learning rules
     if conn.learning_rule is not None:
         # TODO: provide a general way for transforms to expose learnable params
-        if not isinstance(conn.transform, Dense):
+        if not isinstance(conn.transform, (Dense, NoTransform)):
             raise NotImplementedError(
                 "Learning on connections with %s transforms is not supported"
-                % (type(conn.transform).__name__)
+                % (type(conn.transform).__name__,)
             )
 
         rule = conn.learning_rule
@@ -368,5 +368,5 @@ def build_connection(model, conn):
         eval_points=eval_points,
         solver_info=solver_info,
         transform=conn.transform,
-        weights=weights.initial_value,
+        weights=getattr(weights, "initial_value", None),
     )

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -46,6 +46,11 @@ def signal_probe(model, key, probe):
     except IndexError:
         raise BuildError("Attribute %r is not probeable on %s." % (key, probe.obj))
 
+    if sig is None:
+        raise BuildError(
+            "Attribute %r on %s is None, cannot be probed" % (key, probe.obj)
+        )
+
     if probe.slice is not None:
         sig = sig[probe.slice]
 

--- a/nengo/builder/transforms.py
+++ b/nengo/builder/transforms.py
@@ -4,7 +4,7 @@ from nengo.builder import Builder, Operator, Signal
 from nengo.builder.operator import DotInc, ElementwiseInc, Reset, SparseDotInc
 from nengo.exceptions import BuildError
 from nengo.rc import rc
-from nengo.transforms import Convolution, Dense, Sparse
+from nengo.transforms import Convolution, Dense, NoTransform, Sparse
 from nengo._vendor.npconv2d import conv2d
 
 
@@ -205,3 +205,22 @@ class ConvInc(Operator):
             Y[...] += conv2d.conv2d(X, W, pad=pad, stride=stride)[0]
 
         return step_conv
+
+
+@Builder.register(NoTransform)
+def build_no_transform(
+    model, transform, sig_in, decoders=None, encoders=None, rng=np.random
+):
+    """Build a `.NoTransform` transform object."""
+
+    if decoders is not None or encoders is not None:
+        return build_dense(
+            model,
+            Dense(shape=(transform.size_out, transform.size_in), init=1.0),
+            sig_in,
+            decoders=decoders,
+            encoders=encoders,
+            rng=rng,
+        )
+
+    return sig_in, None

--- a/nengo/transforms.py
+++ b/nengo/transforms.py
@@ -551,3 +551,50 @@ class ChannelShape:
     def dimensions(self):
         """The spatial dimensionality of the represented signal."""
         return len(self.shape) - 1
+
+
+class NoTransform(Transform):
+    """Directly pass the signal through without any transform operations.
+
+    .. versionadded:: 3.1.0
+
+    Parameters
+    ----------
+    size_in : int
+        Dimensionality of transform input and output.
+    """
+
+    def __init__(self, size_in):
+        super().__init__()
+
+        self._size_in = size_in
+
+    def sample(self, rng=np.random):
+        """Returns concrete weights to implement the specified transform.
+
+        Parameters
+        ----------
+        rng : `numpy.random.mtrand.RandomState`, optional
+            Random number generator state.
+
+        Raises
+        ------
+        TypeError
+            There is nothing to sample for NoTransform, so it is an error
+            if this is called.
+        """
+        raise TypeError("Cannot sample a NoTransform")
+
+    @property
+    def _argreprs(self):
+        return ["size_in=%d" % self.size_in]
+
+    @property
+    def size_in(self):
+        """Expected size of input to transform."""
+        return self._size_in
+
+    @property
+    def size_out(self):
+        """Expected size of output from transform."""
+        return self._size_in

--- a/nengo/utils/builder.py
+++ b/nengo/utils/builder.py
@@ -7,7 +7,9 @@ import numpy as np
 from nengo.exceptions import MovedError, Unconvertible, ValidationError
 
 
-def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
+def full_transform(  # noqa: C901
+    conn, slice_pre=True, slice_post=True, allow_scalars=True
+):
     """Compute the full transform matrix for a Dense connection transform.
 
     Parameters
@@ -24,16 +26,21 @@ def full_transform(conn, slice_pre=True, slice_post=True, allow_scalars=True):
         If false, these scalars will be turned into scaled identity matrices.
     """
     # imported here to avoid circular imports
-    from nengo import Dense  # pylint: disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
+    from nengo import Dense
+    from nengo.transforms import NoTransform
 
-    if not isinstance(conn.transform, Dense):
+    if isinstance(conn.transform, NoTransform):
+        transform = np.array(1.0)
+    elif not isinstance(conn.transform, Dense):
         raise ValidationError(
             "full_transform can only be applied to Dense transforms",
             attr="transform",
             obj=conn,
         )
+    else:
+        transform = conn.transform.init
 
-    transform = conn.transform.init
     pre_slice = conn.pre_slice if slice_pre and conn.function is None else slice(None)
     post_slice = conn.post_slice if slice_post else slice(None)
 

--- a/nengo/utils/tests/test_builder.py
+++ b/nengo/utils/tests/test_builder.py
@@ -5,6 +5,7 @@ import pytest
 
 import nengo
 from nengo.exceptions import MovedError, Unconvertible
+from nengo.transforms import NoTransform
 from nengo.utils.builder import (
     full_transform,
     generate_graphviz,
@@ -27,7 +28,7 @@ def test_full_transform():
 
         # Pre slice with default transform -> 1x3 transform
         conn = nengo.Connection(node3[2], ens1)
-        assert np.all(conn.transform.init == np.array(1))
+        assert isinstance(conn.transform, NoTransform)
         assert np.all(full_transform(conn) == np.array([[0, 0, 1]]))
 
         # Post slice with 1x1 transform -> 1x2 transform

--- a/nengo/version.py
+++ b/nengo/version.py
@@ -7,7 +7,7 @@ a release version. Release versions are git tagged with the version.
 """
 
 name = "nengo"
-version_info = (3, 0, 1)  # (major, minor, patch)
+version_info = (3, 1, 0)  # (major, minor, patch)
 dev = 0
 
 version = "{v}{dev}".format(


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

This implements the idea described in https://github.com/nengo/nengo/issues/1580.  Basically, rather than always having an implicit `transform=1` operation on Connections, we just don't apply any transform if none is specified.  In most cases this won't make any difference in the model's behaviour (since `transform=1` wasn't doing anything anyway), but it can save time and memory.

The only situation I can see it being noticeable is if someone was using the default transform and then later on accessing `my_conn.transform`. Previously that would return a `Dense` transform object, now it will return a `NoTransform` object. That seems relatively unlikely (and easy to resolve), but I updated the next version to 3.1.0 for that reason.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a new test in `test_learning_rules` for the new validation checks, and since this is the default transform it is being tested pretty thoroughly in most of the existing tests.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

The main implementation change is in `builder/transforms.py`, which uses the new `Null` transform type defined in `transforms.py`. And then there is new validation added for learning rule parameters in `connection.py` to make sure that there are weights for learning to be applied to. Other than that it's relatively minor changes.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.