### PR TITLE
Fix some signals not correctly marked readonly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Release history
 **Fixed**
 
 - Operator graph step order will now be deterministic. (`#1654`_)
+- Fixed an issue in which some simulators could not be reset due to signals
+  not being marked as readonly. (`#1676`_)
 
 **Removed**
 
@@ -54,6 +56,7 @@ Release history
 .. _#1649: https://github.com/nengo/nengo/pull/1649
 .. _#1654: https://github.com/nengo/nengo/pull/1654
 .. _#1660: https://github.com/nengo/nengo/pull/1660
+.. _#1676: https://github.com/nengo/nengo/pull/1676
 
 3.1.0 (November 17, 2020)
 =========================

--- a/nengo/builder/optimizer.py
+++ b/nengo/builder/optimizer.py
@@ -693,6 +693,7 @@ class DotIncMerger(Merger):
                 name=f"{s.name}[{i}]",
                 base=A,
                 offset=i * A.itemsize * np.prod(A.shape[1:]),
+                readonly=readonly,
             )
             assert np.allclose(
                 s.initial_value, A_sigr[s].initial_value, atol=0, rtol=0, equal_nan=True

--- a/nengo/builder/signal.py
+++ b/nengo/builder/signal.py
@@ -155,7 +155,13 @@ class Signal:
 
         view = self._initial_value[item]
         offset = npext.array_offset(view) - npext.array_offset(self._initial_value)
-        return Signal(view, name=f"{self.name}[{item}]", base=self.base, offset=offset)
+        return Signal(
+            view,
+            name=f"{self.name}[{item}]",
+            base=self.base,
+            offset=offset,
+            readonly=self.readonly,
+        )
 
     def __repr__(self):
         return f"Signal(name={self._name}, shape={self.shape})"

--- a/nengo/tests/test_examples.py
+++ b/nengo/tests/test_examples.py
@@ -26,27 +26,28 @@ _pytest.capture.DontReadFromInput.write = lambda: None
 _pytest.capture.DontReadFromInput.flush = lambda: None
 
 
-too_slow = [
-    "basal-ganglia",
-    "inhibitory-gating",
-    "izhikevich",
-    "learn-communication-channel",
-    "learn-product",
-    "learn-square",
-    "learn-unsupervised",
-    "lorenz-attractor",
-    "nef-algorithm",
-    "nef-summary",
-    "network-design",
-    "network-design-advanced",
-]
+too_slow = {
+    "advanced/inhibitory-gating",
+    "advanced/izhikevich",
+    "advanced/nef-algorithm",
+    "advanced/nef-summary",
+    "dynamics/lorenz-attractor",
+    "learning/learn-communication-channel",
+    "learning/learn-product",
+    "learning/learn-square",
+    "learning/learn-unsupervised",
+    "learning/lmu",
+    "networks/basal-ganglia",
+    "usage/network-design",
+    "usage/network-design-advanced",
+}
 
 files = [
     f for f in examples_dir.glob("**/*.ipynb") if ".ipynb_checkpoints" not in str(f)
 ]
 all_examples = [f.relative_to(examples_dir).with_suffix("") for f in files]
-slow_examples = [f for f in all_examples if f.stem in too_slow]
-fast_examples = [f for f in all_examples if f.stem not in too_slow]
+slow_examples = [f for f in all_examples if f.as_posix() in too_slow]
+fast_examples = [f for f in all_examples if f.as_posix() not in too_slow]
 
 # glob goes in arbitrary order, so sort after the fact to keep pytest happy
 # convert paths to literal strings so that they're displayed nicer in the pytest name

--- a/nengo/utils/tests/test_least_squares_solvers.py
+++ b/nengo/utils/tests/test_least_squares_solvers.py
@@ -29,14 +29,14 @@ def run_solver(solver, m=30, n=20, d=1, cond=10, sys_rng=np.random, **kwargs):
     y = np.dot(A, x)
     x2, _ = solver(A, y, **kwargs)
 
-    return x, x2
+    return x, x2, A
 
 
 @pytest.mark.parametrize("cond, sigma", [(5, 1e-4), (500, 1e-6), (1e5, 1e-8)])
 def test_cholesky(cond, sigma, rng, allclose):
     rng = np.random
     solver = Cholesky()
-    x, x2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
+    x, x2, _ = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
 
     tol = np.sqrt(cond) * 1e-7  # this is a guesstimate, and also depends on sigma
     assert allclose(x2, x, atol=tol, rtol=tol)
@@ -46,7 +46,7 @@ def test_cholesky(cond, sigma, rng, allclose):
 def test_conjgrad_scipy(cond, sigma, tol, rng, allclose):
     pytest.importorskip("scipy")
     solver = ConjgradScipy(tol=tol)
-    x, x2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
+    x, x2, _ = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
 
     tol = cond * tol
     assert allclose(x2, x, atol=tol, rtol=tol)
@@ -56,7 +56,7 @@ def test_conjgrad_scipy(cond, sigma, tol, rng, allclose):
 def test_lsmr_scipy(cond, sigma, tol, rng, allclose):
     pytest.importorskip("scipy")
     solver = LSMRScipy(tol=tol)
-    x, x2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
+    x, x2, _ = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
 
     tol = cond * tol
     assert allclose(x2, x, atol=tol, rtol=tol)
@@ -66,16 +66,18 @@ def test_lsmr_scipy(cond, sigma, tol, rng, allclose):
     "cond, sigma, tol, maxiters",
     [
         (5, 1e-8, 1e-2, None),  # standard run
-        (50, 1e-8, 1e-4, None),  # precision run
+        (50, 1e-8, 1e-4, 100),  # precision run (extra iterations help convergence)
         (1.1, 1e-15, 0, 1000),  # hit "no perceptible change in p" line
     ],
 )
 def test_conjgrad(cond, sigma, tol, maxiters, rng, allclose):
     solver = Conjgrad(tol=tol, maxiters=maxiters)
