### PR TITLE
Ensure op graph order is deterministic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,16 @@ Release history
 3.1.1 (unreleased)
 ==================
 
+**Fixed**
 
+- Operator graph step order will now be deterministic. (`#1654`_)
+
+**Removed**
+
+- Removed ``nengo.utils.graphs.graph`` (this was a small utility function for building
+  graphs that was only used in tests). (`#1654`_)
+
+.. _#1654: https://github.com/nengo/nengo/pull/1654
 
 3.1.0 (November 17, 2020)
 =========================

--- a/docs/examples/usage/config.ipynb
+++ b/docs/examples/usage/config.ipynb
@@ -287,13 +287,13 @@
     "    with nengo.Network() as subnet:\n",
     "        subnet.config[nengo.Ensemble].neuron_type = nengo.LIFRate()\n",
     "        subnet.config[nengo.Ensemble].radius = 3.0\n",
-    "        print(\"\\nIn 'subnet' context:\")\n",
+    "        print(\"In 'subnet' context:\")\n",
     "        print(nengo.Config.all_defaults(nengo.Ensemble))\n",
     "\n",
     "        with nengo.Network() as subsubnet:\n",
     "            subsubnet.config[nengo.Ensemble].neuron_type = nengo.Direct()\n",
     "            subsubnet.config[nengo.Ensemble].radius = 2.0\n",
