### PR TITLE
Officially support Python 3.8 on all platforms

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -59,6 +59,7 @@ setup_py:
     - "Programming Language :: Python :: 3.5"
     - "Programming Language :: Python :: 3.6"
     - "Programming Language :: Python :: 3.7"
+    - "Programming Language :: Python :: 3.8"
     - "Topic :: Scientific/Engineering :: Artificial Intelligence"
 
 setup_cfg:
@@ -255,6 +256,8 @@ travis_yml:
       if: "branch =~ ^release-candidate-*"
     - dist: bionic
       python: 3.7
+    - dist: bionic
+      python: 3.8
   pypi_user: tbekolay
   deploy_dists:
     - sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,9 @@ jobs:
   -
     dist: bionic
     python: 3.7
+  -
+    dist: bionic
+    python: 3.8
   - stage: deploy
     if: branch =~ ^release-candidate-* OR tag =~ ^v[0-9]*
     env: SCRIPT="deploy"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,7 @@ Release history
 
 **Changed**
 
+- Nengo is now compatible with Python 3.8. (`#1628`_)
 - The default Connection transform is now ``None``, meaning that there will be
   no transform applied. This only changes behavior when learning on a
   neuron-neuron connection with the default scalar transform. In that situation
@@ -92,6 +93,7 @@ Release history
   `#1607 <https://github.com/nengo/nengo/pull/1607>`__)
 
 .. _#1609: https://github.com/nengo/nengo/pull/1609
+.. _#1628: https://github.com/nengo/nengo/pull/1628
 
 3.0.0 (November 18, 2019)
 =========================

--- a/conftest.py
+++ b/conftest.py
@@ -5,10 +5,10 @@ from nengo.rc import rc
 
 def pytest_runtest_setup(item):
     rc.reload_rc([])
-    rc.set("decoder_cache", "enabled", "False")
-    rc.set("exceptions", "simplified", "False")
-    rc.set("nengo.Simulator", "fail_fast", "True")
-    rc.set("progress", "progress_bar", "False")
+    rc["decoder_cache"]["enabled"] = "False"
+    rc["exceptions"]["simplified"] = "False"
+    rc["nengo.Simulator"]["fail_fast"] = "True"
+    rc["progress"]["progress_bar"] = "False"
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -114,7 +114,7 @@ class Model:
         the ``operators`` attribute.
         """
         self.operators.append(op)
-        if rc.getboolean("nengo.Simulator", "fail_fast"):
+        if rc["nengo.Simulator"].getboolean("fail_fast"):
             # Fail fast by trying make_step with a temporary sigdict
             signals = SignalDict()
             op.init_signals(signals)

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -1,4 +1,4 @@
-import collections
+from collections import defaultdict
 import warnings
 
 import numpy as np
@@ -85,7 +85,7 @@ class Model:
         self.seeds = {}
         self.seeded = {}
 
-        self.sig = collections.defaultdict(dict)
+        self.sig = defaultdict(dict)
         self.sig["common"][0] = Signal(
             np.array(0.0, dtype=rc.float_dtype), readonly=True, name="ZERO"
         )

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -1,4 +1,4 @@
-import collections
+from collections import namedtuple
 
 import numpy as np
 
@@ -19,7 +19,7 @@ from nengo.utils.numpy import is_integer, is_iterable
 built_attrs = ["eval_points", "solver_info", "weights", "transform"]
 
 
-class BuiltConnection(collections.namedtuple("BuiltConnection", built_attrs)):
+class BuiltConnection(namedtuple("BuiltConnection", built_attrs)):
     """Collects the parameters generated in `.build_connection`.
 
     These are stored here because in the majority of cases the equivalent

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -1,4 +1,4 @@
-import collections
+from collections import namedtuple
 import warnings
 
 import numpy as np
@@ -24,7 +24,7 @@ built_attrs = [
 ]
 
 