-    x, x2 = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
+    x, x2, A = run_solver(solver, d=2, cond=cond, sys_rng=rng, sigma=sigma)
 
+    # conjgrad stopping tol is based on residual in y, so compare y (`y = A.dot(x)`)
+    # (this particularly helps in the ill-conditioned case)
     tol = cond * max(tol, 1e-5)
-    assert allclose(x2, x, atol=tol, rtol=tol)
+    assert allclose(A.dot(x2), A.dot(x), atol=tol, rtol=tol)
 
 
 def test_conjgrad_errors():
@@ -86,7 +88,9 @@ def test_conjgrad_errors():
 
 @pytest.mark.parametrize("cond, tol", [(5, 1e-2), (100, 1e-3)])
 def test_blockconjgrad(cond, tol, rng, allclose):
-    x, x2 = run_solver(BlockConjgrad(tol=tol), d=5, cond=cond, sys_rng=rng, sigma=1e-8)
+    x, x2, _ = run_solver(
+        BlockConjgrad(tol=tol), d=5, cond=cond, sys_rng=rng, sigma=1e-8
+    )
     assert allclose(x2, x, atol=tol, rtol=tol)
 
 
@@ -98,7 +102,7 @@ def test_blockconjgrad_errors():
 
 @pytest.mark.parametrize("cond", [5, 1000])
 def test_svd(cond, rng, allclose):
-    x, x2 = run_solver(SVD(), d=5, cond=cond, sys_rng=rng, sigma=1e-8)
+    x, x2, _ = run_solver(SVD(), d=5, cond=cond, sys_rng=rng, sigma=1e-8)
     assert allclose(x2, x, atol=1e-8, rtol=1e-8)
 
 
@@ -108,5 +112,5 @@ def test_randomized_svd_fallback(cond, rng, allclose):
     pytest.importorskip("sklearn")
     m, n = 30, 20
     solver = RandomizedSVD(n_components=min(m, n))
-    x, x2 = run_solver(solver, m=m, n=n, d=5, cond=cond, sys_rng=rng, sigma=1e-8)
+    x, x2, _ = run_solver(solver, m=m, n=n, d=5, cond=cond, sys_rng=rng, sigma=1e-8)
     assert allclose(x2, x, atol=1e-8, rtol=1e-8)


### PR DESCRIPTION
**Motivation and context:**
A user reported issues in resetting a simulator with recent versions of Nengo. The issue was that some signals were not marked readonly, but their underlying NumPy arrays were readonly. This PR fixes the case that was causing the issue for the user.

**How has this been tested?**
Existing tests still run, the user's model now resets correctly.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
