### PR TITLE
Update links to Sphinx websites

### DIFF
--- a/.templates/LICENSE.rst.template
+++ b/.templates/LICENSE.rst.template
@@ -7,8 +7,8 @@ Nengo imports or vendorizes several open source libraries.
 
 * `NumPy <https://numpy.org/>`_ - Used under
   `BSD license <https://numpy.org/doc/stable/license.html>`__
-* `Sphinx <http://sphinx-doc.org/>`_ - Used under
-  `BSD license <https://bitbucket.org/birkenfeld/sphinx/src/be5bd373a1a47fb68d70523b6e980e654e070e9f/LICENSE?at=default>`__
+* `Sphinx <https://www.sphinx-doc.org/>`_ - Used under
+  `BSD license <https://github.com/sphinx-doc/sphinx/blob/master/LICENSE>`__
 * `numpydoc <https://github.com/numpy/numpydoc>`_ - Used under
   `BSD license <https://github.com/numpy/numpydoc/blob/master/LICENSE.txt>`__
 * `matplotlib <https://matplotlib.org/>`_ - Used under

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -31,8 +31,8 @@ Nengo imports or vendorizes several open source libraries.
 
 * `NumPy <https://numpy.org/>`_ - Used under
   `BSD license <https://numpy.org/doc/stable/license.html>`__
-* `Sphinx <http://sphinx-doc.org/>`_ - Used under
-  `BSD license <https://bitbucket.org/birkenfeld/sphinx/src/be5bd373a1a47fb68d70523b6e980e654e070e9f/LICENSE?at=default>`__
+* `Sphinx <https://www.sphinx-doc.org/>`_ - Used under
+  `BSD license <https://github.com/sphinx-doc/sphinx/blob/master/LICENSE>`__
 * `numpydoc <https://github.com/numpy/numpydoc>`_ - Used under
   `BSD license <https://github.com/numpy/numpydoc/blob/master/LICENSE.txt>`__
 * `matplotlib <https://matplotlib.org/>`_ - Used under


### PR DESCRIPTION
**Motivation and context:**
The previous link of `http://sphinx-doc.org` times out frequently. Apparently it immediately redirects to `www.sphinx-doc.org`, which is more robust, so we should just link directly there. Also, the license file has moved but we were using the old location.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [na] I have run the test suite locally and all tests passed.