-class BuiltEnsemble(collections.namedtuple("BuiltEnsemble", built_attrs)):
+class BuiltEnsemble(namedtuple("BuiltEnsemble", built_attrs)):
     """Collects the parameters generated in `.build_ensemble`.
 
     These are stored here because in the majority of cases the equivalent

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -627,7 +627,7 @@ class DecoderCache:
         -------
         str
         """
-        return rc.get("decoder_cache", "path")
+        return rc["decoder_cache"]["path"]
 
     def _close_fd(self):
         if self._fd is not None:
@@ -698,7 +698,7 @@ class DecoderCache:
             return
 
         if limit is None:
-            limit = rc.get("decoder_cache", "size")
+            limit = rc["decoder_cache"]["size"]
         if isinstance(limit, str):
             limit = human2bytes(limit)
 
@@ -849,8 +849,8 @@ class NoDecoderCache:
 
 def get_default_decoder_cache():
     """Get default decoder implementation based on config settings."""
-    if rc.getboolean("decoder_cache", "enabled"):
-        decoder_cache = DecoderCache(rc.getboolean("decoder_cache", "readonly"))
+    if rc["decoder_cache"].getboolean("enabled"):
+        decoder_cache = DecoderCache(rc["decoder_cache"].getboolean("readonly"))
     else:
         decoder_cache = NoDecoderCache()
     return decoder_cache

--- a/nengo/config.py
+++ b/nengo/config.py
@@ -476,7 +476,7 @@ class SupportDefaultsMixin:
         if val is Default:
             val = Config.default(type(self), name)
 
-        if rc.getboolean("exceptions", "simplified"):
+        if rc["exceptions"].getboolean("simplified"):
             try:
                 super().__setattr__(name, val)
             except ValidationError:

--- a/nengo/networks/tests/test_assoc_mem.py
+++ b/nengo/networks/tests/test_assoc_mem.py
@@ -158,7 +158,6 @@ def test_am_wta(Simulator, plt, seed, rng):
     assert similarity(sim.data[utils_p][more_b], np.array([1, 0, 1, 1])) < 0.001
 
 
