### PR TITLE
Correct docstring for oscillator's frequency

### DIFF
--- a/docs/examples/dynamics/controlled-oscillator.ipynb
+++ b/docs/examples/dynamics/controlled-oscillator.ipynb
@@ -108,7 +108,7 @@
    "outputs": [],
    "source": [
     "tau = 0.1  # Post-synaptic time constant for feedback\n",
-    "w_max = 10  # Maximum frequency is w_max/(2*pi)\n",
+    "w_max = 10  # Maximum frequency in Hz is w_max/(2*pi)\n",
     "\n",
     "model = nengo.Network(label='Controlled Oscillator')\n",
     "with model:\n",
@@ -118,7 +118,7 @@
     "    # The feedback connection\n",
     "    def feedback(x):\n",
     "        x0, x1, w = x  # These are the three variables stored in the ensemble\n",
-    "        return x0 + w * w_max * tau * x1, x1 - w * w_max * tau * x0, 0\n",
+    "        return x0 - w * w_max * tau * x1, x1 + w * w_max * tau * x0, 0\n",
     "\n",
     "    nengo.Connection(oscillator, oscillator, function=feedback, synapse=tau)\n",
     "\n",

--- a/nengo/networks/oscillator.py
+++ b/nengo/networks/oscillator.py
@@ -14,7 +14,7 @@ class Oscillator(nengo.Network):
     recurrent_tau : float
         Time constant on the recurrent connection.
     frequency : float
-        Desired frequency, in Hz, of the cyclic oscillation.
+        Desired frequency, in radians per second, of the cyclic oscillation.
     n_neurons : int
         Number of neurons in the recurrently connected ensemble.
     **kwargs


### PR DESCRIPTION
The units are in radians per second. To specify the frequency in Hz, this value must be multiplied by ``2*np.pi``. FYI, can also make it more accurate using equation 5.9 from [my thesis](https://uwspace.uwaterloo.ca/bitstream/handle/10012/14625/Voelker_Aaron.pdf) but this requires knowing `dt`.

**Motivation and context:**
Corrects documentation.

**How has this been tested?**
N/A

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [N/A] I have updated the documentation accordingly.
- [N/A] I have included a changelog entry.
- [N/A] I have added tests to cover my changes.
- [N/A] I have run the test suite locally and all tests passed.