### PR TITLE
Raise error when re-opening closed simulator

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -271,11 +271,11 @@ codecov_yml:
 
 pre_commit_config_yaml:
   exclude:
-    - "_vendor/*"
+    - "_vendor/"
 
 pyproject_toml:
   exclude:
-    - "_vendor/*"
+    - "_vendor/"
 
 version_py:
   major: 3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       files: \.py$
       exclude: |
           (?x)(
-              _vendor/*
+              _vendor/
           )
 -   repo: https://github.com/pycqa/isort
     rev: 5.6.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,6 +125,7 @@ Release history
   overwrite an existing attribute. (`#1611`_)
 - The ``encoders`` and ``eval_points`` of ``Ensemble`` are now sampled from
   ``ScatteredHypersphere`` by default. (`#1611`_)
+- Trying to re-open a closed Simulator will now raise an error. (`#1599`_)
 
 **Deprecated**
 
@@ -158,6 +159,7 @@ Release history
 - Fixed a shape error when applying PES learning with a slice on the pre-synaptic
   object. (`#1640`_)
 
+.. _#1599: https://github.com/nengo/nengo/pull/1599
 .. _#1609: https://github.com/nengo/nengo/pull/1609
 .. _#1611: https://github.com/nengo/nengo/pull/1611
 .. _#1627: https://github.com/nengo/nengo/pull/1627

--- a/nengo/simulator.py
+++ b/nengo/simulator.py
@@ -208,6 +208,9 @@ class Simulator:
             )
 
     def __enter__(self):
+        if self.closed:
+            raise SimulatorClosed("Cannot re-open after simulator is closed")
+
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -167,6 +167,17 @@ def test_close_steps(Simulator):
         sim.step()
 
 
+def test_sim_reopen(Simulator):
+    with Simulator(nengo.Network()) as sim:
+        assert not sim.closed
+
+    assert sim.closed
+
+    with pytest.raises(SimulatorClosed, match="simulator is closed"):
+        with sim:
+            pass
+
+
 def test_warn_on_opensim_del(Simulator):
     with nengo.Network() as net:
         nengo.Ensemble(10, 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["setuptools", "wheel"]
 target-version = ['py36']
 exclude = '''
 (
-    _vendor/*
+    _vendor/
 )
 '''
 


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

As pointed out in https://github.com/nengo/nengo-dl/issues/115, re-opening a closed Simulator is not something that is generally supported in Nengo, so we should raise an error in the core Simulator as well for consistency.

This is a breaking change, for anyone who was re-opening closed Simulators.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a test in `test_simulator`.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.