-@pytest.mark.xfail(reason="This test is not consistent", strict=False)
 def test_am_complex(Simulator, plt, seed, rng):
     """Complex auto-associative memory test.
 

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -1,4 +1,4 @@
-import collections
+from collections import namedtuple, OrderedDict
 import inspect
 
 import numpy as np
@@ -559,7 +559,7 @@ class NdarrayParam(Parameter):
         return ndarray
 
 
-FunctionInfo = collections.namedtuple("FunctionInfo", ["function", "size"])
+FunctionInfo = namedtuple("FunctionInfo", ["function", "size"])
 
 
 class FunctionParam(Parameter):
@@ -614,7 +614,7 @@ class FrozenObject:
     _param_init_order = []
 
     def __init__(self):
-        self._paramdict = collections.OrderedDict(
+        self._paramdict = OrderedDict(
             (k, v)
             for k, v in inspect.getmembers(type(self))
             if isinstance(v, Parameter) and not isinstance(v, ObsoleteParam)

--- a/nengo/tests/test_config.py
+++ b/nengo/tests/test_config.py
@@ -466,12 +466,12 @@ def test_config_pickle(tmp_path):
 
 @pytest.mark.parametrize("simplified", [False, True])
 def test_supportdefaultsmixin_exceptions(request, simplified):
-    def finalizer(val=nengo.rc.get("exceptions", "simplified")):
-        nengo.rc.set("exceptions", "simplified", val)
+    def finalizer(val=nengo.rc["exceptions"]["simplified"]):
+        nengo.rc["exceptions"]["simplified"] = val
 
     request.addfinalizer(finalizer)
 
-    nengo.rc.set("exceptions", "simplified", str(simplified))
+    nengo.rc["exceptions"]["simplified"] = str(simplified)
 
     class MyClass(SupportDefaultsMixin):
         p = Parameter("p", default="baba", readonly=True)

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -83,6 +83,7 @@ def assert_noexceptions(nb_file, tmpdir):
 @pytest.mark.example
 @pytest.mark.parametrize("nb_file", fast_examples)
 @pytest.mark.filterwarnings("ignore:Creating new attribute 'memory_location'")
+@pytest.mark.filterwarnings("ignore:Matplotlib is currently using agg")
 def test_fast_noexceptions(nb_file, tmpdir):
     """Ensure that no cells raise an exception."""
     pytest.importorskip("IPython", minversion="3.0")

--- a/nengo/tests/test_exceptions.py
+++ b/nengo/tests/test_exceptions.py
@@ -44,7 +44,7 @@ def test_validation_error(request):
         )
     )
 
-    nengo.rc.set("exceptions", "simplified", "False")
+    nengo.rc["exceptions"]["simplified"] = "False"
 
     with nengo.Network():
         with pytest.raises(ValidationError) as excinfo:
@@ -67,7 +67,7 @@ def test_validation_error(request):
         ],
     )
 
-    nengo.rc.set("exceptions", "simplified", "True")
+    nengo.rc["exceptions"]["simplified"] = "True"
 
     with pytest.raises(ValidationError) as excinfo:
         nengo.dists.PDF(x=[1, 1], p=[0.1, 0.2])

--- a/nengo/tests/test_rc.py
+++ b/nengo/tests/test_rc.py
@@ -14,5 +14,5 @@ def test_read_file(tmp_path):
     with open(filepath, "r") as fh:
         rc.read_file(fh)
 
-    assert rc.getint("test_rc_section", "setting0") == 3
-    assert rc.getint("test_rc_section", "setting1") == 5
+    assert int(rc["test_rc_section"]["setting0"]) == 3
+    assert int(rc["test_rc_section"]["setting1"]) == 5

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -49,7 +49,7 @@ def test_dtype(Simulator, request, seed, bits):
         nengo.Connection(u, a)
         p = nengo.Probe(a)
 
-    rc.set("precision", "bits", bits)
+    rc["precision"]["bits"] = bits
     with Simulator(model) as sim:
         sim.step()
 

--- a/nengo/utils/builder.py
+++ b/nengo/utils/builder.py
@@ -1,6 +1,6 @@
 """Helper functions for backends generating their own Builder system."""
 
-import collections
+from collections import defaultdict
 
 import numpy as np
 
@@ -237,8 +237,8 @@ def remove_passthrough_nodes(  # noqa: C901
 
 def find_all_io(connections):
     """Build up a list of all inputs and outputs for each object."""
-    inputs = collections.defaultdict(list)
-    outputs = collections.defaultdict(list)
+    inputs = defaultdict(list)
+    outputs = defaultdict(list)
     for c in connections:
         inputs[c.post_obj].append(c)
         outputs[c.pre_obj].append(c)

--- a/nengo/utils/nco.py
+++ b/nengo/utils/nco.py
@@ -71,6 +71,11 @@ class Subfile:
         self.max_size -= size
         return self.fileobj.read(size)
 
+    def readinto(self, b):
+        size = self.fileobj.readinto(b)
+        self.max_size -= size
+        return size
+
     def readline(self, size=None):
         size = min(size, self.max_size) if size is not None else self.max_size
         data = self.fileobj.readline(size)

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -1,7 +1,7 @@
 """
 Extra functions to extend the capabilities of Numpy.
 """
-import collections
+from collections.abc import Iterable
 import logging
 
 import warnings
@@ -43,7 +43,7 @@ def is_iterable(obj):
     if isinstance(obj, np.ndarray):
         return obj.ndim > 0  # 0-d arrays give error if iterated over
     else:
-        return isinstance(obj, collections.abc.Iterable)
+        return isinstance(obj, Iterable)
 
 
 def is_number(obj, check_complex=False):

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -432,9 +432,8 @@ class HtmlProgressBar(ProgressBar):  # pragma: no cover
         def __repr__(self):
             return (
                 "HtmlProgressBar cannot be displayed. Please use the "
-                "TerminalProgressBar. It can be enabled with "
-                "`nengo.rc.set('progress', 'progress_bar', "
-                "'nengo.utils.progress.TerminalProgressBar')`."
+                "TerminalProgressBar. It can be enabled with `nengo.rc['progress']"
+                "['progress_bar'] = 'nengo.utils.progress.TerminalProgressBar'`."
             )
 
         def _repr_html_(self):
@@ -767,13 +766,13 @@ def get_default_progressbar():
     ``ProgressBar``
     """
     try:
