### PR TITLE
Fix validation of Choice dist with scalar samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,9 +91,11 @@ Release history
 - Fixed a bug where the ``LstsqDrop`` solver errored when solving for zero weights.
   (`#1541 <https://github.com/nengo/nengo/issues/1541>`__,
   `#1607 <https://github.com/nengo/nengo/pull/1607>`__)
+- Fixed a bug in the validation of ``Choice`` distributions. (`#1630`_)
 
 .. _#1609: https://github.com/nengo/nengo/pull/1609
 .. _#1628: https://github.com/nengo/nengo/pull/1628
+.. _#1630: https://github.com/nengo/nengo/pull/1630
 
 3.0.0 (November 18, 2019)
 =========================

--- a/nengo/dists.py
+++ b/nengo/dists.py
@@ -354,7 +354,7 @@ class Choice(Distribution):
 
     @property
     def dimensions(self):
-        return np.prod(self.options.shape[1:])
+        return 0 if self.options.ndim == 1 else np.prod(self.options.shape[1:])
 
     def sample(self, n, d=None, rng=np.random):
         if d is not None and self.dimensions != d:

--- a/nengo/tests/test_dists.py
+++ b/nengo/tests/test_dists.py
@@ -168,6 +168,9 @@ def test_choice_errors():
     with pytest.raises(ValidationError, match="Sum of weights must be positive"):
         Choice([1, 2], [0, 0])
 
+    with pytest.raises(ValidationError, match="Options must be of dimensionality 1"):
+        Choice([0]).sample(n=2, d=1)
+
 
 @pytest.mark.parametrize("shape", [(12, 2), (7, 1), (7,), (1, 1)])
 def test_samples(shape, rng, allclose):

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -387,7 +387,7 @@ def test_noise_copies_ok(Simulator, NonDirectNeuronType, seed, plt, allclose):
     We test this both with the default system and without.
     """
 
-    process = FilteredNoise(synapse=nengo.Alpha(1.0), dist=Choice([0.5]))
+    process = FilteredNoise(synapse=nengo.Alpha(1.0), dist=Choice([[0.5]]))
     with nengo.Network(seed=seed) as model:
         if (
             NonDirectNeuronType.spiking


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

`Choice([0, 1, 2, 3])` should have `dimensionality==0` (because we're sampling scalar values from that list of options). But it was being treated as `dimensions==1`, because `options.shape[1:] == []` and `np.prod([]) == 1`. This caused it to miss the validation for, e.g., `nengo.Connection(a.neurons, b.neurons, transform=Choice([0])` (this would correctly raise an error if `a.n_neurons > 1`, but the validation would be missed for `a.neurons == 1`, and we'd end up with a weird error downstream).

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

This supercedes https://github.com/nengo/nengo-dl/pull/166

Fixes https://github.com/nengo/nengo-dl/issues/124

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a test for the 0-dimensionality validation check.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.