### PR TITLE
Allow NumPy scalars for eval points

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b0
+    rev: 21.12b0
     hooks:
     - id: black
       files: \.py$

--- a/nengo/builder/connection.py
+++ b/nengo/builder/connection.py
@@ -85,7 +85,7 @@ def get_targets(conn, eval_points, dtype=None):
                     f"Building {conn}: Connection function returned "
                     "None. Cannot solve for decoders."
                 )
-            if not isinstance(out, (int, float, np.ndarray)):
+            if isinstance(out, (tuple, list)):
                 out = np.hstack(out)
             targets[i] = out
 

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -18,7 +18,6 @@ try:
         """Check if ``obj`` is a sparse matrix."""
         return isinstance(obj, scipy_sparse.spmatrix)
 
-
 except ImportError as e:
     logger.info("Could not import scipy.sparse:\n%s", str(e))
     scipy_sparse = None


### PR DESCRIPTION
**Motivation and context:**
In #1677, we fixed a NumPy warning in which an array was being set with list, tuple, or other iterable. We fixed it by checking if it was a number or ndarray. We didn't consider NumPy scalar types, which NengoDL uses, and which fail when `np.hstack` is called on them.

This fixes that issue. Since the issue exists only in master and not in a release version, we don't need a changelog entry.

**How has this been tested?**
NengoDL tests pass with this.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
