### PR TITLE
Reset op resets to initial signal value

### DIFF
--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -722,9 +722,9 @@ def build_voja(model, voja, rule):
 
     # Learning signal, defaults to 1 in case no connection is made
     # and multiplied by the learning_rate * dt
-    learning = Signal(shape=rule.size_in, name="Voja:learning")
+    learning = Signal(initial_value=np.ones(rule.size_in), name="Voja:learning")
     assert rule.size_in == 1
-    model.add_op(Reset(learning, value=1.0))
+    model.add_op(Reset(learning))
     model.sig[rule]["in"] = learning  # optional connection will attach here
 
     scaled_encoders = model.sig[post]["encoders"]

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -251,16 +251,14 @@ class TimeUpdate(Operator):
 
 
 class Reset(Operator):
-    """Assign a constant value to a Signal.
+    """Resets a signal to its initial value.
 
-    Implements ``dst[...] = value``.
+    Implements ``dst[...] = dst.initial_value``.
 
     Parameters
     ----------
     dst : Signal
         The Signal to reset.
-    value : float, optional
-        The constant value to which ``dst`` is set.
     tag : str, optional
         A label associated with the operator, for debugging purposes.
 
@@ -270,8 +268,6 @@ class Reset(Operator):
         The Signal to reset.
     tag : str or None
         A label associated with the operator, for debugging purposes.
-    value : float
-        The constant value to which ``dst`` is set.
 
     Notes
     -----
@@ -283,7 +279,6 @@ class Reset(Operator):
 
     def __init__(self, dst, value=0, tag=None):
         super().__init__(tag=tag)
-        self.value = float(value)
 
         self.sets = [dst]
         self.incs = []
@@ -300,10 +295,9 @@ class Reset(Operator):
 
     def make_step(self, signals, dt, rng):
         target = signals[self.dst]
-        value = self.value
 
         def step_reset():
-            target[...] = value
+            target[...] = self.dst.initial_value
 
         return step_reset
 

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -525,12 +525,12 @@ class ResetMerger(Merger):
 
     @staticmethod
     def is_mergeable(op1, op2):
-        return SigMerger.check([op1.dst, op2.dst]) and op1.value == op2.value
+        return SigMerger.check([op1.dst, op2.dst])
 
     @staticmethod
     def merge(ops):
         dst, replacements = SigMerger.merge([o.dst for o in ops])
-        return Reset(dst, ops[0].value), replacements
+        return Reset(dst), replacements
 
 
 @OpMerger.register(Copy)


### PR DESCRIPTION
**Motivation and context:**
When I was preparing the 3.1 release, I found that a slow test was failing. To fix it, I added a `Reset` op, which required resetting the value to a two-dimensional value instead of a scalar. Rather than deal with that, I though it made more sense to have `Reset` reset signals to their initial values, whatever they may be.

In the end, I went with another approach to fix the slow test failure, but this PR still seems like a useful one to have IMO.

**How has this been tested?**
Existing tests cover it.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
- [ ] Discuss if this change is worthwhile
- [ ] Add changelog entry
