### PR TITLE
Sphinx 3.0 compatibility fix

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -87,10 +87,7 @@ Lock
 Magic
 =====
 
-.. automodule:: nengo.utils.magic
-
-   .. autoautosummary:: nengo.utils.magic
-      :nosignatures:
+.. autofunction:: nengo.utils.magic.decorator
 
 Matplotlib
 ==========


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

The Sphinx 3.0 release broke our docs, this fixes them.

The problem has to do with documenting the internal `wrapt` classes (which we vendor in `nengo.utils.magic`). Those do some weird things with their docstrings (specifically, `__doc__` is a property, rather than a string), and when Sphinx tries to document those classes it errors out.

I'm not sure why this worked in Sphinx 2.0 and not 3.0. I spent a little while trying to fix it, but couldn't find a solution. If we are particularly motivated we could make a minimal example and make a bug report in Sphinx. But since it isn't really important that we document those classes I just excluded them to make the problem go away.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Built the docs locally, no errors

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.