### PR TITLE
Fix cache bug if index version is too new

### DIFF
--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -749,8 +749,11 @@ class DecoderCache:
         def cached_solver(
             conn, gain, bias, x, targets, rng=np.random, **uncached_kwargs
         ):
-            if not self._in_context:
-                warnings.warn("Cannot use cached solver outside of `with cache` block.")
+            if not self._in_context or self._index is None:
+                if not self._in_context:
+                    warnings.warn(
+                        "Cannot use cached solver outside of `with cache` block."
+                    )
                 return solver_fn(
                     conn, gain, bias, x, targets, rng=rng, **uncached_kwargs
                 )

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -1,6 +1,7 @@
 import errno
 import multiprocessing
 import os
+import pickle
 import sys
 from subprocess import CalledProcessError
 
@@ -178,6 +179,19 @@ def test_corrupted_decoder_cache_index(tmpdir):
     with DecoderCache(cache_dir=cache_dir):
         pass
     assert len(os.listdir(cache_dir)) == 2  # index, index.lock
+
+
+def test_too_new_decoder_cache_index(tmpdir):
+    cache_dir = str(tmpdir)
+
+    # Write index with super large version numbers
+    with open(os.path.join(cache_dir, CacheIndex._INDEX), "wb") as f:
+        pickle.dump((1000, 1000), f)
+
+    with DecoderCache(cache_dir=cache_dir) as cache:
+        solver_mock = SolverMock()
+        cache.wrap_solver(solver_mock)(**get_solver_test_args())
+        assert SolverMock.n_calls[solver_mock] == 1
 
 
 def test_decoder_cache_invalidation(tmpdir):


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

If the cache version is too new, we should just ignore the cache. Currently, there's an error because it tries to use the index when it's `None`.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

I added a test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
