### PR TITLE
Use autosummary renaming to simplify docs

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -194,6 +194,31 @@ docs_conf_py:
     getting_started.html: getting-started.html
     improving_performance.html: improving-performance.html
     user_guide.html: user-guide.html
+  autoautosummary_change_modules:
+    nengo:
+      - nengo.learning_rules.PES
+      - nengo.learning_rules.BCM
+      - nengo.learning_rules.Oja
+      - nengo.learning_rules.Voja
+      - nengo.neurons.Direct
+      - nengo.neurons.RectifiedLinear
+      - nengo.neurons.SpikingRectifiedLinear
+      - nengo.neurons.Sigmoid
+      - nengo.neurons.LIF
+      - nengo.neurons.LIFRate
+      - nengo.neurons.AdaptiveLIF
+      - nengo.neurons.AdaptiveLIFRate
+      - nengo.neurons.Izhikevich
+      - nengo.synapses.LinearFilter
+      - nengo.synapses.Lowpass
+      - nengo.synapses.Alpha
+      - nengo.transforms.Dense
+      - nengo.transforms.Sparse
+      - nengo.transforms.Convolution
+      - nengo.config.Config
+    nengo.builder:
+      - nengo.builder.operator.Operator
+      - nengo.builder.signal.Signal
 
 travis_yml:
   python: 3.6

--- a/docs/backend-api.rst
+++ b/docs/backend-api.rst
@@ -55,60 +55,18 @@ and reference documentation, read on.
 Basic operators
 ---------------
 
-.. TODO: nengo.builder.operator.Operator should be nengo.builder.Operator
-
 .. automodule:: nengo.builder.operator
-   :no-members:
 
-.. autosummary::
-   :nosignatures:
-
-   nengo.builder.Operator
-   nengo.builder.operator.TimeUpdate
-   nengo.builder.operator.Reset
-   nengo.builder.operator.Copy
-   nengo.builder.operator.ElementwiseInc
-   nengo.builder.operator.reshape_dot
-   nengo.builder.operator.DotInc
-   nengo.builder.operator.SparseDotInc
-   nengo.builder.operator.BsrDotInc
-   nengo.builder.operator.SimPyFunc
-
-.. autoclass:: nengo.builder.Operator
-
-.. autoclass:: nengo.builder.operator.TimeUpdate
-
-.. autoclass:: nengo.builder.operator.Reset
-
-.. autoclass:: nengo.builder.operator.Copy
-
-.. autoclass:: nengo.builder.operator.ElementwiseInc
-
-.. autofunction:: nengo.builder.operator.reshape_dot
-
-.. autoclass:: nengo.builder.operator.DotInc
-
-.. autoclass:: nengo.builder.operator.SparseDotInc
-
-.. autoclass:: nengo.builder.operator.BsrDotInc
-
-.. autoclass:: nengo.builder.operator.SimPyFunc
+   .. autoautosummary:: nengo.builder.operator
+      :nosignatures:
 
 Signals
 -------
 
-.. autosummary::
-   :nosignatures:
+.. automodule:: nengo.builder.signal
 
-   nengo.builder.Signal
-   nengo.builder.signal.is_sparse
-   nengo.builder.signal.SignalDict
-
-.. autoclass:: nengo.builder.Signal
-
-.. autofunction:: nengo.builder.signal.is_sparse
-
-.. autoclass:: nengo.builder.signal.SignalDict
+   .. autoautosummary:: nengo.builder.signal
+      :nosignatures:
 
 Network builder
 ---------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "nbsphinx",
     "nengo_sphinx_theme",
+    "nengo_sphinx_theme.ext.backoff",
     "nengo_sphinx_theme.ext.redirects",
     "numpydoc",
     "nengo_sphinx_theme.ext.autoautosummary",
@@ -69,6 +70,7 @@ linkcheck_ignore = [r"http://localhost:\d+"]
 linkcheck_anchors = True
 default_role = "py:obj"
 pygments_style = "sphinx"
