### PR TITLE
Fix Signal.may_share_memory comparison with self

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,8 +93,11 @@ Release history
   (`#1541 <https://github.com/nengo/nengo/issues/1541>`__,
   `#1607 <https://github.com/nengo/nengo/pull/1607>`__)
 - Fixed a bug in the validation of ``Choice`` distributions. (`#1630`_)
+- Fixed a bug where a ``Signal`` did not register as sharing memory with itself.
+  (`#1627`_)
 
 .. _#1609: https://github.com/nengo/nengo/pull/1609
+.. _#1627: https://github.com/nengo/nengo/pull/1627
 .. _#1628: https://github.com/nengo/nengo/pull/1628
 .. _#1629: https://github.com/nengo/nengo/pull/1629
 .. _#1630: https://github.com/nengo/nengo/pull/1630

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -281,8 +281,9 @@ class Signal:
         other : Signal
             The other signal we are investigating.
         """
-        return (self.is_view or other.is_view) and np.may_share_memory(
-            self.initial_value, other.initial_value
+        return (self is other) or (
+            (self.is_view or other.is_view)
+            and np.may_share_memory(self.initial_value, other.initial_value)
         )
 
     def reshape(self, *shape):

--- a/nengo/builder/tests/test_learning_rules.py
+++ b/nengo/builder/tests/test_learning_rules.py
@@ -3,7 +3,7 @@ from nengo.builder.tests.test_operator import _test_operator_arg_attributes
 
 
 def test_simpes():
-    argnames = ["pre_filtered", "error", "delta", "learning_rate", "encoders"]
+    argnames = ["pre_filtered", "error", "delta", "learning_rate"]
     non_signals = ["learning_rate"]
     _, sim = _test_operator_arg_attributes(SimPES, argnames, non_signals=non_signals)
 

--- a/nengo/builder/tests/test_signal.py
+++ b/nengo/builder/tests/test_signal.py
@@ -221,6 +221,25 @@ def test_signal_offset():
     assert s[1:].offset == value.strides[1]
 
 
+def test_may_share_memory(rng):
+    def may_share_memory(a, b):
+        a_b, b_a = a.may_share_memory(b), b.may_share_memory(a)
+        assert a_b == b_a  # check commutative property
+        return a_b
+
+    sig_a = Signal(initial_value=rng.rand(3, 4))
+    sig_b = Signal(initial_value=rng.rand(3, 4))
+    assert may_share_memory(sig_a, sig_a)
+    assert may_share_memory(sig_b, sig_b)
+    assert not may_share_memory(sig_a, sig_b)
+
+    assert may_share_memory(sig_a[0:2, :], sig_a)
+    assert may_share_memory(sig_a[0:2, :], sig_a[1:3, :])
+    assert not may_share_memory(sig_a[0, :], sig_a[1, :])
+    assert not may_share_memory(sig_a[0:2, :], sig_b)
+    assert not may_share_memory(sig_a[0:2, :], sig_b[1:3, :])
+
+
 def make_signal(sig_type, shape, indices, data):
     dense = np.zeros(shape)
     dense[indices[:, 0], indices[:, 1]] = data

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -377,8 +377,12 @@ def test_noise_gen(Simulator, NonDirectNeuronType, seed, plt, allclose):
 
     assert np.sum(sim.data[pos_p], axis=0) >= np.sum(sim.data[normal_p], axis=0)
     assert np.sum(sim.data[normal_p], axis=0) >= np.sum(sim.data[neg_p], axis=0)
-    assert not allclose(sim.data[normal_p], sim.data[pos_p], record_rmse=False)
-    assert not allclose(sim.data[normal_p], sim.data[neg_p], record_rmse=False)
+    assert not allclose(
+        sim.data[normal_p], sim.data[pos_p], record_rmse=False, print_fail=0
+    )
+    assert not allclose(
+        sim.data[normal_p], sim.data[neg_p], record_rmse=False, print_fail=0
+    )
 
 
 def test_noise_copies_ok(Simulator, NonDirectNeuronType, seed, plt, allclose):

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -84,7 +84,9 @@ def _test_pes(
     tend = t > 0.4
     assert allclose(sim.data[post_p][tend], vout, atol=0.05)
     assert allclose(sim.data[error_p][tend], 0, atol=0.05)
-    assert not allclose(weights[0], weights[-1], atol=1e-5, record_rmse=False)
+    assert not allclose(
+        weights[0], weights[-1], atol=1e-5, record_rmse=False, print_fail=0
+    )
 
 
 def test_pes_ens_ens(Simulator, NonDirectNeuronType, plt, seed, allclose):
@@ -284,6 +286,21 @@ def test_pes_cycle(Simulator):
         pass
 
 
+def test_pes_adv_idx(Simulator):
+    with nengo.Network() as net:
+        pre = nengo.Ensemble(10, 1)
+        post = nengo.Ensemble(10, 1)
+        nengo.Connection(
+            pre.neurons,
+            post.neurons[[0, 2, 3]],
+            learning_rule_type=nengo.PES(),
+            transform=np.ones((3, pre.n_neurons)),
+        )
+
+    with pytest.raises(BuildError, match="does not support advanced indexing"):
+        Simulator(net)
+
+
 @pytest.mark.parametrize(
     "rule_type, solver",
     [
@@ -332,7 +349,7 @@ def test_unsupervised(Simulator, rule_type, solver, seed, rng, plt, allclose):
     plt.ylabel("Weights")
 
     assert not allclose(
-        sim.data[weights_p][0], sim.data[weights_p][-1], record_rmse=False
+        sim.data[weights_p][0], sim.data[weights_p][-1], record_rmse=False, print_fail=0
     )
 
 
@@ -393,7 +410,10 @@ def test_dt_dependence(Simulator, plt, learning_rule, seed, rng, allclose):
 
     assert allclose(trans_data[0], trans_data[1], atol=3e-3)
     assert not allclose(
-        sim.data[m.weights_p][0], sim.data[m.weights_p][-1], record_rmse=False
+        sim.data[m.weights_p][0],
+        sim.data[m.weights_p][-1],
+        record_rmse=False,
+        print_fail=0,
     )
 
 
@@ -574,7 +594,9 @@ def test_voja_modulate(Simulator, NonDirectNeuronType, seed, allclose):
 
     # Check that encoders changed during first 0.5s
     i = np.where(tend)[0][0]  # first time point after changeover
-    assert not allclose(sim.data[p_enc][0], sim.data[p_enc][i], record_rmse=False)
+    assert not allclose(
+        sim.data[p_enc][0], sim.data[p_enc][i], record_rmse=False, print_fail=0
+    )
 
 
 def test_frozen():

--- a/nengo/tests/test_processes.py
+++ b/nengo/tests/test_processes.py
@@ -318,10 +318,16 @@ def test_seed(Simulator, seed, allclose):
     tols = dict(atol=1e-7, rtol=1e-4)
     assert allclose(sim1.data[ap], sim2.data[ap], **tols)
     assert allclose(sim1.data[bp], sim2.data[bp], **tols)
-    assert not allclose(sim1.data[cp], sim2.data[cp], record_rmse=False, **tols)
-    assert not allclose(sim1.data[ap], sim1.data[bp], record_rmse=False, **tols)
+    assert not allclose(
+        sim1.data[cp], sim2.data[cp], record_rmse=False, print_fail=0, **tols
+    )
+    assert not allclose(
+        sim1.data[ap], sim1.data[bp], record_rmse=False, print_fail=0, **tols
+    )
     assert allclose(sim1.data[dp], sim2.data[dp], **tols)
-    assert not allclose(sim1.data[ep], sim2.data[ep], record_rmse=False, **tols)
+    assert not allclose(
+        sim1.data[ep], sim2.data[ep], record_rmse=False, print_fail=0, **tols
+    )
 
 
 def test_present_input(Simulator, rng, allclose):

--- a/nengo/tests/test_reprs.py
+++ b/nengo/tests/test_reprs.py
@@ -610,10 +610,8 @@ def test_operators():
         repr(SimPyFunc(sig, lambda x: 0.0, True, sig, tag="tag")),
         "<SimPyFunc 'tag' at 0x*>",
     )
-    assert fnmatch(repr(SimPES(sig, sig, sig, sig, 0.1)), "<SimPES at 0x*>")
-    assert fnmatch(
-        repr(SimPES(sig, sig, sig, sig, 0.1, tag="tag")), "<SimPES 'tag' at 0x*>"
-    )
+    assert fnmatch(repr(SimPES(sig, sig, sig, 0.1)), "<SimPES at 0x*>")
+    assert fnmatch(repr(SimPES(sig, sig, sig, 0.1, tag="tag")), "<SimPES 'tag' at 0x*>")
     assert fnmatch(repr(SimBCM(sig, sig, sig, sig, 0.1)), "<SimBCM at 0x*>")
     assert fnmatch(
         repr(SimBCM(sig, sig, sig, sig, 0.1, tag="tag")), "<SimBCM 'tag' at 0x*>"

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -299,7 +299,7 @@ def test_probe_cache(Simulator, allclose):
         sim.run_steps(10)
         ub = np.array(sim.data[up])
 
-    assert not allclose(ua, ub, atol=1e-1, record_rmse=False)
+    assert not allclose(ua, ub, atol=1e-1, record_rmse=False, print_fail=0)
 
 
 def test_invalid_run_time(Simulator):

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -141,7 +141,7 @@ def test_linearfilter_y0(allclose):
     v = 9.81
     x = v * np.ones(10)
     assert allclose(synapse.filt(x, y0=v), v)
-    assert not allclose(synapse.filt(x, y0=0), v, record_rmse=False)
+    assert not allclose(synapse.filt(x, y0=0), v, record_rmse=False, print_fail=0)
 
     # --- y0 does not work for high-order synapse when DC gain is zero
     synapse = LinearFilter([1, 0], [1, 1])
@@ -286,7 +286,7 @@ def test_combined_delay(Simulator, allclose):
     # for sys1, this comes from two levels of filtering
     # for sys2, this comes from one level of filtering + delay in sys2
     assert allclose(sim.data[p1][:2], 0)
-    assert not allclose(sim.data[p1][2], 0, record_rmse=False)
+    assert not allclose(sim.data[p1][2], 0, record_rmse=False, print_fail=0)
 
 
 def test_synapseparam():


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

A signal always shares memory with itself. This bug caused problems in NengoOCL (it's unclear whether it made things less efficient in Nengo core or NengoDL).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

The idea has been tested with NengoOCL. NengoOCL doesn't yet support Nengo `master`, so this exact code hasn't been tested there yet.

Also, should add a unit test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [x] Add unit test