-        pbar = rc.getboolean("progress", "progress_bar")
+        pbar = rc["progress"].getboolean("progress_bar")
         if pbar:
             pbar = "auto"
         else:
             pbar = "none"
     except ValueError:
-        pbar = rc.get("progress", "progress_bar")
+        pbar = rc["progress"]["progress_bar"]
 
     if pbar.lower() == "auto":
         if get_ipython() is not None and check_ipy_version((5, 0)):  # pragma: no cover

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -1,6 +1,7 @@
 """Functions that extend the Python Standard Library."""
 
-import collections
+from collections import namedtuple
+from collections.abc import Hashable, MutableMapping, MutableSet
 import inspect
 import itertools
 import os
@@ -10,7 +11,7 @@ import time
 import weakref
 
 
-class WeakKeyDefaultDict(collections.abc.MutableMapping):
+class WeakKeyDefaultDict(MutableMapping):
     """WeakKeyDictionary that allows to define a default."""
 
     def __init__(self, default_factory, items=None, **kwargs):
@@ -39,7 +40,7 @@ class WeakKeyDefaultDict(collections.abc.MutableMapping):
         return len(self._data)
 
 
-class WeakKeyIDDictionary(collections.abc.MutableMapping):
+class WeakKeyIDDictionary(MutableMapping):
     """WeakKeyDictionary that uses object ID to hash.
 
     This ignores the ``__eq__`` and ``__hash__`` functions on objects,
@@ -127,7 +128,7 @@ class WeakKeyIDDictionary(collections.abc.MutableMapping):
             self.__setitem__(key, value)
 
 
-class WeakSet(collections.abc.MutableSet):
+class WeakSet(MutableSet):
     """Uses weak references to store the items in the set."""
 
     def __init__(self, items=None):
@@ -153,7 +154,7 @@ class WeakSet(collections.abc.MutableSet):
             del self._data[key]
 
 
-CheckedCall = collections.namedtuple("CheckedCall", ("value", "invoked"))
+CheckedCall = namedtuple("CheckedCall", ("value", "invoked"))
 
 
 def checked_call(func, *args, **kwargs):
@@ -231,7 +232,7 @@ def groupby(objects, key, hashable=None, force_list=True):
         # get first item without advancing iterator, and see if key is hashable
         objects, objects2 = itertools.tee(iter(objects))
         item0 = next(objects2)
-        hashable = isinstance(key(item0), collections.abc.Hashable)
+        hashable = isinstance(key(item0), Hashable)
 
     if hashable:
         # use a dictionary to sort by hash (faster)

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -6,7 +6,6 @@ import inspect
 import itertools
 import os
 import shutil
-import sys
 import time
 import weakref
 
@@ -284,17 +283,15 @@ class Timer:
 
     """
 
-    TIMER = time.clock if sys.platform == "win32" else time.time
-
     def __init__(self):
         self.start = None
         self.end = None
         self.duration = None
 
     def __enter__(self):
-        self.start = Timer.TIMER()
+        self.start = time.perf_counter()
         return self
 
     def __exit__(self, type, value, traceback):
-        self.end = Timer.TIMER()
+        self.end = time.perf_counter()
         self.duration = self.end - self.start

--- a/nengo/utils/tests/test_nco.py
+++ b/nengo/utils/tests/test_nco.py
@@ -54,6 +54,12 @@ class TestSubfile:
         with testfile.open() as f:
             assert Subfile(f, 2, 14).readline(15) == data[2:11]
 
+    def test_readinto(self, data, testfile):
+        b = bytearray(4)
+        with testfile.open("rb") as f:
+            assert Subfile(f, 2, 6).readinto(b) == 4
+        assert b == b"2345"
+
     def test_seek(self, data, testfile):
         with testfile.open() as f:
             sf = Subfile(f, 2, 6)

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -163,19 +163,19 @@ class TestAutoProgressBar:
         assert progress_bar.closed
 
     def test_get_default_progressbar(self):
