### PR TITLE
Fixing deprecated numpy.product

### DIFF
--- a/nengo/utils/filter_design.py
+++ b/nengo/utils/filter_design.py
@@ -48,7 +48,7 @@ from numpy import (
     dot,
     eye,
     poly,
-    product,
+    prod,
     r_,
     roots,
     zeros,
@@ -339,11 +339,11 @@ def ss2tf(A, B, C, D, input=0):
     except ValueError:  # pragma: no cover
         den = 1
 
-    if (product(B.shape, axis=0) == 0) and (
-        product(C.shape, axis=0) == 0
+    if (prod(B.shape, axis=0) == 0) and (
+        prod(C.shape, axis=0) == 0
     ):  # pragma: no cover
         num = np.ravel(D)
-        if (product(D.shape, axis=0) == 0) and (product(A.shape, axis=0) == 0):
+        if (prod(D.shape, axis=0) == 0) and (prod(A.shape, axis=0) == 0):
             den = []
         return num, den
 


### PR DESCRIPTION
**Motivation and context:**
`numpy.product` used in `nengo/utils/filter_design.py` is deprecated and seems to have been removed in numpy v2.0. This was causing some issues when importing nengo.

**How has this been tested?**
Importing nengo and using the function `ss2tf` works was expected after change.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.
