### PR TITLE
Make op 'set' semantics more consistent

### DIFF
--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -166,7 +166,7 @@ def slice_signal(model, signal, sl):
     else:
         size = np.arange(signal.size, dtype=rc.float_dtype)[sl].size
         sliced_signal = Signal(shape=size, name="%s.sliced" % signal.name)
-        model.add_op(Copy(signal, sliced_signal, src_slice=sl))
+        model.add_op(Copy(signal, sliced_signal, src_slice=sl, tag="%s.pre_slice"))
         return sliced_signal
 
 
@@ -318,7 +318,13 @@ def build_connection(model, conn):
             sliced_out = Signal(shape=gains.shape, name="%s.sliced_out" % conn)
             model.add_op(Reset(sliced_out))
             model.add_op(
-                Copy(sliced_out, model.sig[conn]["out"], dst_slice=post_slice, inc=True)
+                Copy(
+                    sliced_out,
+                    model.sig[conn]["out"],
+                    dst_slice=post_slice,
+                    inc=True,
+                    tag="%s.slice" % conn,
+                )
             )
 
         model.add_op(

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -221,7 +221,13 @@ def build_ensemble(model, ens):
         model.sig[ens.neurons]["bias"] = Signal(
             bias, name="%s.bias" % ens, readonly=True
         )
-        model.add_op(Copy(model.sig[ens.neurons]["bias"], model.sig[ens.neurons]["in"]))
+        model.add_op(
+            Copy(
+                model.sig[ens.neurons]["bias"],
+                model.sig[ens.neurons]["in"],
+                tag="%s.bias" % ens.neurons,
+            )
+        )
         # This adds the neuron's operator and sets other signals
         model.build(ens.neuron_type, ens.neurons)
 

--- a/nengo/builder/neurons.py
+++ b/nengo/builder/neurons.py
@@ -45,8 +45,8 @@ class SimNeurons(Operator):
 
     Notes
     -----
-    1. sets ``[output] + states``
-    2. incs ``[]``
+    1. sets ``[output]``
+    2. incs ``states``
     3. reads ``[J]``
     4. updates ``[]``
     """
@@ -55,8 +55,8 @@ class SimNeurons(Operator):
         super().__init__(tag=tag)
         self.neurons = neurons
 
-        self.sets = [output] + ([] if states is None else states)
-        self.incs = []
+        self.sets = [output]
+        self.incs = [] if states is None else states
         self.reads = [J]
         self.updates = []
 
@@ -70,7 +70,7 @@ class SimNeurons(Operator):
 
     @property
     def states(self):
-        return self.sets[1:]
+        return self.incs
 
     def _descstr(self):
         return "%s, %s, %s" % (self.neurons, self.J, self.output)

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -213,26 +213,26 @@ class TimeUpdate(Operator):
 
     Notes
     -----
-    1. sets ``[step, time]``
-    2. incs ``[]``
+    1. sets ``[time]``
+    2. incs ``[step]``
     3. reads ``[]``
     4. updates ``[]``
     """
 
     def __init__(self, step, time, tag=None):
         super().__init__(tag=tag)
-        self.sets = [step, time]
-        self.incs = []
+        self.sets = [time]
+        self.incs = [step]
         self.reads = []
         self.updates = []
 
     @property
     def step(self):
-        return self.sets[0]
+        return self.incs[0]
 
     @property
     def time(self):
-        return self.sets[1]
+        return self.sets[0]
 
     def make_step(self, signals, dt, rng):
         step = signals[self.step]

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -59,7 +59,9 @@ def signal_probe(model, key, probe):
     else:
         model.sig[probe]["in"] = Signal(shape=sig.shape, name=str(probe))
         model.sig[probe]["filtered"] = model.build(probe.synapse, sig, mode="update")
-        model.add_op(Copy(model.sig[probe]["filtered"], model.sig[probe]["in"]))
+        model.add_op(
+            Copy(model.sig[probe]["filtered"], model.sig[probe]["in"], tag="%s" % probe)
+        )
 
 
 probemap = {


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

We organize the signals associated with an Operator according to whether the operator sets, increments, reads, or updates that signal. The difference between a "set" and an "increment" is that an increment applies some delta to the existing value of a signal, whereas a set overrides whatever the existing value was.  In a couple places we had marked an operation that incremented a signal as a set instead.

In particular:
- `TimeUpdate.step`. This op is implementing `step += 1`, so `step` should be an inc rather than a set.
- `SimNeurons.states`. This one isn't as clear cut, since we don't really know how a neuron model might be using the state. However, I think we should assume that the neuron model will be reading 
the value of the state and applying some change (that's why it needs to track the state), rather than 
ignoring the current state value and setting it to some value. So this makes more sense as an inc than a set. It could be argued that this should be an `update` rather than an `inc`, but that would change the semantics of any signal probes that read these state values, so I went with `inc`.

In practice this change doesn't change the behaviour of the model at all (since sets and incs are scheduled consecutively, with no other ops in between, moving a signal from one to the other doesn't really matter). But this can matter in other backends (e.g. NengoDL) which are relying on the assumption that sets really are sets (i.e. do not depend on the current value of the signal), which is where I noticed this.

I also added tags to a couple ops that didn't have them that I noticed while looking at this.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Based on #1591 (since that one has some general fixes required to get the CI passing).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

All the tests pass without modification after this change, so there is no functional effect (as we'd expect).

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.