### PR TITLE
Add SimProbe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,13 @@ repos:
     rev: 20.8b0
     hooks:
     - id: black
+      files: \.py$
       exclude: |
           (?x)(
               _vendor/*
           )
+-   repo: https://github.com/pycqa/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+        files: \.py$

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,7 @@ Release history
 - Added the ``RLS`` (recursive least-squares) learning rule, which is an online
   version of the least-squares method typically used for offline decoder-solving.
   (`#1611`_, `example <learn-product_>`__)
+- Added the ``SimProbe`` operator, which marks a signal as being probed. (`#1653`_)
 
 **Changed**
 
@@ -125,6 +126,7 @@ Release history
 .. _#1629: https://github.com/nengo/nengo/pull/1629
 .. _#1630: https://github.com/nengo/nengo/pull/1630
 .. _#1640: https://github.com/nengo/nengo/pull/1640
+.. _#1653: https://github.com/nengo/nengo/pull/1653
 .. _learn-product: https://www.nengo.ai/nengo/examples/learning/learn-product.html
 
 3.0.0 (November 18, 2019)

--- a/nengo/__init__.py
+++ b/nengo/__init__.py
@@ -35,18 +35,22 @@ There are two options for getting Nengo working:
     )
 del sys
 
+
 # Nengo namespace (API)
+from nengo import spa  # pylint: disable=cyclic-import
+from nengo import dists, exceptions, networks, presets, processes, utils
 from nengo.base import Process
 from nengo.config import Config
 from nengo.connection import Connection
 from nengo.ensemble import Ensemble
-from nengo.node import Node
+from nengo.learning_rules import BCM, PES, RLS, Oja, Voja
+from nengo.network import Network
 from nengo.neurons import (
+    LIF,
     AdaptiveLIF,
     AdaptiveLIFRate,
     Direct,
     Izhikevich,
-    LIF,
     LIFRate,
     PoissonSpiking,
     RectifiedLinear,
@@ -56,16 +60,13 @@ from nengo.neurons import (
     StochasticSpiking,
     Tanh,
 )
-from nengo.network import Network
-from nengo.learning_rules import BCM, Oja, PES, RLS, Voja
+from nengo.node import Node
 from nengo.params import Default
 from nengo.probe import Probe
-from nengo.rc import rc, RC_DEFAULTS
+from nengo.rc import RC_DEFAULTS, rc
 from nengo.simulator import Simulator
 from nengo.synapses import Alpha, LinearFilter, Lowpass, Triangle
 from nengo.transforms import Convolution, Dense, Sparse
-from nengo import dists, exceptions, networks, presets, processes, utils
-from nengo import spa  # pylint: disable=cyclic-import
 
 logger = logging.getLogger(__name__)
 try:

--- a/nengo/_vendor/npconv2d/conv2d.py
+++ b/nengo/_vendor/npconv2d/conv2d.py
@@ -26,6 +26,7 @@ SOFTWARE.
 from __future__ import division
 
 import numpy as np
+
 from nengo.utils.numpy import array_offset
 
 

--- a/nengo/_vendor/portalocker/__init__.py
+++ b/nengo/_vendor/portalocker/__init__.py
@@ -1,8 +1,4 @@
-from . import __about__
-from . import constants
-from . import exceptions
-from . import portalocker
-from . import utils
+from . import __about__, constants, exceptions, portalocker, utils
 
 #: The package name on Pypi
 __package_name__ = __about__.__package_name__

--- a/nengo/_vendor/portalocker/portalocker.py
+++ b/nengo/_vendor/portalocker/portalocker.py
@@ -1,7 +1,6 @@
 import os
-from . import exceptions
-from . import constants
 
+from . import constants, exceptions
 
 if os.name == 'nt':  # pragma: no cover
     import msvcrt

--- a/nengo/_vendor/portalocker/utils.py
+++ b/nengo/_vendor/portalocker/utils.py
@@ -1,11 +1,10 @@
-import os
-import time
 import atexit
-import tempfile
 import contextlib
-from . import exceptions
-from . import constants
-from . import portalocker
+import os
+import tempfile
+import time
+
+from . import constants, exceptions, portalocker
 
 current_time = getattr(time, "monotonic", time.time)
 

--- a/nengo/_vendor/scipy/sparse/linalg_expm.py
+++ b/nengo/_vendor/scipy/sparse/linalg_expm.py
@@ -40,9 +40,9 @@ import math
 
 import numpy as np
 
+from ..special import comb
 from .linalg_interface import LinearOperator
 from .linalg_onenormest import onenormest
-from ..special import comb
 
 UPPER_TRIANGULAR = 'upper_triangular'
 

--- a/nengo/base.py
+++ b/nengo/base.py
@@ -1,5 +1,5 @@
-from copy import copy as std_copy
 import warnings
+from copy import copy as std_copy
 
 import numpy as np
 
@@ -9,13 +9,13 @@ from nengo.exceptions import NotAddedToNetworkWarning, ValidationError
 from nengo.params import (
     FrozenObject,
     IntParam,
-    iter_params,
     NumberParam,
     Parameter,
     StringParam,
     Unconfigurable,
+    iter_params,
 )
-from nengo.utils.numpy import as_shape, maxint, maxseed, is_integer
+from nengo.utils.numpy import as_shape, is_integer, maxint, maxseed
 
 
 class NetworkMember(type):

--- a/nengo/builder/__init__.py
+++ b/nengo/builder/__init__.py
@@ -1,8 +1,3 @@
-# Must be imported first as build functions rely on them
-from .builder import Builder, Model
-from .operator import Operator
-from .signal import Signal
-
 # Must be imported in order to register the build functions
 from . import (
     connection,
@@ -15,3 +10,6 @@ from . import (
     processes,
     transforms,
 )
+from .builder import Builder, Model
+from .operator import Operator
+from .signal import Signal

--- a/nengo/builder/builder.py
+++ b/nengo/builder/builder.py
@@ -1,10 +1,10 @@
-from collections import defaultdict
 import warnings
+from collections import defaultdict
 
 import numpy as np
 
-from nengo.builder.signal import Signal, SignalDict
 from nengo.builder.operator import TimeUpdate
+from nengo.builder.signal import Signal, SignalDict
 from nengo.cache import NoDecoderCache
 from nengo.exceptions import BuildError
 from nengo.rc import rc

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -2,18 +2,19 @@ from collections import namedtuple
 
 import numpy as np
 
-from nengo.builder import Builder, Signal
+from nengo.builder.builder import Builder
 from nengo.builder.ensemble import gen_eval_points, get_activities
 from nengo.builder.node import SimPyFunc
 from nengo.builder.operator import Copy, ElementwiseInc, Reset
+from nengo.builder.signal import Signal
 from nengo.connection import Connection
-from nengo.transforms import Dense, NoTransform
 from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError
 from nengo.neurons import Direct
 from nengo.node import Node
 from nengo.rc import rc
 from nengo.solvers import NoSolver, Solver
+from nengo.transforms import Dense, NoTransform
 from nengo.utils.numpy import is_integer, is_iterable
 
 built_attrs = ["eval_points", "solver_info", "weights", "transform"]

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -1,11 +1,12 @@
-from collections import namedtuple
 import warnings
+from collections import namedtuple
 
 import numpy as np
 
 import nengo.utils.numpy as npext
-from nengo.builder import Builder, Signal
+from nengo.builder.builder import Builder
 from nengo.builder.operator import Copy, DotInc, Reset
+from nengo.builder.signal import Signal
 from nengo.dists import Distribution, get_samples
 from nengo.ensemble import Ensemble
 from nengo.exceptions import BuildError, NengoWarning

--- a/nengo/builder/learning_rules.py
+++ b/nengo/builder/learning_rules.py
@@ -1,8 +1,9 @@
 import numpy as np
 
-from nengo.builder import Builder, Operator, Signal
+from nengo.builder.builder import Builder
 from nengo.builder.connection import slice_signal
-from nengo.builder.operator import Copy, DotInc, Reset
+from nengo.builder.operator import Copy, DotInc, Operator, Reset
+from nengo.builder.signal import Signal
 from nengo.connection import LearningRule
 from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError

--- a/nengo/builder/network.py
+++ b/nengo/builder/network.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 
 import nengo.utils.numpy as npext
-from nengo.builder import Builder
+from nengo.builder.builder import Builder
 from nengo.connection import Connection
 from nengo.ensemble import Ensemble
 from nengo.network import Network

--- a/nengo/builder/neurons.py
+++ b/nengo/builder/neurons.py
@@ -1,6 +1,8 @@
 import numpy as np
 
-from nengo.builder import Builder, Operator, Signal
+from nengo.builder.builder import Builder
+from nengo.builder.operator import Operator
+from nengo.builder.signal import Signal
 from nengo.exceptions import BuildError
 from nengo.neurons import NeuronType, RatesToSpikesNeuronType
 from nengo.utils.numpy import is_array_like

--- a/nengo/builder/node.py
+++ b/nengo/builder/node.py
@@ -1,5 +1,6 @@
-from nengo.builder import Builder, Signal
+from nengo.builder.builder import Builder
 from nengo.builder.operator import Reset, SimPyFunc
+from nengo.builder.signal import Signal
 from nengo.exceptions import BuildError
 from nengo.node import Node
 from nengo.processes import Process

--- a/nengo/builder/operator.py
+++ b/nengo/builder/operator.py
@@ -34,9 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
 
+import nengo.utils.numpy as npext
 from nengo.exceptions import BuildError, SimulationError
 from nengo.utils.functions import function_name
-import nengo.utils.numpy as npext
 
 
 class Operator:

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -1,9 +1,9 @@
 """Operator graph optimizers."""
 
-from collections import defaultdict, namedtuple
-from itertools import zip_longest
 import logging
 import warnings
+from collections import defaultdict, namedtuple
+from itertools import zip_longest
 
 import numpy as np
 

--- a/nengo/builder/probe.py
+++ b/nengo/builder/probe.py
@@ -1,6 +1,7 @@
-from nengo.builder import Builder, Signal
+from nengo.builder.builder import Builder
 from nengo.builder.connection import slice_signal
 from nengo.builder.operator import Copy, Reset
+from nengo.builder.signal import Signal
 from nengo.connection import Connection, LearningRule
 from nengo.ensemble import Ensemble, Neurons
 from nengo.exceptions import BuildError

--- a/nengo/builder/processes.py
+++ b/nengo/builder/processes.py
@@ -1,4 +1,6 @@
-from nengo.builder import Builder, Operator, Signal
+from nengo.builder.builder import Builder
+from nengo.builder.operator import Operator
+from nengo.builder.signal import Signal
 from nengo.processes import Process
 from nengo.rc import rc
 

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -2,10 +2,10 @@ from io import StringIO
 
 import numpy as np
 
+import nengo.utils.numpy as npext
 from nengo.exceptions import SignalError
 from nengo.rc import rc
 from nengo.transforms import SparseMatrix
-import nengo.utils.numpy as npext
 
 
 def is_sparse(obj):

--- a/nengo/builder/tests/test_operator.py
+++ b/nengo/builder/tests/test_operator.py
@@ -8,10 +8,10 @@ from nengo.builder.operator import (
     ElementwiseInc,
     Operator,
     Reset,
-    reshape_dot,
     SimPyFunc,
     SparseDotInc,
     TimeUpdate,
+    reshape_dot,
 )
 from nengo.exceptions import BuildError
 

--- a/nengo/builder/tests/test_optimizer.py
+++ b/nengo/builder/tests/test_optimizer.py
@@ -1,9 +1,10 @@
 import numpy as np
-from numpy.testing import assert_almost_equal
 import pytest
+from numpy.testing import assert_almost_equal
 
 import nengo
 from nengo.builder.neurons import SimNeurons
+from nengo.builder.operator import Copy, ElementwiseInc
 from nengo.builder.optimizer import (
     CopyMerger,
     ElementwiseIncMerger,
@@ -12,7 +13,6 @@ from nengo.builder.optimizer import (
     SigMerger,
     SimNeuronsMerger,
 )
-from nengo.builder.operator import Copy, ElementwiseInc
 from nengo.builder.signal import Signal
 from nengo.tests.test_learning_rules import learning_net
 from nengo.transforms import SparseMatrix

--- a/nengo/builder/tests/test_probe.py
+++ b/nengo/builder/tests/test_probe.py
@@ -1,6 +1,7 @@
 import pytest
 
 import nengo
+from nengo.builder.probe import SimProbe
 from nengo.exceptions import BuildError
 
 
@@ -9,7 +10,13 @@ def test_signal_probe(seed):
 
     # --- test probing wrong type
     with nengo.Network() as net:
-        p = nengo.Probe(nengo.Node(0))
+        node = nengo.Node(0)
+        p = nengo.Probe(node)
+
+    with nengo.Simulator(net) as sim:
+        probe_ops = [op for op in sim.model.operators if isinstance(op, SimProbe)]
+        assert len(probe_ops) == 1
+        assert probe_ops[0].signal is sim.model.sig[node]["out"]
 
     # hack to change probe target without tripping API validation
     nengo.Probe.target.data[p] = 1

--- a/nengo/builder/tests/test_probe.py
+++ b/nengo/builder/tests/test_probe.py
@@ -1,6 +1,6 @@
 import pytest
-import nengo
 
+import nengo
 from nengo.exceptions import BuildError
 
 

--- a/nengo/builder/tests/test_processes.py
+++ b/nengo/builder/tests/test_processes.py
@@ -1,4 +1,5 @@
 import pytest
+
 from nengo.builder.processes import SimProcess
 from nengo.builder.tests.test_operator import _test_operator_arg_attributes
 

--- a/nengo/builder/tests/test_transforms.py
+++ b/nengo/builder/tests/test_transforms.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pytest
 
+from nengo.builder.signal import Signal
+from nengo.builder.tests.test_operator import _test_operator_arg_attributes
+from nengo.builder.transforms import ConvInc, multiply
 from nengo.exceptions import BuildError
 from nengo.transforms import Convolution
-from nengo.builder.signal import Signal
-from nengo.builder.transforms import ConvInc, multiply
-from nengo.builder.tests.test_operator import _test_operator_arg_attributes
 
 
 def test_multiply():

--- a/nengo/builder/transforms.py
+++ b/nengo/builder/transforms.py
@@ -1,11 +1,12 @@
 import numpy as np
 
-from nengo.builder import Builder, Operator, Signal
-from nengo.builder.operator import DotInc, ElementwiseInc, Reset, SparseDotInc
+from nengo._vendor.npconv2d import conv2d
+from nengo.builder.builder import Builder
+from nengo.builder.operator import DotInc, ElementwiseInc, Operator, Reset, SparseDotInc
+from nengo.builder.signal import Signal
 from nengo.exceptions import BuildError
 from nengo.rc import rc
 from nengo.transforms import Convolution, Dense, NoTransform, Sparse
-from nengo._vendor.npconv2d import conv2d
 
 
 def multiply(x, y):

--- a/nengo/cache.py
+++ b/nengo/cache.py
@@ -7,19 +7,19 @@ import os
 import pickle
 import shutil
 import struct
-from subprocess import CalledProcessError
 import sys
-from uuid import uuid1
 import warnings
+from subprocess import CalledProcessError
+from uuid import uuid1
 
 import numpy as np
 
 from nengo.dists import (
+    PDF,
     Choice,
     CosineSimilarity,
     Exponential,
     Gaussian,
-    PDF,
     Samples,
     ScatteredHypersphere,
     SqrtBeta,
@@ -34,11 +34,11 @@ from nengo.exceptions import (
     TimeoutError,
 )
 from nengo.neurons import (
+    LIF,
     AdaptiveLIF,
     AdaptiveLIFRate,
     Direct,
     Izhikevich,
-    LIF,
     LIFRate,
     PoissonSpiking,
     RectifiedLinear,
@@ -64,12 +64,12 @@ from nengo.solvers import (
 from nengo.utils import nco
 from nengo.utils.cache import byte_align, bytes2human, human2bytes
 from nengo.utils.least_squares_solvers import (
+    SVD,
+    BlockConjgrad,
     Cholesky,
+    Conjgrad,
     ConjgradScipy,
     LSMRScipy,
-    Conjgrad,
-    BlockConjgrad,
-    SVD,
     RandomizedSVD,
 )
 from nengo.utils.lock import FileLock

--- a/nengo/network.py
+++ b/nengo/network.py
@@ -1,5 +1,5 @@
-from copy import deepcopy
 import warnings
+from copy import deepcopy
 
 from nengo.config import Config
 from nengo.connection import Connection

--- a/nengo/networks/__init__.py
+++ b/nengo/networks/__init__.py
@@ -1,7 +1,7 @@
-from .ensemblearray import EnsembleArray
 from .actionselection import BasalGanglia, Thalamus
 from .assoc_mem import AssociativeMemory
 from .circularconvolution import CircularConvolution
+from .ensemblearray import EnsembleArray
 from .integrator import Integrator
 from .oscillator import Oscillator
 from .product import Product

--- a/nengo/networks/assoc_mem.py
+++ b/nengo/networks/assoc_mem.py
@@ -2,8 +2,8 @@ import warnings
 
 import numpy as np
 
-from nengo.connection import Connection
 from nengo.config import Config
+from nengo.connection import Connection
 from nengo.dists import Choice, Exponential, Uniform
 from nengo.ensemble import Ensemble
 from nengo.exceptions import ValidationError
@@ -11,6 +11,7 @@ from nengo.network import Network
 from nengo.node import Node
 from nengo.utils.network import with_self
 from nengo.utils.numpy import is_iterable
+
 from .ensemblearray import EnsembleArray
 
 

--- a/nengo/networks/tests/test_assoc_mem.py
+++ b/nengo/networks/tests/test_assoc_mem.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 
-from nengo.exceptions import ValidationError
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.networks.assoc_mem import AssociativeMemory
 
 

--- a/nengo/neurons.py
+++ b/nengo/neurons.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 
-from nengo.dists import Choice, Distribution, get_samples, Uniform
+from nengo.dists import Choice, Distribution, Uniform, get_samples
 from nengo.exceptions import SimulationError, ValidationError
 from nengo.params import DictParam, FrozenObject, NumberParam, Parameter
 from nengo.rc import rc

--- a/nengo/params.py
+++ b/nengo/params.py
@@ -1,5 +1,5 @@
-from collections import namedtuple, OrderedDict
 import inspect
+from collections import OrderedDict, namedtuple
 
 import numpy as np
 

--- a/nengo/presets.py
+++ b/nengo/presets.py
@@ -1,6 +1,8 @@
 """Configuration presets for common use cases."""
 
-from nengo import Config, Ensemble, dists
+from nengo.config import Config
+from nengo.dists import Choice, Exponential, Uniform
+from nengo.ensemble import Ensemble
 
 
 def ThresholdingEnsembles(threshold, intercept_width=0.15, radius=1.0):
@@ -39,7 +41,7 @@ def ThresholdingEnsembles(threshold, intercept_width=0.15, radius=1.0):
     """
     config = Config(Ensemble)
     config[Ensemble].radius = radius
-    config[Ensemble].intercepts = dists.Exponential(intercept_width, threshold, radius)
-    config[Ensemble].encoders = dists.Choice([[1]])
-    config[Ensemble].eval_points = dists.Uniform(threshold / radius, 1)
+    config[Ensemble].intercepts = Exponential(intercept_width, threshold, radius)
+    config[Ensemble].encoders = Choice([[1]])
+    config[Ensemble].eval_points = Uniform(threshold / radius, 1)
     return config

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -2,7 +2,7 @@ from nengo.base import NengoObject, NengoObjectParam, ObjView
 from nengo.config import Config
 from nengo.connection import Connection, LearningRule
 from nengo.exceptions import ValidationError
-from nengo.params import Default, ConnectionDefault, NumberParam, Parameter, StringParam
+from nengo.params import ConnectionDefault, Default, NumberParam, Parameter, StringParam
 from nengo.solvers import SolverParam
 from nengo.synapses import SynapseParam
 

--- a/nengo/rc.py
+++ b/nengo/rc.py
@@ -59,8 +59,8 @@ Commented lines show the default values for each setting.
 
 """
 
-from configparser import ConfigParser, DEFAULTSECT
 import logging
+from configparser import DEFAULTSECT, ConfigParser
 
 import numpy as np
 

--- a/nengo/solvers.py
+++ b/nengo/solvers.py
@@ -13,9 +13,9 @@ import numpy as np
 import nengo.utils.least_squares_solvers as lstsq
 from nengo.params import BoolParam, FrozenObject, NdarrayParam, NumberParam, Parameter
 from nengo.utils.least_squares_solvers import (
+    LeastSquaresSolverParam,
     format_system,
     rmses,
-    LeastSquaresSolverParam,
 )
 
 

--- a/nengo/spa/actions.py
+++ b/nengo/spa/actions.py
@@ -5,7 +5,7 @@ import warnings
 from collections import OrderedDict
 
 from nengo.exceptions import SpaParseError
-from nengo.spa.action_objects import Symbol, Source, DotProduct, Summation
+from nengo.spa.action_objects import DotProduct, Source, Summation, Symbol
 
 
 class Expression:

--- a/nengo/spa/cortical.py
+++ b/nengo/spa/cortical.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import nengo
 import nengo.spa.action_build
-from nengo.spa.action_objects import Symbol, Source, Convolution
+from nengo.spa.action_objects import Convolution, Source, Symbol
 from nengo.spa.module import Module
 
 

--- a/nengo/spa/module.py
+++ b/nengo/spa/module.py
@@ -1,7 +1,7 @@
-import nengo
+from nengo.network import Network
 
 
-class Module(nengo.Network):
+class Module(Network):
     """Base class for SPA Modules.
 
     Modules are networks that also have a list of inputs and outputs,

--- a/nengo/spa/spa.py
+++ b/nengo/spa/spa.py
@@ -2,14 +2,14 @@ import warnings
 
 import numpy as np
 
-import nengo
 from nengo.exceptions import SpaModuleError
-from nengo.spa.vocab import Vocabulary
+from nengo.network import Network
 from nengo.spa.module import Module
-from nengo.spa.utils import enable_spa_params
+from nengo.spa.utils import enable_spa_params, similarity
+from nengo.spa.vocab import Vocabulary
 
 
-class SPA(nengo.Network):
+class SPA(Network):
     """Base class for SPA models.
 
     This expands the standard `.Network` system to support structured
@@ -253,4 +253,4 @@ class SPA(nengo.Network):
         """
         if vocab is None:
             vocab = self.config[probe.target].vocab
-        return nengo.spa.similarity(data[probe], vocab)
+        return similarity(data[probe], vocab)

--- a/nengo/spa/state.py
+++ b/nengo/spa/state.py
@@ -2,8 +2,8 @@ import numpy as np
 
 import nengo
 from nengo.exceptions import ValidationError
-from nengo.spa.module import Module
 from nengo.networks.ensemblearray import EnsembleArray
+from nengo.spa.module import Module
 
 
 class State(Module):

--- a/nengo/spa/tests/test_action_objects.py
+++ b/nengo/spa/tests/test_action_objects.py
@@ -1,7 +1,7 @@
 import pytest
 
 from nengo.exceptions import SpaParseError
-from nengo.spa.action_objects import Symbol, Source, DotProduct
+from nengo.spa.action_objects import DotProduct, Source, Symbol
 
 A = Symbol("A")
 B = Symbol("B")

--- a/nengo/spa/tests/test_actions.py
+++ b/nengo/spa/tests/test_actions.py
@@ -2,7 +2,7 @@ import pytest
 
 from nengo import spa
 from nengo.exceptions import SpaParseError
-from nengo.spa.actions import Expression, Effect, Action, Actions
+from nengo.spa.actions import Action, Actions, Effect, Expression
 
 
 def test_expression():

--- a/nengo/spa/tests/test_assoc_mem.py
+++ b/nengo/spa/tests/test_assoc_mem.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 import nengo
-from nengo.spa import Vocabulary, Input
-from nengo.spa.utils import similarity
+from nengo.spa import Input, Vocabulary
 from nengo.spa.assoc_mem import AssociativeMemory
+from nengo.spa.utils import similarity
 
 
 def test_am_spa_interaction(Simulator, seed, rng):

--- a/nengo/spa/thalamus.py
+++ b/nengo/spa/thalamus.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import nengo
 from nengo.dists import Uniform
-from nengo.spa.action_objects import Symbol, Source, Convolution
+from nengo.spa.action_objects import Convolution, Source, Symbol
 from nengo.spa.module import Module
 
 

--- a/nengo/spa/vocab.py
+++ b/nengo/spa/vocab.py
@@ -6,7 +6,7 @@ from nengo.exceptions import ReadonlyError, SpaParseError, ValidationError
 from nengo.params import Parameter
 from nengo.rc import rc
 from nengo.spa import pointer
-from nengo.utils.numpy import is_iterable, is_number, is_integer
+from nengo.utils.numpy import is_integer, is_iterable, is_number
 
 
 class Vocabulary:

--- a/nengo/tests/test_cache.py
+++ b/nengo/tests/test_cache.py
@@ -5,21 +5,21 @@ import sys
 from subprocess import CalledProcessError
 
 import numpy as np
-from numpy.testing import assert_equal
 import pytest
+from numpy.testing import assert_equal
 
 import nengo
+import nengo.neurons
+import nengo.utils.least_squares_solvers
 from nengo.cache import (
     CacheIndex,
     DecoderCache,
     Fingerprint,
-    get_fragment_size,
     WriteableCacheIndex,
+    get_fragment_size,
 )
 from nengo.exceptions import CacheIOWarning, FingerprintError
-import nengo.neurons
 from nengo.solvers import LstsqL2
-import nengo.utils.least_squares_solvers
 
 
 class Mock:

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -8,8 +8,8 @@ import nengo.utils.numpy as npext
 from nengo.connection import ConnectionSolverParam
 from nengo.dists import Choice, UniformHypersphere
 from nengo.exceptions import BuildError, ValidationError
-from nengo.solvers import LstsqL2
 from nengo.processes import Piecewise
+from nengo.solvers import LstsqL2
 from nengo.transforms import Dense, NoTransform
 from nengo.utils.testing import signals_allclose
 

--- a/nengo/tests/test_copy.py
+++ b/nengo/tests/test_copy.py
@@ -1,5 +1,5 @@
-from copy import copy
 import pickle
+from copy import copy
 
 import numpy as np
 import pytest
@@ -7,7 +7,7 @@ import pytest
 import nengo
 from nengo import spa
 from nengo.exceptions import NetworkContextError, NotAddedToNetworkWarning
-from nengo.params import IntParam, iter_params, NdarrayParam
+from nengo.params import IntParam, NdarrayParam, iter_params
 from nengo.utils.numpy import is_array_like
 from nengo.utils.progress import TerminalProgressBar
 

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -8,7 +8,7 @@ import nengo.utils.numpy as npext
 from nengo.dists import Choice, Uniform, UniformHypersphere
 from nengo.exceptions import BuildError, NengoWarning
 from nengo.neurons import RegularSpiking
-from nengo.processes import WhiteNoise, FilteredNoise
+from nengo.processes import FilteredNoise, WhiteNoise
 from nengo.utils.testing import signals_allclose
 
 

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -1,7 +1,7 @@
 import os
 
-import pytest
 import _pytest.capture
+import pytest
 
 from nengo.utils.paths import examples_dir
 from nengo.utils.stdlib import execfile

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -1,7 +1,7 @@
-import nengo
 import numpy as np
 import pytest
 
+import nengo
 from nengo.builder import Builder
 from nengo.builder.ensemble import get_activities
 from nengo.builder.learning_rules import SimRLS

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -1,6 +1,6 @@
-from collections import defaultdict
 import logging
 import time
+from collections import defaultdict
 
 import numpy as np
 import pytest
@@ -8,11 +8,11 @@ import pytest
 import nengo
 from nengo.exceptions import BuildError, SimulationError, ValidationError
 from nengo.neurons import (
+    LIF,
     AdaptiveLIF,
     AdaptiveLIFRate,
     Direct,
     Izhikevich,
-    LIF,
     LIFRate,
     NeuronType,
     NeuronTypeParam,

--- a/nengo/tests/test_params.py
+++ b/nengo/tests/test_params.py
@@ -3,7 +3,7 @@ import pytest
 
 import nengo
 from nengo import params
-from nengo.exceptions import ObsoleteError, ValidationError, ConfigError
+from nengo.exceptions import ConfigError, ObsoleteError, ValidationError
 from nengo.params import FunctionInfo
 
 

--- a/nengo/tests/test_probe.py
+++ b/nengo/tests/test_probe.py
@@ -1,7 +1,6 @@
 import logging
 
 import numpy as np
-import pytest
 
 import nengo
 from nengo.utils.stdlib import Timer
@@ -30,7 +29,6 @@ def test_multirun(Simulator, rng, allclose):
             assert allclose(sim_t[-1], t_sum, rtol=rtol)
 
 
-@pytest.mark.slow
 def test_dts(Simulator, seed, rng):
     """Test probes with different dts and runtimes"""
 

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -1,8 +1,8 @@
 import logging
 import pickle
-import pkg_resources
 
 import numpy as np
+import pkg_resources
 import pytest
 
 import nengo
@@ -12,7 +12,7 @@ from nengo.builder.ensemble import BuiltEnsemble
 from nengo.builder.operator import DotInc
 from nengo.builder.signal import Signal
 from nengo.exceptions import SimulatorClosed, ValidationError
-from nengo.rc import rc, RC_DEFAULTS
+from nengo.rc import RC_DEFAULTS, rc
 from nengo.utils.progress import ProgressBar
 
 

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -397,7 +397,7 @@ def test_compare_solvers(Simulator, plt, seed, allclose):
         names = []
         for solver in decoder_solvers + weight_solvers:
             b = nengo.Ensemble(N, dimensions=1, seed=seed + 1)
-            nengo.Connection(a, b, solver=solver)
+            nengo.Connection(a, b, solver=solver, transform=1)
             probes.append(nengo.Probe(b))
             names.append(
                 "%s(%s)" % (type(solver).__name__, "w" if solver.weights else "d")

--- a/nengo/tests/test_solvers.py
+++ b/nengo/tests/test_solvers.py
@@ -11,11 +11,7 @@ import pytest
 import nengo
 from nengo.dists import Choice, Uniform, UniformHypersphere
 from nengo.exceptions import BuildError, ValidationError
-from nengo.utils.numpy import rms, norm
-from nengo.utils.stdlib import Timer
-from nengo.utils.testing import signals_allclose
 from nengo.solvers import (
-    lstsq,
     Lstsq,
     LstsqDrop,
     LstsqL1,
@@ -27,7 +23,11 @@ from nengo.solvers import (
     NnlsL2,
     NnlsL2nz,
     NoSolver,
+    lstsq,
 )
+from nengo.utils.numpy import norm, rms
+from nengo.utils.stdlib import Timer
+from nengo.utils.testing import signals_allclose
 
 
 class Factory:

--- a/nengo/tests/test_synapses.py
+++ b/nengo/tests/test_synapses.py
@@ -8,7 +8,6 @@ from nengo.synapses import Alpha, LinearFilter, Lowpass, Synapse, SynapseParam, 
 from nengo.utils.filter_design import cont2discrete
 from nengo.utils.testing import signals_allclose
 
-
 # The following num, den are for a 4th order analog Butterworth filter,
 # generated with `scipy.signal.butter(4, 0.1, analog=False)`
 butter_num = np.array([0.0004166, 0.0016664, 0.0024996, 0.0016664, 0.0004166])

--- a/nengo/tests/test_transforms.py
+++ b/nengo/tests/test_transforms.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 import nengo
-from nengo.exceptions import BuildError, ValidationError
 from nengo._vendor.npconv2d import conv2d
+from nengo.exceptions import BuildError, ValidationError
 
 
 @pytest.mark.parametrize("dimensions", (1, 2))

--- a/nengo/transforms.py
+++ b/nengo/transforms.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from nengo.base import FrozenObject
-from nengo.dists import Distribution, DistOrArrayParam, Uniform
+from nengo.dists import DistOrArrayParam, Distribution, Uniform
 from nengo.exceptions import ValidationError
 from nengo.params import (
     BoolParam,

--- a/nengo/utils/__init__.py
+++ b/nengo/utils/__init__.py
@@ -1,15 +1,17 @@
-from . import builder
-from . import cache
-from . import connection
-from . import ensemble
-from . import filter_design
-from . import functions
-from . import graphs
-from . import ipython
-from . import magic
-from . import nco
-from . import network
-from . import numpy
-from . import paths
-from . import simulator
-from . import stdlib
+from . import (
+    builder,
+    cache,
+    connection,
+    ensemble,
+    filter_design,
+    functions,
+    graphs,
+    ipython,
+    magic,
+    nco,
+    network,
+    numpy,
+    paths,
+    simulator,
+    stdlib,
+)

--- a/nengo/utils/connection.py
+++ b/nengo/utils/connection.py
@@ -32,8 +32,8 @@ def eval_point_decoding(conn, sim, eval_points=None):
     # pylint: disable=import-outside-toplevel
     # note: these are imported here to avoid circular imports
     from nengo import rc
-    from nengo.builder.ensemble import get_activities
     from nengo.builder.connection import get_targets
+    from nengo.builder.ensemble import get_activities
 
     dtype = rc.float_dtype
 

--- a/nengo/utils/filter_design.py
+++ b/nengo/utils/filter_design.py
@@ -40,18 +40,18 @@ import warnings
 
 import numpy as np
 from numpy import (
-    product,
-    zeros,
+    allclose,
     array,
-    dot,
-    r_,
-    eye,
+    asarray,
     atleast_1d,
     atleast_2d,
+    dot,
+    eye,
     poly,
+    product,
+    r_,
     roots,
-    asarray,
-    allclose,
+    zeros,
 )
 
 from nengo._vendor.scipy import expm

--- a/nengo/utils/ipython.py
+++ b/nengo/utils/ipython.py
@@ -10,11 +10,11 @@ try:
     from IPython.display import HTML
 
     if IPython.version_info[0] <= 3:  # pragma: no cover
-        from IPython.nbconvert import PythonExporter
         from IPython import nbformat
+        from IPython.nbconvert import PythonExporter
     else:
-        from nbconvert import PythonExporter
         import nbformat
+        from nbconvert import PythonExporter
 
 except ImportError:  # pragma: no cover
 

--- a/nengo/utils/lock.py
+++ b/nengo/utils/lock.py
@@ -1,5 +1,5 @@
-from nengo.exceptions import TimeoutError
 from nengo._vendor import portalocker
+from nengo.exceptions import TimeoutError
 
 
 class FileLock:

--- a/nengo/utils/matplotlib.py
+++ b/nengo/utils/matplotlib.py
@@ -1,5 +1,5 @@
-from distutils.version import LooseVersion
 import warnings
+from distutils.version import LooseVersion
 
 import matplotlib
 import matplotlib.pyplot as plt

--- a/nengo/utils/nco.py
+++ b/nengo/utils/nco.py
@@ -39,8 +39,8 @@ import struct
 
 import numpy as np
 
-from .cache import byte_align
 from ..exceptions import CacheIOError
+from .cache import byte_align
 
 
 class Subfile:

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -1,15 +1,13 @@
 """
 Extra functions to extend the capabilities of Numpy.
 """
-from collections.abc import Iterable
 import logging
-
 import warnings
+from collections.abc import Iterable
 
 import numpy as np
 
 from ..exceptions import ValidationError
-
 
 logger = logging.getLogger(__name__)
 try:

--- a/nengo/utils/paths.py
+++ b/nengo/utils/paths.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-
 if sys.platform.startswith("win"):  # pragma: no cover
     config_dir = os.path.expanduser(os.path.join("~", ".nengo"))
     cache_dir = os.path.join(config_dir, "cache")

--- a/nengo/utils/progress.py
+++ b/nengo/utils/progress.py
@@ -1,25 +1,24 @@
 """Utilities for progress tracking and display to the user."""
 
-from datetime import timedelta
-from html import escape
 import importlib
 import os
-from shutil import get_terminal_size
 import sys
 import threading
 import time
 import uuid
 import warnings
+from datetime import timedelta
+from html import escape
+from shutil import get_terminal_size
 
 import numpy as np
 
-from .ipython import check_ipy_version, get_ipython
 from ..exceptions import ValidationError
 from ..rc import rc
-
+from .ipython import check_ipy_version, get_ipython
 
 if get_ipython() is not None:
-    from IPython.display import display, Javascript  # pragma: no cover
+    from IPython.display import Javascript, display  # pragma: no cover
 
 
 class MemoryLeakWarning(UserWarning):

--- a/nengo/utils/simulator.py
+++ b/nengo/utils/simulator.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import itertools
+from collections import defaultdict
 
 from .graphs import add_edges
 from .stdlib import groupby

--- a/nengo/utils/stdlib.py
+++ b/nengo/utils/stdlib.py
@@ -1,11 +1,11 @@
 """Functions that extend the Python Standard Library."""
 
-from collections import namedtuple
-from collections.abc import Hashable, MutableMapping, MutableSet
 import inspect
 import itertools
 import time
 import weakref
+from collections import namedtuple
+from collections.abc import Hashable, MutableMapping, MutableSet
 
 
 class WeakKeyDefaultDict(MutableMapping):

--- a/nengo/utils/tests/test_builder.py
+++ b/nengo/utils/tests/test_builder.py
@@ -4,14 +4,14 @@ import numpy as np
 import pytest
 
 import nengo
-from nengo.exceptions import MovedError, ValidationError, Unconvertible
+from nengo.exceptions import MovedError, Unconvertible, ValidationError
 from nengo.transforms import NoTransform
 from nengo.utils.builder import (
+    _create_replacement_connection,
     full_transform,
     generate_graphviz,
     objs_and_connections,
     remove_passthrough_nodes,
-    _create_replacement_connection,
 )
 
 

--- a/nengo/utils/tests/test_connection.py
+++ b/nengo/utils/tests/test_connection.py
@@ -1,6 +1,6 @@
+import matplotlib.tri as tri
 import numpy as np
 import pytest
-import matplotlib.tri as tri
 
 import nengo
 from nengo.utils.connection import eval_point_decoding

--- a/nengo/utils/tests/test_ensemble.py
+++ b/nengo/utils/tests/test_ensemble.py
@@ -1,10 +1,10 @@
-import numpy as np
 import mpl_toolkits.mplot3d
+import numpy as np
 import pytest
 
 import nengo
 from nengo.dists import Uniform
-from nengo.utils.ensemble import response_curves, tuning_curves, _similarity
+from nengo.utils.ensemble import _similarity, response_curves, tuning_curves
 
 
 def plot_tuning_curves(plt, eval_points, activities):

--- a/nengo/utils/tests/test_filter_design.py
+++ b/nengo/utils/tests/test_filter_design.py
@@ -2,18 +2,18 @@ import numpy as np
 import pytest
 
 from nengo.utils.filter_design import (
-    cont2discrete,
-    tf2zpk,
-    zpk2tf,
-    normalize,
-    tf2ss,
     _none_to_empty_2d,
-    _shape_or_none,
     _restore,
+    _shape_or_none,
     abcd_normalize,
+    cont2discrete,
+    normalize,
     ss2tf,
-    zpk2ss,
     ss2zpk,
+    tf2ss,
+    tf2zpk,
+    zpk2ss,
+    zpk2tf,
 )
 
 

--- a/nengo/utils/tests/test_least_squares_solvers.py
+++ b/nengo/utils/tests/test_least_squares_solvers.py
@@ -1,15 +1,15 @@
+import numpy as np
 import pytest
 
-import numpy as np
 from nengo.exceptions import ValidationError
 from nengo.utils.least_squares_solvers import (
+    SVD,
     BlockConjgrad,
     Cholesky,
     Conjgrad,
     ConjgradScipy,
     LSMRScipy,
     RandomizedSVD,
-    SVD,
 )
 
 

--- a/nengo/utils/tests/test_lock.py
+++ b/nengo/utils/tests/test_lock.py
@@ -1,5 +1,5 @@
-import os.path
 import multiprocessing
+import os.path
 import sys
 import time
 

--- a/nengo/utils/tests/test_magic.py
+++ b/nengo/utils/tests/test_magic.py
@@ -1,10 +1,6 @@
 import inspect
 
-from nengo.utils.magic import (
-    decorator,
-    ObjectProxy,
-    BoundFunctionWrapper,
-)
+from nengo.utils.magic import BoundFunctionWrapper, ObjectProxy, decorator
 
 
 class RunState:

--- a/nengo/utils/tests/test_nco.py
+++ b/nengo/utils/tests/test_nco.py
@@ -1,10 +1,10 @@
 import os
 import struct
 
-import pytest
-
 import numpy as np
+import pytest
 from numpy.testing import assert_equal
+
 import nengo.utils.nco as nco
 from nengo.exceptions import CacheIOError
 from nengo.utils.nco import Subfile

--- a/nengo/utils/tests/test_numpy.py
+++ b/nengo/utils/tests/test_numpy.py
@@ -4,10 +4,10 @@ import itertools
 import numpy as np
 import pytest
 
-from nengo.exceptions import ValidationError
 import nengo.utils.numpy as npext
-from nengo.utils.numpy import array_hash, meshgrid_nd, as_shape, broadcast_shape, array
 from nengo._vendor.scipy import expm
+from nengo.exceptions import ValidationError
+from nengo.utils.numpy import array, array_hash, as_shape, broadcast_shape, meshgrid_nd
 
 
 def test_meshgrid_nd(allclose):

--- a/nengo/utils/tests/test_progress.py
+++ b/nengo/utils/tests/test_progress.py
@@ -1,6 +1,6 @@
-from collections import namedtuple
 import sys
 import time
+from collections import namedtuple
 
 import pytest
 
@@ -8,17 +8,16 @@ import nengo.rc as rc
 from nengo.exceptions import ValidationError
 from nengo.utils.progress import (
     AutoProgressBar,
-    get_default_progressbar,
     HtmlProgressBar,
     NoProgressBar,
     Progress,
     ProgressBar,
     ProgressTracker,
     TerminalProgressBar,
-    to_progressbar,
     WriteProgressToFile,
+    get_default_progressbar,
+    to_progressbar,
 )
-
 
 Update = namedtuple(
     "Update", ("name_during", "name_after", "n_steps", "max_steps", "finished")

--- a/nengo/utils/tests/test_stdlib.py
+++ b/nengo/utils/tests/test_stdlib.py
@@ -5,12 +5,12 @@ import numpy as np
 import pytest
 
 from nengo.utils.stdlib import (
-    checked_call,
-    groupby,
     Timer,
     WeakKeyDefaultDict,
     WeakKeyIDDictionary,
     WeakSet,
+    checked_call,
+    groupby,
 )
 
 

--- a/nengo/utils/tests/test_testing.py
+++ b/nengo/utils/tests/test_testing.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from nengo.utils.testing import signals_allclose, ThreadedAssertion
+from nengo.utils.testing import ThreadedAssertion, signals_allclose
 
 
 def add_close_noise(x, atol, rtol, rng):

--- a/nengo/utils/threading.py
+++ b/nengo/utils/threading.py
@@ -1,5 +1,5 @@
-from collections.abc import Sequence
 import threading
+from collections.abc import Sequence
 
 
 class ThreadLocalStack(threading.local, Sequence):  # pylint: disable=too-many-ancestors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,7 @@ exclude = '''
     _vendor/*
 )
 '''
+
+[tool.isort]
+profile = "black"
+src_paths = ["nengo"]


### PR DESCRIPTION
**Motivation and context:**
While prepping the 3.1 release, I noticed a test was failing. Adding an operator for probing fixes that, and is something that NengoOCL and NengoDL are already doing in some form. Currently the operator (named `SimProbe` to match our other similar operators) does nothing, but in the future we should add the probing logic here.

**How has this been tested?**
Unmarked `test_dts` as not actually being slow, which is the test that this PR is required to pass.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
