### PR TITLE
Fix LinearFilter for tensors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,8 +26,14 @@ Release history
 
 - Added ``groups`` parameter to ``nengo.Convolution``. (`#1675`_, `#1684`_)
 
+**Fixed**
+
+- Fixed an issue where ``nengo.LinearFilter`` and subclasses (e.g. ``Lowpass``,
+  ``Alpha``) would fail when running on tensors with dimension >= 3. (`#1687`_)
+
 .. _#1675: https://github.com/nengo/nengo/issues/1675
 .. _#1684: https://github.com/nengo/nengo/pull/1684
+.. _#1687: https://github.com/nengo/nengo/pull/1687
 
 3.2.0 (January 27, 2022)
 ========================


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

LinearFilter wasn't working properly for tensors with `ndim >= 3`.

Also upgraded black and isort since pre-commit hooks were failing due to changes in click (https://github.com/psf/black/issues/2964). 

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a unit test that reproduces the failure in the absence of the fix.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.