### PR TITLE
Fix typo in connections.rst

### DIFF
--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -91,7 +91,7 @@ that one should keep in mind when using decoded connections.
   It will never be run during the simulation.
 
   When you define a function in a node,
-  it will be execute on every simulation timestep.
+  it will be executed on every simulation timestep.
   That may lead you to think that the function
   passed to a connection is executed on every timestep,
   but that is *not* the case for decoded connections.


### PR DESCRIPTION
`will be execute` -> `will be executed`

**Motivation and context:**
Just a typo!

**How has this been tested?**
N/A

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
All other N/A because its just a typo :) 


**Still to do:**
Do I need to add myself in `people.md` or is this straightforward enough where its not required?
