### PR TITLE
Fix bug with sliced neuron-to-neuron PES learning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,12 +95,15 @@ Release history
 - Fixed a bug in the validation of ``Choice`` distributions. (`#1630`_)
 - Fixed a bug where a ``Signal`` did not register as sharing memory with itself.
   (`#1627`_)
+- Fixed a shape error when applying PES learning to a neuron-to-neuron connection with a
+  slice on the post-synaptic neurons. (`#1640`_)
 
 .. _#1609: https://github.com/nengo/nengo/pull/1609
 .. _#1627: https://github.com/nengo/nengo/pull/1627
 .. _#1628: https://github.com/nengo/nengo/pull/1628
 .. _#1629: https://github.com/nengo/nengo/pull/1629
 .. _#1630: https://github.com/nengo/nengo/pull/1630
+.. _#1640: https://github.com/nengo/nengo/pull/1640
 
 3.0.0 (November 18, 2019)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,9 @@ Release history
 
 - ``NeuronType.step`` replaces the ``NeuronType.step_math`` method,
   which will be removed in Nengo 4.0.0. (`#1609`_)
+- ``Connection.is_decoded`` is deprecated, as the definition of whether a Connection
+  is decoded or not was ambiguous. Instead we recommend directly checking the pre/post
+  objects for the properties of interest. (`#1640`_)
 
 **Fixed**
 
@@ -97,6 +100,12 @@ Release history
   (`#1627`_)
 - Fixed a shape error when applying PES learning to a neuron-to-neuron connection with a
   slice on the post-synaptic neurons. (`#1640`_)
+- Fixed a shape error when applying PES learning to a neuron->ensemble connection with
+  a weight solver. (`#1640`_)
+- Fixed a shape error when applying PES learning to an ensemble->neuron connection.
+  (`#1640`_)
+- Fixed a shape error when applying PES learning with a slice on the pre-synaptic
+  object. (`#1640`_)
 
 .. _#1609: https://github.com/nengo/nengo/pull/1609
 .. _#1627: https://github.com/nengo/nengo/pull/1627

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -708,9 +708,17 @@ def build_pes(model, pes, rule):
                 "PES learning rule does not support advanced indexing on non-decoded "
                 "connections"
             )
-        encoders = model.sig[post]["encoders"][:, conn.post_slice]
 
-        local_error = Signal(shape=(post.n_neurons,))
+        encoders = model.sig[post]["encoders"]
+        # slice along neuron dimension if connecting to a neuron object, otherwise
+        # slice along state dimension
+        encoders = (
+            encoders[:, conn.post_slice]
+            if isinstance(conn.post_obj, Ensemble)
+            else encoders[conn.post_slice, :]
+        )
+
+        local_error = Signal(shape=(encoders.shape[0],))
         model.add_op(Reset(local_error))
         model.add_op(DotInc(encoders, error, local_error, tag="PES:encode"))
 

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -46,7 +46,7 @@ class LearningRuleType(FrozenObject, SupportDefaultsMixin):
     * ``'post'``: vector error signal in post-object space
     * ``'mid'``: vector error signal in the ``conn.size_mid`` space
     * ``'pre_state'``: vector error signal in pre-synaptic ensemble space
-    * ``'post_state'``: vector error signal in pre-synaptic ensemble space
+    * ``'post_state'``: vector error signal in post-synaptic ensemble space
 
     The difference between ``'post_state'`` and ``'post'`` is that with the
     former, if a ``Neurons`` object is passed, it will use the dimensionality

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -1015,10 +1015,12 @@ def test_connectionlearningruletypeparam():
         a = nengo.Ensemble(10, 1)
         b = nengo.Ensemble(11, 1)
 
-        with pytest.raises(ValueError):  # need a 2D transform for BCM
+        with pytest.raises(
+            ValidationError, match="can only be applied on connections to neurons"
+        ):
             nengo.Connection(a, b, learning_rule_type=nengo.BCM())
 
-        with pytest.raises(ValueError):  # transform must be correct shape
+        with pytest.raises(ValidationError, match="does not match expected shape"):
             nengo.Connection(
                 a, b, transform=np.ones((10, 11)), learning_rule_type=nengo.BCM()
             )
@@ -1214,3 +1216,9 @@ def test_learning_transform_shape_error(Simulator):
     ):
         with Simulator(net):
             pass
+
+
+def test_is_decoded_deprecation():
+    with pytest.warns(DeprecationWarning, match="is_decoded is deprecated"):
+        with nengo.Network():
+            assert nengo.Connection(nengo.Node(0), nengo.Node(size_in=1)).is_decoded


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Applying PES learning to a neuron-to-neuron connection with a slice on the post-synaptic neurons did not work correctly (we were incorrectly applying the slicing to the state dimension instead of the neuron dimension).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a new test, see `test_pes_neuron_neuron_slice`.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.