-    "            print(\"\\nIn 'subsubnet' context:\")\n",
+    "            print(\"In 'subsubnet' context:\")\n",
     "            print(nengo.Config.all_defaults(nengo.Ensemble))"
    ]
   },

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -455,7 +455,7 @@ class OpMerger:
 
         independent_of_ops_tomerge = (
             op not in tomerge.all_dependents
-            and len(tomerge.dependents[op].intersection(tomerge.ops)) == 0
+            and tomerge.dependents[op].isdisjoint(tomerge.ops)
         )
         independent_of_prior_merges = (
             op not in tomerge.merged
@@ -496,7 +496,7 @@ class Merger:
 
     @staticmethod
     def check_signals(op, tomerge):
-        return len(tomerge.all_signals.intersection(op.all_signals)) == 0
+        return tomerge.all_signals.isdisjoint(op.all_signals)
 
     @staticmethod
     def is_mergeable(op1, op2):

--- a/nengo/tests/test_base.py
+++ b/nengo/tests/test_base.py
@@ -31,21 +31,21 @@ def test_nengoobjectparam_nonzero():
     """Can check that objects have nonzero size in/out."""
 
     class Test:
-        nin = NengoObjectParam("nin", nonzero_size_in=True)
-        nout = NengoObjectParam("nout", nonzero_size_out=True)
+        n_in = NengoObjectParam("n_in", nonzero_size_in=True)
+        n_out = NengoObjectParam("n_out", nonzero_size_out=True)
 
     inst = Test()
     with nengo.Network():
-        nin = nengo.Node(output=lambda t: t)
-        nout = nengo.Node(output=lambda t, x: None, size_in=1)
-        probe = nengo.Probe(nin)
+        n_in = nengo.Node(output=lambda t: t)
+        n_out = nengo.Node(output=lambda t, x: None, size_in=1)
+        probe = nengo.Probe(n_in)
 
         with pytest.raises(ValidationError):
-            inst.nin = nin
+            inst.n_in = n_in
         with pytest.raises(ValidationError):
-            inst.nout = nout
+            inst.n_out = n_out
         with pytest.raises(ValidationError):
-            inst.nout = probe
+            inst.n_out = probe
 
-        inst.nin = nout
-        inst.nout = nin
+        inst.n_in = n_out
+        inst.n_out = n_in

--- a/nengo/utils/filter_design.py
+++ b/nengo/utils/filter_design.py
@@ -324,8 +324,8 @@ def ss2tf(A, B, C, D, input=0):
     # Check consistency and make them all rank-2 arrays
     A, B, C, D = abcd_normalize(A, B, C, D)
 
-    nout, nin = D.shape
-    if input >= nin:
+    n_out, n_in = D.shape
+    if input >= n_in:
         raise ValueError("System does not have the input specified.")
 
     # make MOSI from possibly MOMI system.
@@ -348,8 +348,8 @@ def ss2tf(A, B, C, D, input=0):
 
     num_states = A.shape[0]
     type_test = A[:, 0] + B[:, 0] + C[0, :] + D
-    num = np.zeros((nout, num_states + 1), type_test.dtype)
-    for k in range(nout):
+    num = np.zeros((n_out, num_states + 1), type_test.dtype)
+    for k in range(n_out):
         Ck = atleast_2d(C[k, :])
         num[k] = poly(A - dot(B, Ck)) + (D[k] - 1) * den
 

--- a/nengo/utils/tests/test_graphs.py
+++ b/nengo/utils/tests/test_graphs.py
@@ -1,19 +1,29 @@
+import collections
+
 from nengo.utils import graphs
 
 
+def graph(edges=None):
+    """Construct graph from edges."""
+    g = collections.defaultdict(set)
+    if edges is not None:
+        g.update(edges)
+    return g
+
+
 def test_reversedict():
-    edges = graphs.graph({"a": {"b", "c"}, "b": set(), "c": set()})
+    edges = graph({"a": {"b", "c"}, "b": set(), "c": set()})
     r_edges = graphs.reverse_edges(edges)
     assert r_edges == {"a": set(), "b": {"a"}, "c": {"a"}}
 
 
 def test_toposort():
-    edges = graphs.graph({"a": {"b", "c"}, "b": {"c"}, "c": set()})
+    edges = graph({"a": {"b", "c"}, "b": {"c"}, "c": set()})
     assert graphs.toposort(edges) == ["a", "b", "c"]
 
 
 def test_transitive_closure():
-    edges = graphs.graph({"a": {}, "b": {"c", "d"}, "c": set(), "d": {"e"}, "e": set()})
+    edges = graph({"a": {}, "b": {"c", "d"}, "c": set(), "d": {"e"}, "e": set()})
     assert graphs.transitive_closure(edges) == {
         "a": set(),
         "b": {"c", "d", "e"},
@@ -24,6 +34,6 @@ def test_transitive_closure():
 
 
 def test_add_edges():
-    edges = graphs.graph({"a": {"b", "c"}})
+    edges = graph({"a": {"b", "c"}})
     graphs.add_edges(edges, [("a", "d"), ("b", "c")])
     assert edges == {"a": {"b", "c", "d"}, "b": {"c"}}

--- a/nengo/utils/tests/test_stdlib.py
+++ b/nengo/utils/tests/test_stdlib.py
@@ -5,6 +5,8 @@ import numpy as np
 import pytest
 
 from nengo.utils.stdlib import (
+    FrozenOrderedSet,
+    OrderedSet,
     Timer,
     WeakKeyDefaultDict,
     WeakKeyIDDictionary,
@@ -283,3 +285,26 @@ def test_weakset_init():
     # init from another weakset
     s2 = WeakSet(s)
     assert k in s2
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 6, 0), reason="OrderedSet only works in Python>=3.6"
+)
+def test_ordered_set():
+    my_set = OrderedSet(("c", "b", "a"))
+
+    # order is preserved
+    assert tuple(my_set) == ("c", "b", "a")
+    my_set |= "d"
+    assert tuple(my_set) == ("c", "b", "a", "d")
+    my_set -= "b"
+    assert tuple(my_set) == ("c", "a", "d")
+
+    # not hashable
+    with pytest.raises(TypeError, match="OrderedSet is not hashable"):
+        _ = {my_set: "val"}
+
+    # hashable
+    my_frozen_set = FrozenOrderedSet(my_set)
+    assert tuple(my_frozen_set) == ("c", "a", "d")
+    assert {my_frozen_set: "val"}[my_frozen_set] == "val"


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Rebuilding the same network multiple times could produce a different op order each time (as long as all those orders respected the constraints of the topological sort). While this doesn't have any functional impact on the model, it can be problematic for backends that are more sensitive to op order (e.g., NengoDL, where the order of operators can impact the layout of signals in memory).

This changes all the usages of `set`/`frozenset` in the builder to `OrderedSet`/`FrozenOrderedSet` (analogous to `OrderedDict`, these are sets that preserve their insertion order).

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

https://github.com/nengo/nengo-dl/pull/187 depends on this PR

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

See new tests in `test_builder.py` and `test_graphs.py`.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.