### PR TITLE
Fix test_pytest_nengo.py to work with new pytest

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -47,7 +47,7 @@ setup_py:
   tests_req:
     - jupyter
     - matplotlib>=1.4
-    - pytest>=3.6
+    - pytest>=3.9.1
     - pytest-allclose
     - pytest-plt
     - pytest-rng

--- a/nengo/tests/test_pytest_nengo.py
+++ b/nengo/tests/test_pytest_nengo.py
@@ -9,12 +9,10 @@ def test_unsupported(xfail, testdir):
 
     # Set up a dummy nengo package directory, so that `pytest_nengo.is_nengo_test`
     # returns True
-    testdir.tmpdir = testdir.tmpdir.mkdir("nengo")
-    testdir.chdir()
-    testdir.makefile(".py", __init__="")
+    nengo_dir = testdir.mkpydir("nengo")
 
-    # Create a test file with some dummy tests
-    testdir.makefile(
+    # Create a test file with some dummy tests, and move it into nengo_dir
+    test_file_path = testdir.makefile(
         ".py",
         test_file="""
         import pytest
@@ -34,6 +32,7 @@ def test_unsupported(xfail, testdir):
             assert True
         """,
     )
+    test_file_path.move(test_file_path.new(dirname=nengo_dir))
 
     # Create the .ini file to skip/xfail the failing tests. This will
     # make sure square brackets for parameters just skip that parametrization.

--- a/pytest_nengo.py
+++ b/pytest_nengo.py
@@ -31,10 +31,10 @@ seen when calling pytest with the ``-v`` argument.
            "This skips a parametrized test with a specific parameter value."
 """
 
-from fnmatch import fnmatch
 import importlib
 import shlex
 import sys
+from fnmatch import fnmatch
 
 try:
     import resource

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ optional_req = [
 tests_req = [
     "jupyter",
     "matplotlib>=1.4",
-    "pytest>=3.6",
+    "pytest>=3.9.1",
     "pytest-allclose",
     "pytest-plt",
     "pytest-rng",


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

`test_pytest_nengo.test_unsupported` is breaking with new pytest (6.2.1), since we can't overwrite `tmpdir` anymore.

Also increase minimum pytest to 3.9.1 (which has `tmp_path`).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

- Ran modified test with pytest 6.2.1, and it works. Also double-checked that file is moved properly.
- Ran all tests with pytest 3.9.1, and they all pass.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
