### PR TITLE
Combine rates/spikes state into single output variable

### DIFF
--- a/docs/examples/usage/rectified-linear.ipynb
+++ b/docs/examples/usage/rectified-linear.ipynb
@@ -46,7 +46,7 @@
     "class RectifiedLinear(nengo.neurons.NeuronType):\n",
     "    \"\"\"A rectified linear neuron model.\"\"\"\n",
     "\n",
-    "    state = {\"rates\": nengo.dists.Choice([0.])}\n",
+    "    state = {\"output\": nengo.dists.Choice([0.])}\n",
     "\n",
     "    # We don't need any additional parameters here;\n",
     "    # gain and bias are sufficient. But, if we wanted\n",
@@ -59,9 +59,9 @@
     "        bias = -intercepts * gain\n",
     "        return gain, bias\n",
     "\n",
-    "    def step(self, dt, J, rates):\n",
+    "    def step(self, dt, J, output):\n",
     "        \"\"\"Compute rates in Hz for input current (incl. bias)\"\"\"\n",
-    "        rates[...] = np.maximum(0., J)"
+    "        output[...] = np.maximum(0., J)"
    ]
   },
   {

--- a/docs/examples/usage/rectified-linear.ipynb
+++ b/docs/examples/usage/rectified-linear.ipynb
@@ -46,8 +46,6 @@
     "class RectifiedLinear(nengo.neurons.NeuronType):\n",
     "    \"\"\"A rectified linear neuron model.\"\"\"\n",
     "\n",
-    "    state = {\"output\": nengo.dists.Choice([0.])}\n",
-    "\n",
     "    # We don't need any additional parameters here;\n",
     "    # gain and bias are sufficient. But, if we wanted\n",
     "    # more parameters, we could accept them by creating\n",

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -215,6 +215,9 @@ def build_ensemble(model, ens):
         model.sig[ens.neurons]["in"] = Signal(
             shape=ens.n_neurons, name="%s.neuron_in" % ens
         )
+        model.sig[ens.neurons]["out"] = Signal(
+            shape=ens.n_neurons, name="%s.neuron_out" % ens
+        )
         model.sig[ens.neurons]["bias"] = Signal(
             bias, name="%s.bias" % ens, readonly=True
         )

--- a/nengo/builder/neurons.py
+++ b/nengo/builder/neurons.py
@@ -17,8 +17,6 @@ class SimNeurons(Operator):
         The `.NeuronType`, which defines a ``step`` function.
     J : Signal
         The input current.
-    output : Signal
-        The neuron output signal that will be set.
     state : list, optional
         A list of additional neuron state signals set by ``step``.
     tag : str, optional
@@ -30,8 +28,6 @@ class SimNeurons(Operator):
         The input current.
     neurons : NeuronType
         The `.NeuronType`, which defines a ``step`` function.
-    output : Signal
-        The neuron output signal that will be set.
     state : list
         A list of additional neuron state signals set by ``step``.
     tag : str or None
@@ -39,7 +35,7 @@ class SimNeurons(Operator):
 
     Notes
     -----
-    1. sets ``[output] + state``
+    1. sets ``state``
     2. incs ``[]``
     3. reads ``[J]``
     4. updates ``[]``
@@ -133,9 +129,7 @@ def build_neurons(model, neurontype, neurons):
                 "currently supported." % (key, type(init).__name__)
             )
 
-    model.sig[neurons]["out"] = (
-        state["spikes"] if neurontype.spiking else state["rates"]
-    )
+    model.sig[neurons]["out"] = state["output"]
     model.add_op(
         SimNeurons(neurons=neurontype, J=model.sig[neurons]["in"], state=state)
     )

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -717,6 +717,7 @@ class SimNeuronsMerger(Merger):
     @staticmethod
     def merge(ops):
         J, J_sigr = SigMerger.merge([op.J for op in ops])
+        output, out_sigr = SigMerger.merge([op.output for op in ops])
         state = {}
         state_sigr = {}
         for key in ops[0].state_idxs:
@@ -728,11 +729,11 @@ class SimNeuronsMerger(Merger):
             warnings.warn(
                 "Extra state has been modified when merging two or more SimNeurons "
                 "ops associated with %r neuron types. If this causes issues, turn off "
-                "the optimizer." % (type(ops[0].neurons).__name__)
+                "the optimizer." % (type(ops[0].neurons).__name__,)
             )
         return (
-            SimNeurons(ops[0].neurons, J, state=state),
-            Merger.merge_dicts(J_sigr, state_sigr),
+            SimNeurons(ops[0].neurons, J, output, state=state),
+            Merger.merge_dicts(J_sigr, out_sigr, state_sigr),
         )
 
 

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -719,8 +719,8 @@ class SimNeuronsMerger(Merger):
         J, J_sigr = SigMerger.merge([op.J for op in ops])
         state = {}
         state_sigr = {}
-        for key in ops[0].state_sigs:
-            st, st_sigr = SigMerger.merge([op.sets[op.state_sigs[key]] for op in ops])
+        for key in ops[0].state_idxs:
+            st, st_sigr = SigMerger.merge([op.sets[op.state_idxs[key]] for op in ops])
             state[key] = st
             state_sigr.update(st_sigr)
         state.update(ops[0].state_extra)

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -64,8 +64,8 @@ def signal_probe(model, key, probe):
 
 probemap = {
     Ensemble: {"decoded_output": None, "input": "in", "scaled_encoders": "encoders"},
-    Neurons: {"output": None, "spikes": None, "rates": None, "input": "in"},
-    Node: {"output": None},
+    Neurons: {"output": "out", "spikes": "out", "rates": "out", "input": "in"},
+    Node: {"output": "out"},
     Connection: {"output": "weighted", "input": "in"},
     LearningRule: {},  # make LR signals probeable, but no mapping required
 }
@@ -108,7 +108,7 @@ def build_probe(model, probe):
     else:
         raise BuildError("Type %r is not probeable" % type(probe.obj).__name__)
 
-    key = probeables[probe.attr] if probe.attr in probeables else probe.attr
+    key = probeables.get(probe.attr, probe.attr)
     if key is None:
         conn_probe(model, probe)
     else:

--- a/nengo/builder/tests/test_neurons.py
+++ b/nengo/builder/tests/test_neurons.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import nengo
@@ -10,15 +11,34 @@ from nengo.builder.neurons import SimNeurons
 )
 def test_spiking_builders(SpikingType):
     # use a base type with its own state(s), to make sure those states get built
-    neuron_type = SpikingType(nengo.AdaptiveLIFRate())
+    neuron_type = SpikingType(
+        nengo.AdaptiveLIFRate(initial_state={"adaptation": np.ones(10) * 2}),
+        initial_state={"voltage": np.ones(10) * 3}
+        if SpikingType is nengo.RegularSpiking
+        else {},
+    )
 
     with nengo.Network() as net:
         neurons = nengo.Ensemble(10, 1, neuron_type=neuron_type).neurons
 
+        # check that the expected attributes are probeable
+        nengo.Probe(neurons, "output")
+        nengo.Probe(neurons, "rate_out")
+        nengo.Probe(neurons, "adaptation")
+        if SpikingType is nengo.RegularSpiking:
+            nengo.Probe(neurons, "voltage")
+
     with nengo.Simulator(net) as sim:
-        ops = [op for op in sim.model.operators if isinstance(op, SimNeurons)]
-        assert len(ops) == 1
+        ops = [op for op in sim.step_order if isinstance(op, SimNeurons)]
+        assert len(ops) == 2
+        assert ops[0].neurons is neurons.ensemble.neuron_type.base_type
+        assert ops[1].neurons is neurons.ensemble.neuron_type
 
         adaptation = sim.model.sig[neurons]["adaptation"]
         # All signals get put in `sets`
         assert sum(adaptation is sig for sig in ops[0].sets) == 1
+
+        # check that initial state argument is applied correctly
+        assert np.allclose(sim.signals[sim.model.sig[neurons]["adaptation"]], 2)
+        if SpikingType is nengo.RegularSpiking:
+            assert np.allclose(sim.signals[sim.model.sig[neurons]["voltage"]], 3)

