### PR TITLE
Update links to pytest docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -356,13 +356,13 @@ Release history
   external `pytest-plt <https://www.nengo.ai/pytest-plt/>`__ package instead.
   (`#1566 <https://github.com/nengo/nengo/pull/1566>`__)
 - The internal ``logger`` fixture has been removed. Use pytest's
-  `log capturing <https://docs.pytest.org/en/latest/logging.html>`__ instead.
+  `log capturing <https://docs.pytest.org/en/stable/logging.html>`__ instead.
   (`#1566 <https://github.com/nengo/nengo/pull/1566>`__)
 - Removed ``nengo.log`` and ``nengo.utils.logging``. Use the standard Python
   and pytest logging modules instead.
   (`#1566 <https://github.com/nengo/nengo/pull/1566>`__)
 - The internal ``analytics`` and ``analytics_data`` fixtures have been removed.
-  Use pytest's `cache fixture <https://docs.pytest.org/en/latest/cache.html>`__
+  Use pytest's `cache fixture <https://docs.pytest.org/en/stable/cache.html>`__
   instead.
   (`#1566 <https://github.com/nengo/nengo/pull/1566>`__)
 - The ``RefSimulator`` fixture has been removed. Use the ``Simulator`` fixture

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -90,8 +90,8 @@ Writing your own tests
 ----------------------
 
 When writing your own tests, please make use of
-custom Nengo `fixtures <https://docs.pytest.org/en/latest/fixture.html>`_
-and `markers <https://docs.pytest.org/en/latest/example/markers.html>`_
+custom Nengo `fixtures and markers
+<https://github.com/nengo/nengo/blob/master/pytest_nengo.py>`_
 to integrate well with existing tests.
 See existing tests for examples, or consult
 


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Pytest moved their documentation around a bit, which broke some of our links.

When I was reading the contributing docs I thought it might be more helpful to point users to our specific fixtures/markers, rather than the generic pytest fixture/marker documentation, so I updated that to point to `pytest_nengo` instead. For the rest I just updated the links.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.