### PR TITLE
Copy inputs for process step functions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
     - PYTHON: "C:\\Miniconda37"
-      CONDA_PYTHON: "python=3.6"
+      CONDA_PYTHON: "python=3.7"
     - PYTHON: "C:\\Miniconda37-x64"
       CONDA_PYTHON: "python=3.9"
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,12 +51,16 @@ Release history
 
 - Fixed a bug with a problematic cache index breaking decoder solvers. The solver now
   avoids using the cache, rather than crashing. (`#1649`_)
+- Fixed an inconsistency in which normal ``Node`` output functions would receive
+  a copy of the input signal, while ``Process`` step functions would not.
+  ``Process`` step functions now also receive copies. (`#1679`_)
 
 .. _#1648: https://github.com/nengo/nengo/pull/1648
 .. _#1649: https://github.com/nengo/nengo/pull/1649
 .. _#1654: https://github.com/nengo/nengo/pull/1654
 .. _#1660: https://github.com/nengo/nengo/pull/1660
 .. _#1676: https://github.com/nengo/nengo/pull/1676
+.. _#1679: https://github.com/nengo/nengo/pull/1679
 
 3.1.0 (November 17, 2020)
 =========================

--- a/nengo/builder/tests/test_processes.py
+++ b/nengo/builder/tests/test_processes.py
@@ -1,7 +1,9 @@
+import numpy as np
 import pytest
 
 from nengo.builder.processes import SimProcess
 from nengo.builder.tests.test_operator import _test_operator_arg_attributes
+from nengo.processes import Process
 
 
 def test_simprocess():
@@ -14,3 +16,30 @@ def test_simprocess():
 
     with pytest.raises(ValueError, match="Unrecognized mode"):
         _test_operator_arg_attributes(SimProcess, argnames, args={"mode": "badval"})
+
+
+@pytest.mark.parametrize("mode", ["set", "inc"])
+@pytest.mark.parametrize("has_input", [False, True])
+def test_simprocess_make_step(mode, has_input, rng):
+    t0 = rng.uniform(size=1)
+    in0 = rng.uniform(size=1)
+    out0 = rng.uniform(size=1)
+    ref = t0 + (in0 if has_input else 0) + (out0 if mode == "inc" else 0)
+
+    signals = {"in": in0.copy(), "out": out0.copy(), "t": t0.copy()}
+    sim = SimProcess(
+        TimeAddProcess(),
+        input="in" if has_input else None,
+        output="out",
+        t="t",
+        mode=mode,
+    )
+    step = sim.make_step(signals, dt=1, rng=rng)
+    step()
+
+    assert np.array_equal(signals["out"], ref)
+
+
+class TimeAddProcess(Process):
+    def make_step(self, shape_in, shape_out, dt, rng, state):
+        return (lambda t: t) if np.prod(shape_in) == 0 else (lambda t, x: x + t)

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -362,6 +362,7 @@ def test_args(Simulator):
             assert isinstance(t, float)
             assert isinstance(x, np.ndarray)
             assert self.last_x is not x  # x should be a new copy on each call
+            assert x.base is None  # x should not be a view (since it should be a copy)
             self.last_x = x
             assert x[0] == t
 


### PR DESCRIPTION
**Motivation and context:**
While working on https://github.com/nengo/nengo-loihi/pull/312 we discovered that processes don't copy their input `x` value, even though they are copied for non-process node step functions. This PR copies the `x` value for processes as well, making them behave the same.

**How has this been tested?**
Tested that this PR makes the `np.copy` in [this line](https://github.com/nengo/nengo-loihi/pull/312/files#diff-d9c021912f7de6b7afade53e8289d8c593282c0e60e76eb8a514df6b4b3f70f0R16) not necessary. However, we should probably write a test for this within NengoCore.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
Should probably start by writing a test for the behavior. We might have a test that normal node output functions are copies which we can add a process to.

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
- [x] Add test
