### PR TITLE
Avoid using numpy.core, which is deprecated.

### DIFF
--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -27,9 +27,7 @@ except ImportError as e:
 
 maxseed = np.iinfo(np.uint32).max
 maxint = np.iinfo(np.int32).max
-# numpy 1.17 introduced a slowdown to clip, so
-# use np.core.umath.clip instead of np.clip
-clip = np.core.umath.clip
+clip = np.clip
 
 
 def is_integer(obj):


### PR DESCRIPTION
The use of `numpy.core` in [`utils.numpy`](https://github.com/nengo/nengo/blob/d28cb91484eea0036322db5cf039737aaa0693bf/nengo/utils/numpy.py#L32) causes a `DeprecationWarning`:

```
venv/lib/python3.12/site-packages/nengo/utils/numpy.py:32: DeprecationWarning: numpy.core is deprecated and has been renamed to numpy._core. The numpy._core namespace contains private NumPy internals and its use is discouraged, as NumPy internals can change without warning in any release. In practice, most real-world usage of numpy.core is to access functionality in the public NumPy API. If that is the case, use the public NumPy API. If not, you are using NumPy internals. If you would still like to access an internal attribute, use numpy._core.umath.
    clip = np.core.umath.clip
```

This PR fixes that.