### PR TITLE
Fix conjgrad test to be more robust

### DIFF
--- a/nengo/utils/tests/test_least_squares_solvers.py
+++ b/nengo/utils/tests/test_least_squares_solvers.py
@@ -28,15 +28,16 @@ def run_solver(solver, m=30, n=20, d=1, cond=10, sys_rng=np.random, **kwargs):
     # solve system
     y = np.dot(A, x)
     x2, _ = solver(A, y, **kwargs)
+    y2 = np.dot(A, x2)
 
-    return x, x2
+    return x, x2, y, y2
 
 
 @pytest.mark.parametrize("cond, sigma", [(5, 1e-4), (500, 1e-6), (1e5, 1e-8)])
 def test_cholesky(cond, sigma, rng, allclose):
     rng = np.random
     solver = Cholesky()
-    x, x2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
+    x, x2, _, _ = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
 
     tol = np.sqrt(cond) * 1e-7  # this is a guesstimate, and also depends on sigma
     assert allclose(x2, x, atol=tol, rtol=tol)
@@ -46,7 +47,7 @@ def test_cholesky(cond, sigma, rng, allclose):
 def test_conjgrad_scipy(cond, sigma, tol, rng, allclose):
     pytest.importorskip("scipy")
     solver = ConjgradScipy(tol=tol)
-    x, x2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
+    x, x2, _, _ = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
 
     tol = cond * tol
     assert allclose(x2, x, atol=tol, rtol=tol)
@@ -56,7 +57,7 @@ def test_conjgrad_scipy(cond, sigma, tol, rng, allclose):
 def test_lsmr_scipy(cond, sigma, tol, rng, allclose):
     pytest.importorskip("scipy")
     solver = LSMRScipy(tol=tol)
-    x, x2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
+    x, x2, _, _ = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
 
     tol = cond * tol
     assert allclose(x2, x, atol=tol, rtol=tol)
@@ -66,16 +67,18 @@ def test_lsmr_scipy(cond, sigma, tol, rng, allclose):
     "cond, sigma, tol, maxiters",
     [
         (5, 1e-8, 1e-2, None),  # standard run
-        (50, 1e-8, 1e-4, None),  # precision run
+        (50, 1e-8, 1e-4, 100),  # precision run (extra iterations help convergence)
         (1.1, 1e-15, 0, 1000),  # hit "no perceptible change in p" line
     ],
 )
 def test_conjgrad(cond, sigma, tol, maxiters, rng, allclose):
     solver = Conjgrad(tol=tol, maxiters=maxiters)
-    x, x2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
+    _, _, y, y2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
 
+    # conjgrad stopping tol is based on residual in y, so compare y
+    # (this particularly helps in the ill-conditioned case)
     tol = cond * max(tol, 1e-5)
-    assert allclose(x2, x, atol=tol, rtol=tol)
+    assert allclose(y2, y, atol=tol, rtol=tol)
 
 
 def test_conjgrad_errors():
@@ -86,7 +89,9 @@ def test_conjgrad_errors():
 
 @pytest.mark.parametrize("cond, tol", [(5, 1e-2), (100, 1e-3)])
 def test_blockconjgrad(cond, tol, rng, allclose):
-    x, x2 = run_solver(BlockConjgrad(tol=tol), d=5, cond=cond, sys_rng=rng, sigma=1e-8)
+    x, x2, _, _ = run_solver(
+        BlockConjgrad(tol=tol), d=5, cond=cond, sys_rng=rng, sigma=1e-8
+    )
     assert allclose(x2, x, atol=tol, rtol=tol)
 
 
@@ -98,7 +103,7 @@ def test_blockconjgrad_errors():
 
 @pytest.mark.parametrize("cond", [5, 1000])
 def test_svd(cond, rng, allclose):
-    x, x2 = run_solver(SVD(), d=5, cond=cond, sys_rng=rng, sigma=1e-8)
+    x, x2, _, _ = run_solver(SVD(), d=5, cond=cond, sys_rng=rng, sigma=1e-8)
     assert allclose(x2, x, atol=1e-8, rtol=1e-8)
 
 
@@ -108,5 +113,5 @@ def test_randomized_svd_fallback(cond, rng, allclose):
     pytest.importorskip("sklearn")
     m, n = 30, 20
     solver = RandomizedSVD(n_components=min(m, n))
-    x, x2 = run_solver(solver, m=m, n=n, d=5, cond=cond, sys_rng=rng, sigma=1e-8)
+    x, x2, _, _ = run_solver(solver, m=m, n=n, d=5, cond=cond, sys_rng=rng, sigma=1e-8)
     assert allclose(x2, x, atol=1e-8, rtol=1e-8)


### PR DESCRIPTION
It would fail for some seeds on the `cond=50` case. Using extra
iterations ensures it converges (it was sometimes stopping on
iterations, not tolerance), and comparing `y` instead of `x`
ensures the tested error is in the same space as the stopping
tolerance criterion.

**Interactions with other PRs**

Based on #1670.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Ran the test over 100 times with random seeds, it now passes every time.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
