### PR TITLE
Fix python 3.8 compatibility issues

### DIFF
--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -91,7 +91,7 @@ RC_FILES = [
 ]
 
 
-class _RC(configparser.SafeConfigParser):
+class _RC(configparser.ConfigParser):
     """Allows reading from and writing to Nengo RC settings.
 
     This object is a :class:`configparser.ConfigParser`, which means that
@@ -122,7 +122,7 @@ class _RC(configparser.SafeConfigParser):
 
     def __init__(self):
         # configparser uses old-style classes without 'super' support
-        configparser.SafeConfigParser.__init__(self)
+        configparser.ConfigParser.__init__(self)
         self.reload_rc()
 
     @property
@@ -154,14 +154,14 @@ class _RC(configparser.SafeConfigParser):
                 filename = "<???>"
         logger.debug("Reading configuration from {}".format(filename))
         try:
-            return configparser.SafeConfigParser.read_file(self, fp, filename)
+            return configparser.ConfigParser.read_file(self, fp, filename)
         except AttributeError:
             # pylint: disable=deprecated-method
-            return configparser.SafeConfigParser.readfp(self, fp, filename)
+            return configparser.ConfigParser.readfp(self, fp, filename)
 
     def read(self, filenames):
         logger.debug("Reading configuration files {}".format(filenames))
-        return configparser.SafeConfigParser.read(self, filenames)
+        return configparser.ConfigParser.read(self, filenames)
 
     def reload_rc(self, filenames=None):
         """Resets the currently loaded RC settings and loads new RC files.

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -6,7 +6,7 @@ Other Nengo backends provide more specialized Simulators for custom platforms.
 
 import logging
 import warnings
-from collections import Mapping
+from collections.abc import Mapping
 
 import numpy as np
 

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -280,7 +280,7 @@ class Timer:
 
     """
 
-    TIMER = time.clock if sys.platform == "win32" else time.time
+    TIMER = time.perf_counter if sys.platform == "win32" else time.time
 
     def __init__(self):
         self.start = None

--- a/nengo/utils/threading.py
+++ b/nengo/utils/threading.py
@@ -2,7 +2,7 @@ import collections
 import threading
 
 
-class ThreadLocalStack(threading.local, collections.Sequence):
+class ThreadLocalStack(threading.local, collections.abc.Sequence):
     def __init__(self, maxsize=None):
         super().__init__()
         self.maxsize = maxsize


### PR DESCRIPTION
**Motivation and context:**

Fixes Python 3.8+ compatibility issues.

* Use collections.abc for ABC import.
* Use ConfigParser to fix deprecation warnings.
* Use time.perf_counter since time.clock was removed in Python 3.8.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.

Fixes #1593  #1594 