-        rc.set("progress", "progress_bar", "False")
+        rc["progress"]["progress_bar"] = "False"
         assert isinstance(get_default_progressbar(), NoProgressBar)
 
-        rc.set("progress", "progress_bar", "True")
+        rc["progress"]["progress_bar"] = "True"
         assert isinstance(get_default_progressbar(), AutoProgressBar)
 
-        rc.set("progress", "progress_bar", "nengo.utils.progress.HtmlProgressBar")
+        rc["progress"]["progress_bar"] = "nengo.utils.progress.HtmlProgressBar"
         assert isinstance(get_default_progressbar(), HtmlProgressBar)
 
-        rc.set("progress", "progress_bar", "nengo.utils.progress.TerminalProgressBar")
+        rc["progress"]["progress_bar"] = "nengo.utils.progress.TerminalProgressBar"
         assert isinstance(get_default_progressbar(), TerminalProgressBar)
 
-        rc.set("progress", "progress_bar", "nengo.InvalidType")
+        rc["progress"]["progress_bar"] = "nengo.InvalidType"
         with pytest.warns(UserWarning, match="Could not load progress bar"):
             assert isinstance(get_default_progressbar(), NoProgressBar)
 
@@ -243,8 +243,8 @@ def test_progress_tracker():
 
 
 def test_to_progress_bar(request, tmpdir):
-    def finalizer(val=rc.get("progress", "progress_bar")):
-        rc.set("progress", "progress_bar", val)
+    def finalizer(val=rc["progress"]["progress_bar"]):
+        rc["progress"]["progress_bar"] = val
 
     request.addfinalizer(finalizer)
 
@@ -253,7 +253,7 @@ def test_to_progress_bar(request, tmpdir):
         assert isinstance(to_progressbar(val), NoProgressBar)
 
     # test true value
-    rc.set("progress", "progress_bar", "nengo.utils.progress.HtmlProgressBar")
+    rc["progress"]["progress_bar"] = "nengo.utils.progress.HtmlProgressBar"
     assert isinstance(to_progressbar(True), HtmlProgressBar)
 
     progress_bar = WriteProgressToFile(str(tmpdir.join("dummyfile.txt")))

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -213,7 +213,7 @@ def test_write_progress_to_file(tmpdir):
 )
 def test_progress_tracker():
     update_interval = 0.001
-    sleep_interval = 7 * update_interval
+    sleep_interval = 20 * update_interval
     stages = 4
     steps = 3
     total_progress = Progress(name_during="total_prog", max_steps=stages)

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -1,4 +1,4 @@
-import collections
+from collections import namedtuple
 import sys
 import time
 
@@ -20,7 +20,7 @@ from nengo.utils.progress import (
 )
 
 
-Update = collections.namedtuple(
+Update = namedtuple(
     "Update", ("name_during", "name_after", "n_steps", "max_steps", "finished")
 )
 

--- a/nengo/utils/threading.py
+++ b/nengo/utils/threading.py
@@ -1,8 +1,8 @@
-import collections
+from collections.abc import Sequence
 import threading
 
 
-class ThreadLocalStack(threading.local, collections.Sequence):
+class ThreadLocalStack(threading.local, Sequence):
     def __init__(self, maxsize=None):
         super().__init__()
         self.maxsize = maxsize

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
 )


### PR DESCRIPTION
**Motivation and context:**
`time.clock` was removed in Python 3.8, which we used when `sys.platform == "win32"`. This PR uses the new `time.perf_counter`, and then also fixes all deprecation warnings raised in Python 3.8, and does a bit of cleanup associated with those deprecation warnings.

Fixes #1594.

**Interactions with other PRs:**
#1597 also makes Nengo compatible with Python 3.8. Unfortunately we cannot merge code if the author has not signed the CAA, which the author has not done. While I have seen the description of #1597, I did not look at the code diff to ensure no IP issues.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
