### PR TITLE
LearningRuleTypes have "delta" as first probeable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,12 +32,6 @@ Release history
 - Added ``Conv`` and ``ConvTranspose`` aliases for ``Convolution`` and
   ``ConvolutionTranspose``. (`#1648`_)
 
-**Fixed**
-
-- Operator graph step order will now be deterministic. (`#1654`_)
-- Fixed an issue in which some simulators could not be reset due to signals
-  not being marked as readonly. (`#1676`_)
-
 **Removed**
 
 - Removed support for Python 3.5 (which reached its end of life in
@@ -51,9 +45,13 @@ Release history
 
 - Fixed a bug with a problematic cache index breaking decoder solvers. The solver now
   avoids using the cache, rather than crashing. (`#1649`_)
+- Operator graph step order will now be deterministic. (`#1654`_)
+- Fixed an issue in which some simulators could not be reset due to signals
+  not being marked as readonly. (`#1676`_)
 - Fixed an inconsistency in which normal ``Node`` output functions would receive
   a copy of the input signal, while ``Process`` step functions would not.
   ``Process`` step functions now also receive copies. (`#1679`_)
+- Duplicate keys in ``Neurons.probeable`` have been removed. (`#1681`_)
 
 .. _#1648: https://github.com/nengo/nengo/pull/1648
 .. _#1649: https://github.com/nengo/nengo/pull/1649
@@ -61,6 +59,7 @@ Release history
 .. _#1660: https://github.com/nengo/nengo/pull/1660
 .. _#1676: https://github.com/nengo/nengo/pull/1676
 .. _#1679: https://github.com/nengo/nengo/pull/1679
+.. _#1681: https://github.com/nengo/nengo/pull/1681
 
 3.1.0 (November 17, 2020)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ Release history
 - Added ``Conv`` and ``ConvTranspose`` aliases for ``Convolution`` and
   ``ConvolutionTranspose``. (`#1648`_)
 
+**Changed**
+
+- Learning rules now have ``"delta"`` as their default probeable signal. (`#1681`_)
+
 **Removed**
 
 - Removed support for Python 3.5 (which reached its end of life in

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -244,7 +244,7 @@ class Neurons:
     @property
     def probeable(self):
         """(tuple) Signals that can be probed in the neuron population."""
-        return ("output", "input") + self.ensemble.neuron_type.probeable
+        return self.ensemble.neuron_type.probeable + ("input",)
 
     @property
     def size_in(self):

--- a/nengo/learning_rules.py
+++ b/nengo/learning_rules.py
@@ -105,7 +105,7 @@ class PES(LearningRuleType):
     """
 
     modifies = "decoders"
-    probeable = ("error", "activities", "delta")
+    probeable = ("delta", "error", "activities")
 
     learning_rate = NumberParam("learning_rate", low=0, readonly=True, default=1e-4)
     pre_synapse = SynapseParam("pre_synapse", default=Lowpass(tau=0.005), readonly=True)
@@ -216,7 +216,7 @@ class RLS(LearningRuleType):
     """
 
     modifies = "decoders"
-    probeable = ("pre_filtered", "error", "delta", "inv_gamma")
+    probeable = ("delta", "pre_filtered", "error", "inv_gamma")
 
     learning_rate = NumberParam("learning_rate", low=0, readonly=True, default=1e-3)
     pre_synapse = SynapseParam("pre_synapse", default=Lowpass(tau=0.005), readonly=True)
@@ -275,7 +275,7 @@ class BCM(LearningRuleType):
     """
 
     modifies = "weights"
-    probeable = ("theta", "pre_filtered", "post_filtered", "delta")
+    probeable = ("delta", "theta", "pre_filtered", "post_filtered")
 
     learning_rate = NumberParam("learning_rate", low=0, readonly=True, default=1e-9)
     pre_synapse = SynapseParam("pre_synapse", default=Lowpass(tau=0.005), readonly=True)
@@ -347,7 +347,7 @@ class Oja(LearningRuleType):
     """
 
     modifies = "weights"
-    probeable = ("pre_filtered", "post_filtered", "delta")
+    probeable = ("delta", "pre_filtered", "post_filtered")
 
     learning_rate = NumberParam("learning_rate", low=0, readonly=True, default=1e-6)
     pre_synapse = SynapseParam("pre_synapse", default=Lowpass(tau=0.005), readonly=True)
@@ -401,7 +401,7 @@ class Voja(LearningRuleType):
     """
 
     modifies = "encoders"
-    probeable = ("post_filtered", "scaled_encoders", "delta")
+    probeable = ("delta", "post_filtered", "scaled_encoders")
 
     learning_rate = NumberParam("learning_rate", low=0, readonly=True, default=1e-2)
     post_synapse = SynapseParam(

--- a/nengo/probe.py
+++ b/nengo/probe.py
@@ -10,7 +10,7 @@ from nengo.synapses import SynapseParam
 class TargetParam(NengoObjectParam):
     def coerce(self, probe, target):  # pylint: disable=arguments-renamed
         obj = target.obj if isinstance(target, ObjView) else target
-        if not hasattr(obj, "probeable"):
+        if not hasattr(obj, "probeable") or not obj.probeable:
             raise ValidationError(
                 f"Type '{type(obj).__name__}' is not probeable",
                 attr=self.name,

--- a/nengo/tests/test_connection.py
+++ b/nengo/tests/test_connection.py
@@ -1229,3 +1229,9 @@ def test_bad_function_type():
         ens = nengo.Ensemble(10, 1)
         with pytest.raises(ValidationError, match="Invalid connection function type"):
             nengo.Connection(ens, ens, function="hi")
+
+
+def test_probeable():
+    with nengo.Network():
+        conn = nengo.Connection(nengo.Ensemble(10, 1), nengo.Ensemble(10, 1))
+        assert conn.probeable == ("output", "input", "weights")

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -506,3 +506,9 @@ def test_neurons_readonly():
         ens = nengo.Ensemble(10, 1)
         with pytest.raises(ReadonlyError, match="neurons"):
             ens.neurons = "test"
+
+
+def test_probeable():
+    with nengo.Network():
+        ens = nengo.Ensemble(10, 1)
+        assert ens.probeable == ("decoded_output", "input", "scaled_encoders")

--- a/nengo/tests/test_learning_rules.py
+++ b/nengo/tests/test_learning_rules.py
@@ -1078,12 +1078,12 @@ def test_probeable():
     with net:
         net.e = nengo.Ensemble(10, 1)
         net.n = net.e.neurons
-        check_learning_rule(nengo.PES(), ("error", "activities", "delta"))
+        check_learning_rule(nengo.PES(), ("delta", "error", "activities"))
         check_learning_rule(
-            nengo.RLS(), ("pre_filtered", "error", "delta", "inv_gamma")
+            nengo.RLS(), ("delta", "pre_filtered", "error", "inv_gamma")
         )
         check_learning_rule(
-            nengo.BCM(), ("theta", "pre_filtered", "post_filtered", "delta")
+            nengo.BCM(), ("delta", "theta", "pre_filtered", "post_filtered")
         )
-        check_learning_rule(nengo.Oja(), ("pre_filtered", "post_filtered", "delta"))
-        check_learning_rule(nengo.Voja(), ("post_filtered", "scaled_encoders", "delta"))
+        check_learning_rule(nengo.Oja(), ("delta", "pre_filtered", "post_filtered"))
+        check_learning_rule(nengo.Voja(), ("delta", "post_filtered", "scaled_encoders"))

--- a/nengo/tests/test_neurons.py
+++ b/nengo/tests/test_neurons.py
@@ -823,3 +823,29 @@ def test_step_math():
 
     for arg, val in args.items():
         assert (result["state"][arg] if arg.startswith("state") else result[arg]) is val
+
+
+def test_probeable():
+    def check_neuron_type(neuron_type, expected):
+        assert neuron_type.probeable == expected
+        ens = nengo.Ensemble(10, 1, neuron_type=neuron_type)
+        assert ens.neurons.probeable == expected + ("input",)
+
+    with nengo.Network():
+        check_neuron_type(Direct(), ("output",))
+        check_neuron_type(RectifiedLinear(), ("output",))
+        check_neuron_type(SpikingRectifiedLinear(), ("output", "voltage"))
+        check_neuron_type(Sigmoid(), ("output",))
+        check_neuron_type(Tanh(), ("output",))
+        check_neuron_type(LIFRate(), ("output",))
+        check_neuron_type(LIF(), ("output", "voltage", "refractory_time"))
+        check_neuron_type(AdaptiveLIFRate(), ("output", "adaptation"))
+        check_neuron_type(
+            AdaptiveLIF(), ("output", "voltage", "refractory_time", "adaptation")
+        )
+        check_neuron_type(Izhikevich(), ("output", "voltage", "recovery"))
+        check_neuron_type(RegularSpiking(LIFRate()), ("output", "rate_out", "voltage"))
+        check_neuron_type(
+            StochasticSpiking(AdaptiveLIFRate()), ("output", "rate_out", "adaptation")
+        )
+        check_neuron_type(PoissonSpiking(LIFRate()), ("output", "rate_out"))

--- a/nengo/tests/test_node.py
+++ b/nengo/tests/test_node.py
@@ -428,3 +428,8 @@ def test_invalid_values(Simulator, badval):
     with Simulator(model) as sim:
         with pytest.raises(SimulationError):
             sim.run(0.01)
+
+
+def test_probeable():
+    with nengo.Network():
+        assert nengo.Node(np.sin).probeable == ("output",)


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

While best practice is to explicitly pass the `attr` when probing learning rules, it seems sensible to also have some consistent default. The logical choice is "delta", since all learning rules must have this.

Since this is a breaking change (albeit minor), we'll hold off until Nengo 4.0.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [ ] Decide if we want to build this into the base `LearningRuleType` or `LearningRule` itself, such that "delta" is inserted at the front automatically.