--- a/nengo/builder/tests/test_optimizer.py
+++ b/nengo/builder/tests/test_optimizer.py
@@ -198,11 +198,11 @@ def test_elementwiseincmerger_scalars():
 def test_simneuronsmerger_warning(rng):
     nt = nengo.PoissonSpiking(nengo.Tanh())
     op1 = SimNeurons(
-        nt, J=Signal(shape=(1,)), state={"spikes": Signal(shape=(1,)), "rng": rng}
+        nt, J=Signal(shape=(1,)), output=Signal(shape=(1,)), state={"rng": rng}
     )
 
     op2 = SimNeurons(
-        nt, J=Signal(shape=(1,)), state={"spikes": Signal(shape=(1,)), "rng": rng}
+        nt, J=Signal(shape=(1,)), output=Signal(shape=(1,)), state={"rng": rng}
     )
     assert SimNeuronsMerger.is_mergeable(op1, op2)
     with pytest.warns(UserWarning, match="Extra state has been modified"):

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -92,14 +92,6 @@ class NeuronType(FrozenObject):
     def probeable(self):
         return tuple(self.state)
 
-    @property
-    def step_math(self):
-        warnings.warn(
-            "'step_math' has been renamed to 'step'. This alias will be removed "
-            "in Nengo 4.0"
-        )
-        return self.step
-
     def current(self, x, gain, bias):
         """Compute current injected in each neuron given input, gain and bias.
 
@@ -293,6 +285,13 @@ class NeuronType(FrozenObject):
             State variables associated with the population.
         """
         raise NotImplementedError("Neurons must provide step")
+
+    def step_math(self, dt, J, **state):
+        warnings.warn(
+            "'step_math' has been renamed to 'step'. This alias will be removed "
+            "in Nengo 4.0"
+        )
+        return self.step(dt, J, **state)
 
 
 class NeuronTypeParam(Parameter):

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -32,12 +32,12 @@ def test_args(AnyNeuronType, seed, rng):
         )
 
 
-def test_node_to_neurons(Simulator, NonDirectNeuronType, plt, seed, allclose):
+def test_node_to_neurons(Simulator, PositiveNeuronType, plt, seed, allclose):
     N = 50
 
     m = nengo.Network(seed=seed)
     with m:
-        m.config[nengo.Ensemble].neuron_type = NonDirectNeuronType()
+        m.config[nengo.Ensemble].neuron_type = PositiveNeuronType()
         a = nengo.Ensemble(N, dimensions=1)
         inn = nengo.Node(output=np.sin)
         inh = nengo.Node(Piecewise({0: 0, 0.5: 1}))

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -390,7 +390,7 @@ def test_noise_copies_ok(Simulator, NonDirectNeuronType, seed, plt, allclose):
     process = FilteredNoise(synapse=nengo.Alpha(1.0), dist=Choice([0.5]))
     with nengo.Network(seed=seed) as model:
         if (
-            "spikes" in NonDirectNeuronType.state
+            NonDirectNeuronType.spiking
             or RegularSpiking in NonDirectNeuronType.__bases__
         ):
             neuron_type = NonDirectNeuronType(initial_state={"voltage": Choice([0])})

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -772,3 +772,8 @@ def test_bad_initial_state(rng, Simulator):
     with pytest.raises(BuildError, match="State 'dict' is of type 'dict'. Only"):
         with Simulator(net):
             pass
+
+
+def test_spikes_to_spikes_warning():
+    with pytest.warns(UserWarning, match="type 'LIF', which is a spiking"):
+        nengo.PoissonSpiking(nengo.LIF())

--- a/nengo/tests/test_reprs.py
+++ b/nengo/tests/test_reprs.py
@@ -146,7 +146,7 @@ def test_neuron_types():
     check_init_args(RectifiedLinear, ["amplitude", "initial_state"])
     check_repr(RectifiedLinear())
     check_repr(RectifiedLinear(amplitude=2))
-    check_repr(RectifiedLinear(initial_state={"rates": Choice([1.0])}))
+    check_repr(RectifiedLinear(initial_state={"output": Choice([1.0])}))
     assert repr(RectifiedLinear()) == "RectifiedLinear()"
 
     check_init_args(SpikingRectifiedLinear, ["amplitude", "initial_state"])
@@ -158,7 +158,7 @@ def test_neuron_types():
     check_init_args(Sigmoid, ["tau_ref", "initial_state"])
     check_repr(Sigmoid())
     check_repr(Sigmoid(tau_ref=0.1))
-    check_repr(Sigmoid(initial_state={"rates": Choice([1.0])}))
+    check_repr(Sigmoid(initial_state={"output": Choice([1.0])}))
     assert repr(Sigmoid()), "Sigmoid()"
     assert repr(Sigmoid(tau_ref=0.001)) == "Sigmoid(tau_ref=0.001)"
 
