### PR TITLE
Format BuildError in SparseDotInc

### DIFF
--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -643,11 +643,11 @@ class SparseDotInc(DotInc):
     """
 
     def __init__(self, A, X, Y, tag=None):
-        if not A.sparse:
-            raise BuildError("%s: A must be a sparse Signal")
-
         # Disallow reshaping
         super().__init__(A, X, Y, reshape=False, tag=tag)
+
+        if not A.sparse:
+            raise BuildError("%s: A must be a sparse Signal" % self)
 
 
 class BsrDotInc(DotInc):


### PR DESCRIPTION
**Motivation and context:**
`BuildError` in `SparseDotInc` was not supplying anything to format `%s`. Fix modelled after: https://github.com/nengo/nengo/blob/1d554057ba5479fc818d7064a9d9fbb5f9255de8/nengo/builder/operator.py#L424-L427

Note the error also needed to be moved after `super` in order for `str(self)` to have access to the required attributes.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [N/A] I have updated the documentation accordingly.
- [N/A] I have included a changelog entry.
- [N/A] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.