+user_agent = "nengo"
 
 project = "Nengo"
 authors = "Applied Brain Research"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,36 @@ numpydoc_show_class_members = False
 # -- nbsphinx
 nbsphinx_timeout = -1
 
+# -- nengo_sphinx_theme.ext.autoautosummary
+autoautosummary_change_modules = {
+    "nengo": [
+        "nengo.learning_rules.PES",
+        "nengo.learning_rules.BCM",
+        "nengo.learning_rules.Oja",
+        "nengo.learning_rules.Voja",
+        "nengo.neurons.Direct",
+        "nengo.neurons.RectifiedLinear",
+        "nengo.neurons.SpikingRectifiedLinear",
+        "nengo.neurons.Sigmoid",
+        "nengo.neurons.LIF",
+        "nengo.neurons.LIFRate",
+        "nengo.neurons.AdaptiveLIF",
+        "nengo.neurons.AdaptiveLIFRate",
+        "nengo.neurons.Izhikevich",
+        "nengo.synapses.LinearFilter",
+        "nengo.synapses.Lowpass",
+        "nengo.synapses.Alpha",
+        "nengo.transforms.Dense",
+        "nengo.transforms.Sparse",
+        "nengo.transforms.Convolution",
+        "nengo.config.Config",
+    ],
+    "nengo.builder": [
+        "nengo.builder.operator.Operator",
+        "nengo.builder.signal.Signal",
+    ],
+}
+
 # -- sphinx
 nitpicky = True
 exclude_patterns = [

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -29,23 +29,9 @@ can be found below:
 ---------------------
 
 .. automodule:: nengo.config
-   :no-members:
 
-.. autosummary::
-   :nosignatures:
-
-   nengo.Config
-   nengo.config.ClassParams
-   nengo.config.InstanceParams
-   nengo.config.SupportDefaultsMixin
-
-.. autoclass:: nengo.Config
-
-.. autoclass:: nengo.config.ClassParams
-
-.. autoclass:: nengo.config.InstanceParams
-
-.. autoclass:: nengo.config.SupportDefaultsMixin
+    .. autoautosummary:: nengo.config
+       :nosignatures:
 
 Preset configs
 ==============

--- a/docs/frontend-api.rst
+++ b/docs/frontend-api.rst
@@ -42,78 +42,20 @@ Distributions
 Learning rule types
 ===================
 
-.. Note: we don't use automodule/autoautosummary here because we want the
-   canonical reference to these objects to be ``nengo.Class`` even though
-   they actually live in ``nengo.learning_rules.Class``.
+.. automodule:: nengo.learning_rules
 
-.. autosummary::
-   :nosignatures:
-
-   nengo.learning_rules.LearningRuleType
-   nengo.PES
-   nengo.BCM
-   nengo.Oja
-   nengo.Voja
-
-.. autoclass:: nengo.learning_rules.LearningRuleType
-
-.. autoclass:: nengo.PES
-
-.. autoclass:: nengo.BCM
-
-.. autoclass:: nengo.Oja
-
-.. autoclass:: nengo.Voja
-
-.. autoclass:: nengo.learning_rules.LearningRuleTypeParam
-
-.. autoclass:: nengo.learning_rules.LearningRuleTypeSizeInParam
+   .. autoautosummary:: nengo.learning_rules
+      :nosignatures:
+      :exclude-members: LearningRuleTypeParam, LearningRuleTypeSizeInParam
 
 Neuron types
 ============
 
-.. Note: we don't use automodule/autoautosummary here because we want the
-   canonical reference to these objects to be ``nengo.Class`` even though
-   they actually live in ``nengo.neurons.Class``.
+.. automodule:: nengo.neurons
 
-.. autosummary::
-   :nosignatures:
-
-   nengo.neurons.NeuronType
-   nengo.neurons.settled_firingrate
-   nengo.Direct
-   nengo.RectifiedLinear
-   nengo.SpikingRectifiedLinear
-   nengo.Sigmoid
-   nengo.LIF
-   nengo.LIFRate
-   nengo.AdaptiveLIF
-   nengo.AdaptiveLIFRate
-   nengo.Izhikevich
-
-.. autoclass:: nengo.neurons.NeuronType
-
-.. autofunction:: nengo.neurons.settled_firingrate
-
-.. autoclass:: nengo.Direct
-
-.. autoclass:: nengo.RectifiedLinear
-
-.. autoclass:: nengo.SpikingRectifiedLinear
-
-.. autoclass:: nengo.Sigmoid
-
-.. autoclass:: nengo.LIF
-
-.. autoclass:: nengo.LIFRate
-
-.. autoclass:: nengo.AdaptiveLIF
-
-.. autoclass:: nengo.AdaptiveLIFRate
-
-.. autoclass:: nengo.Izhikevich
-
-.. autoclass:: nengo.neurons.NeuronTypeParam
+   .. autoautosummary:: nengo.neurons
+      :nosignatures:
+      :exclude-members: NeuronTypeParam
 
 Processes
 =========
@@ -148,63 +90,17 @@ Solver methods
 Synapse models
 ==============
 
-.. Note: we don't use automodule/autoautosummary here because we want the
-   canonical reference to these objects to be ``nengo.Class`` even though
-   they actually live in ``nengo.synapses.Class``.
+.. automodule:: nengo.synapses
 
-.. autosummary::
-   :nosignatures:
-
-   nengo.synapses.Synapse
-   nengo.LinearFilter
-   nengo.Lowpass
-   nengo.Alpha
-   nengo.synapses.Triangle
-
-.. autoclass:: nengo.synapses.Synapse
-
-.. autoclass:: nengo.LinearFilter
-
-.. autoclass:: nengo.Lowpass
-
-.. autoclass:: nengo.Alpha
-
-.. autoclass:: nengo.synapses.Triangle
-
-.. autoclass:: nengo.synapses.SynapseParam
+   .. autoautosummary:: nengo.synapses
+      :nosignatures:
+      :exclude-members: SynapseParam
 
 Transforms
 ==========
 
-.. Note: we don't use automodule/autoautosummary here because we want the
-   canonical reference to these objects to be ``nengo.Class`` even though
-   they actually live in ``nengo.transforms.Class``.
+.. automodule:: nengo.transforms
 
-.. autosummary::
-   :nosignatures:
-
-   nengo.transforms.Transform
-   nengo.Dense
-   nengo.Sparse
-   nengo.transforms.SparseMatrix
-   nengo.Convolution
-   nengo.transforms.ChannelShape
-   nengo.transforms.NoTransform
-
-.. autoclass:: nengo.transforms.Transform
-
-.. autoclass:: nengo.Dense
-
-.. autoclass:: nengo.Sparse
-
-.. autoclass:: nengo.transforms.SparseMatrix
-
-.. autoclass:: nengo.transforms.SparseInitParam
-
-.. autoclass:: nengo.Convolution
-
-.. autoclass:: nengo.transforms.ChannelShape
-
-.. autoclass:: nengo.transforms.ChannelShapeParam
-
-.. autoclass:: nengo.transforms.NoTransform
+   .. autoautosummary:: nengo.transforms
+      :nosignatures:
+      :exclude-members: SparseInitParam, ChannelShapeParam


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Uses the new `autoautosummary`/`automodule` renaming functionality in `nengo-sphinx-theme` to simplify the documentation (avoids having to manually add each object to the documentation).

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Depends on https://github.com/nengo/nengo-bones/pull/86 and https://github.com/nengo/nengo-sphinx-theme/pull/52

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Built the docs locally and confirmed they looked the same as before (other than a few things being slightly re-ordered).

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.