@@ -171,7 +171,7 @@ def test_neuron_types():
     check_repr(LIFRate(tau_rc=0.05, amplitude=2))
     check_repr(LIFRate(tau_ref=0.02, amplitude=2))
     check_repr(LIFRate(tau_rc=0.05, tau_ref=0.02, amplitude=2))
-    check_repr(LIFRate(initial_state={"rates": Choice([1.0])}))
+    check_repr(LIFRate(initial_state={"output": Choice([1.0])}))
     assert repr(LIFRate()) == "LIFRate()"
     assert repr(LIFRate(tau_rc=0.01, tau_ref=0)) == "LIFRate(tau_rc=0.01, tau_ref=0)"
 
@@ -280,7 +280,7 @@ def test_neuron_types():
     check_init_args(Tanh, ["tau_ref", "initial_state"])
     check_repr(Tanh())
     check_repr(Tanh(tau_ref=0.1))
-    check_repr(Tanh(initial_state={"rates": Choice([1])}))
+    check_repr(Tanh(initial_state={"output": Choice([1])}))
 
 
 def test_learning_rule_types():

--- a/nengo/tests/test_reprs.py
+++ b/nengo/tests/test_reprs.py
@@ -146,7 +146,6 @@ def test_neuron_types():
     check_init_args(RectifiedLinear, ["amplitude", "initial_state"])
     check_repr(RectifiedLinear())
     check_repr(RectifiedLinear(amplitude=2))
-    check_repr(RectifiedLinear(initial_state={"output": Choice([1.0])}))
     assert repr(RectifiedLinear()) == "RectifiedLinear()"
 
     check_init_args(SpikingRectifiedLinear, ["amplitude", "initial_state"])
@@ -158,7 +157,6 @@ def test_neuron_types():
     check_init_args(Sigmoid, ["tau_ref", "initial_state"])
     check_repr(Sigmoid())
     check_repr(Sigmoid(tau_ref=0.1))
-    check_repr(Sigmoid(initial_state={"output": Choice([1.0])}))
     assert repr(Sigmoid()), "Sigmoid()"
     assert repr(Sigmoid(tau_ref=0.001)) == "Sigmoid(tau_ref=0.001)"
 
@@ -171,7 +169,6 @@ def test_neuron_types():
     check_repr(LIFRate(tau_rc=0.05, amplitude=2))
     check_repr(LIFRate(tau_ref=0.02, amplitude=2))
     check_repr(LIFRate(tau_rc=0.05, tau_ref=0.02, amplitude=2))
-    check_repr(LIFRate(initial_state={"output": Choice([1.0])}))
     assert repr(LIFRate()) == "LIFRate()"
     assert repr(LIFRate(tau_rc=0.01, tau_ref=0)) == "LIFRate(tau_rc=0.01, tau_ref=0)"
 
@@ -280,7 +277,6 @@ def test_neuron_types():
     check_init_args(Tanh, ["tau_ref", "initial_state"])
     check_repr(Tanh())
     check_repr(Tanh(tau_ref=0.1))
-    check_repr(Tanh(initial_state={"output": Choice([1])}))
 
 
 def test_learning_rule_types():

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -427,7 +427,7 @@ def test_compare_solvers(Simulator, plt, seed, allclose):
 
 
 @pytest.mark.slow
-def test_regularization(Simulator, nl_nodirect, plt):
+def test_regularization(Simulator, NonDirectNeuronType, plt):
     # TODO: multiple trials per parameter set, with different seeds
 
     Solvers = [LstsqL2, LstsqL2nz]
@@ -443,7 +443,7 @@ def test_regularization(Simulator, nl_nodirect, plt):
 
     model = nengo.Network("test_regularization")
     with model:
-        model.config[nengo.Ensemble].neuron_type = nl_nodirect()
+        model.config[nengo.Ensemble].neuron_type = NonDirectNeuronType()
         u = nengo.Node(output=input_function)
         up = nengo.Probe(u)
 
@@ -556,7 +556,7 @@ def test_eval_points_static(plt, rng):
 
 
 @pytest.mark.slow
