### PR TITLE
Relax NumPy version check

### DIFF
--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -4,6 +4,7 @@ Extra functions to extend the capabilities of Numpy.
 import logging
 import warnings
 from collections.abc import Iterable
+from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -34,11 +35,7 @@ maxint = np.iinfo(np.int32).max
 # numpy 1.17 introduced a slowdown to clip, so
 # use nengo.utils.numpy.clip instead of np.clip
 # This has persisted through 1.19 at least
-clip = (
-    np.core.umath.clip
-    if tuple(int(st) for st in np.__version__.split(".")) >= (1, 17, 0)
-    else np.clip
-)
+clip = np.core.umath.clip if LooseVersion(np.__version__) >= "1.17.0" else np.clip
 
 
 def is_integer(obj):


### PR DESCRIPTION
**Motivation and context:**
I'm using a dev version of NumPy and wasn't able to import Nengo. Turned out we were casting `np.__version__.split(".")` to ints, which causes an error when using a development version of NumPy.

**How has this been tested?**
Able to import Nengo now.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
