### PR TITLE
Remove duplicate output probeable in Neurons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,12 +32,6 @@ Release history
 - Added ``Conv`` and ``ConvTranspose`` aliases for ``Convolution`` and
   ``ConvolutionTranspose``. (`#1648`_)
 
-**Fixed**
-
-- Operator graph step order will now be deterministic. (`#1654`_)
-- Fixed an issue in which some simulators could not be reset due to signals
-  not being marked as readonly. (`#1676`_)
-
 **Removed**
 
 - Removed support for Python 3.5 (which reached its end of life in
@@ -51,9 +45,13 @@ Release history
 
 - Fixed a bug with a problematic cache index breaking decoder solvers. The solver now
   avoids using the cache, rather than crashing. (`#1649`_)
+- Operator graph step order will now be deterministic. (`#1654`_)
+- Fixed an issue in which some simulators could not be reset due to signals
+  not being marked as readonly. (`#1676`_)
 - Fixed an inconsistency in which normal ``Node`` output functions would receive
   a copy of the input signal, while ``Process`` step functions would not.
   ``Process`` step functions now also receive copies. (`#1679`_)
+- Duplicate keys in ``Neurons.probeable`` have been removed. (`#1681`_)
 
 .. _#1648: https://github.com/nengo/nengo/pull/1648
 .. _#1649: https://github.com/nengo/nengo/pull/1649
@@ -61,6 +59,7 @@ Release history
 .. _#1660: https://github.com/nengo/nengo/pull/1660
 .. _#1676: https://github.com/nengo/nengo/pull/1676
 .. _#1679: https://github.com/nengo/nengo/pull/1679
+.. _#1681: https://github.com/nengo/nengo/pull/1681
 
 3.1.0 (November 17, 2020)
 =========================

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -244,7 +244,7 @@ class Neurons:
     @property
     def probeable(self):
         """(tuple) Signals that can be probed in the neuron population."""
-        return ("output", "input") + self.ensemble.neuron_type.probeable
+        return self.ensemble.neuron_type.probeable + ("input",)
 
     @property
     def size_in(self):

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -1229,3 +1229,9 @@ def test_bad_function_type():
         ens = nengo.Ensemble(10, 1)
         with pytest.raises(ValidationError, match="Invalid connection function type"):
             nengo.Connection(ens, ens, function="hi")
+
+
+def test_probeable():
+    with nengo.Network():
+        conn = nengo.Connection(nengo.Ensemble(10, 1), nengo.Ensemble(10, 1))
+        assert conn.probeable == ("output", "input", "weights")

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -506,3 +506,9 @@ def test_neurons_readonly():
         ens = nengo.Ensemble(10, 1)
         with pytest.raises(ReadonlyError, match="neurons"):
             ens.neurons = "test"
+
+
+def test_probeable():
+    with nengo.Network():
+        ens = nengo.Ensemble(10, 1)
+        assert ens.probeable == ("decoded_output", "input", "scaled_encoders")

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -823,3 +823,29 @@ def test_step_math():
 
     for arg, val in args.items():
         assert (result["state"][arg] if arg.startswith("state") else result[arg]) is val
+
+
+def test_probeable():
+    def check_neuron_type(neuron_type, expected):
+        assert neuron_type.probeable == expected
+        ens = nengo.Ensemble(10, 1, neuron_type=neuron_type)
+        assert ens.neurons.probeable == expected + ("input",)
+
+    with nengo.Network():
+        check_neuron_type(Direct(), ("output",))
+        check_neuron_type(RectifiedLinear(), ("output",))
+        check_neuron_type(SpikingRectifiedLinear(), ("output", "voltage"))
+        check_neuron_type(Sigmoid(), ("output",))
+        check_neuron_type(Tanh(), ("output",))
+        check_neuron_type(LIFRate(), ("output",))
+        check_neuron_type(LIF(), ("output", "voltage", "refractory_time"))
+        check_neuron_type(AdaptiveLIFRate(), ("output", "adaptation"))
+        check_neuron_type(
+            AdaptiveLIF(), ("output", "voltage", "refractory_time", "adaptation")
+        )
+        check_neuron_type(Izhikevich(), ("output", "voltage", "recovery"))
+        check_neuron_type(RegularSpiking(LIFRate()), ("output", "rate_out", "voltage"))
+        check_neuron_type(
+            StochasticSpiking(AdaptiveLIFRate()), ("output", "rate_out", "adaptation")
+        )
+        check_neuron_type(PoissonSpiking(LIFRate()), ("output", "rate_out"))

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -428,3 +428,8 @@ def test_invalid_values(Simulator, badval):
     with Simulator(model) as sim:
         with pytest.raises(SimulationError):
             sim.run(0.01)
+
+
+def test_probeable():
+    with nengo.Network():
+        assert nengo.Node(np.sin).probeable == ("output",)


### PR DESCRIPTION
**Motivation and context:**
When you look at `nengo.Ensemble(10, 1, add_to_container=False).neurons.probeable`, you get:

```
('output', 'input', 'output', 'voltage', 'refractory_time')
```

Why's that duplicate `'output'` in there? Seems to have been an oversight from this change: 036a0ce07b24ec247423ff6651c4222d5e2aba38

This PR fixes it:

```
>>> nengo.Ensemble(10, 1, add_to_container=False).neurons.probeable
('output', 'voltage', 'refractory_time', 'input')
```

Note that the order changes such that `'input'` is now at the end. That's so that `'output'` still appears first.

**How has this been tested?**
Verified in the console, but we still need to write tests for this.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
Implement a test.

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