-def test_eval_points(Simulator, nl_nodirect, plt, seed, rng):
+def test_eval_points(Simulator, NonDirectNeuronType, plt, seed, rng):
     n = 100
     d = 5
     filter = 0.08
@@ -581,7 +581,7 @@ def test_eval_points(Simulator, nl_nodirect, plt, seed, rng):
         for i, n_points in enumerate(eval_points):
             model = nengo.Network(seed=seed)
             with model:
-                model.config[nengo.Ensemble].neuron_type = nl_nodirect()
+                model.config[nengo.Ensemble].neuron_type = NonDirectNeuronType()
                 u = nengo.Node(output=x)
                 a = nengo.Ensemble(n * d, dimensions=d, eval_points=points[:n_points])
                 nengo.Connection(u, a, synapse=0)

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -100,15 +100,20 @@ class WeakKeyIDDictionary(collections.abc.MutableMapping):
         del self._ref2id[id(ref)]
 
     def get(self, k, default=None):
+        """Return item from dictionary."""
+
         return self._keyvalues[id(k)] if k in self else default
 
     def keys(self):
+        """Return dictionary keys."""
+
         return self._keyrefs.values()
 
     def iterkeys(self):
         return self._keyrefs.values()
 
     def items(self):
+        """Return dictionary key, value pairs."""
         for k in self:
             yield k, self[k]
 
@@ -117,6 +122,8 @@ class WeakKeyIDDictionary(collections.abc.MutableMapping):
             yield k, self[k]
 
     def update(self, in_dict=None, **kwargs):
+        """Update with items from other dictionary."""
+
         if in_dict is not None:
             for key, value in in_dict.items():
                 self.__setitem__(key, value)


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

A couple changes to simplify working with the new neuron type refactoring (motivated by adding support for the refactoring in NengoDL).

- f87a464 Combines the "rates"/"spikes" state into a single "output" state in all cases. Separating them required a lot of `output = state["rates"] if "rates" in state else state["spikes"]` style code and didn't really add any functional advantages. The only place it was used was to signal to the user whether a neuron type was spiking or not via the `spiking` attribute (which looked up the keys in `state`). This was replaced with a manually specified `spiking` attribute for each neuron type (which seems roughly equal complexity to manually specifying either the "spikes" or "rates" state).
- c92678f Unrelated fix for some sphinx errors triggered by a new release or something.
- 4d4251b Adds a `state` property to `SimNeurons` and `SimProcess` that mimics the pre-refactoring `state` attribute (i.e., dereferences the state indices into actual Signals). This was just a code snippet that I was repeating a lot when working with those ops, so made sense to centralize it, and it also makes it easier to write code that is cross-compatibile pre/post refactoring.
- 2a2a93c Makes the "output" attribute (formerly "rates"/"spikes") a mandatory/automatic feature of NeuronTypes. It was implicitly required previously, in that our code assumed that the output signal exists (e.g., for the purposes of connecting from a neuron object). But there was no guarantee that it actually did exist (it relied on all NeuronTypes manually specifying the "output" state variable). Since it is mandatory it makes more sense to just always include it (reducing boilerplate and avoiding the possibility of that signal not existing). I also think it makes sense conceptually to distinguish between the output signal and other state, as they are treated differently. The main difference is that neuron ops depend on the current value of the state signals to compute their output (i.e., the state signals are `incs` or `updates`; they're currently marked as `sets`, but we plan on changing that, see https://github.com/nengo/nengo/pull/1596). The `output` signal, on the other hand, I think makes more sense conceptually as a `set` (i.e., the neuron op just sets that signal to some value, it does not depend on the current value of the `output` to compute its `output`). It feels weird to think of the neuron's output activity as part of the "state" of those neurons (in the same way that we wouldn't think of the neuron's input signal as part of the "state" of the neurons).
The one significant change as a result is that you cannot set the initial state of the "output" variable. However, we were not reading the initial state of the output variable in any of our neuron types, and (for the reasons outlined above) I don't think any neuron type would/should be.
- e5e4d9f This test was only passing due to a lucky seed; Tanh neurons cannot be inhibited as this test is trying to do, since they can output negative values. Which I think is fine, we don't really need to include Tanh in that test.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

https://github.com/nengo/nengo-dl/pull/159 depends on this PR

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Covered by existing tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

I'd go through the commits sequentially, since they can be taken independently and build on each other.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.