### PR TITLE
Allowed Ensemble(dimensions=0) and made it default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Release history
 4.1.1 (unreleased)
 ==================
 
+** Changed**
+
+- Allowed Ensemble(dimensions=0) and made it default
 
 4.1.0 (May 29, 2025)
 ====================

--- a/nengo/builder/ensemble.py
+++ b/nengo/builder/ensemble.py
@@ -181,28 +181,32 @@ def build_ensemble(model, ens):
     # Create random number generator
     rng = np.random.RandomState(model.seeds[ens])
 
-    eval_points = gen_eval_points(ens, ens.eval_points, rng=rng, dtype=rc.float_dtype)
+    if ens.dimensions > 0:
+        eval_points = gen_eval_points(ens, ens.eval_points, rng=rng, dtype=rc.float_dtype)
 
-    # Set up signal
-    model.sig[ens]["in"] = Signal(shape=ens.dimensions, name=f"{ens}.signal")
-    model.add_op(Reset(model.sig[ens]["in"]))
+        # Set up signal
+        model.sig[ens]["in"] = Signal(shape=ens.dimensions, name=f"{ens}.signal")
+        model.add_op(Reset(model.sig[ens]["in"]))
 
-    # Set up encoders
-    if isinstance(ens.neuron_type, Direct):
-        encoders = np.identity(ens.dimensions, dtype=rc.float_dtype)
-    elif isinstance(ens.encoders, Distribution):
-        encoders = get_samples(ens.encoders, ens.n_neurons, ens.dimensions, rng=rng)
-        encoders = np.asarray(encoders, dtype=rc.float_dtype)
+        # Set up encoders
+        if isinstance(ens.neuron_type, Direct):
+            encoders = np.identity(ens.dimensions, dtype=rc.float_dtype)
+        elif isinstance(ens.encoders, Distribution):
+            encoders = get_samples(ens.encoders, ens.n_neurons, ens.dimensions, rng=rng)
+            encoders = np.asarray(encoders, dtype=rc.float_dtype)
+        else:
+            encoders = npext.array(ens.encoders, min_dims=2, dtype=rc.float_dtype)
+        if ens.normalize_encoders:
+            encoders /= npext.norm(encoders, axis=1, keepdims=True)
+        if np.any(np.isnan(encoders)):
+            raise BuildError(
+                f"NaNs detected in '{ens}' encoders. This usually means that you had "
+                "zero-length encoders that were normalized, resulting in NaNs. Ensure all "
+                "encoders have non-zero length, or set `normalize_encoders=False`."
+            )
     else:
-        encoders = npext.array(ens.encoders, min_dims=2, dtype=rc.float_dtype)
-    if ens.normalize_encoders:
-        encoders /= npext.norm(encoders, axis=1, keepdims=True)
-    if np.any(np.isnan(encoders)):
-        raise BuildError(
-            f"NaNs detected in '{ens}' encoders. This usually means that you had "
-            "zero-length encoders that were normalized, resulting in NaNs. Ensure all "
-            "encoders have non-zero length, or set `normalize_encoders=False`."
-        )
+        encoders = None
+        eval_points = None
 
     # Build the neurons
     gain, bias, max_rates, intercepts = get_gain_bias(ens, rng, dtype=rc.float_dtype)
@@ -225,29 +229,33 @@ def build_ensemble(model, ens):
         # This adds the neuron's operator and sets other signals
         model.build(ens.neuron_type, ens.neurons)
 
-    # Scale the encoders
-    if isinstance(ens.neuron_type, Direct):
-        scaled_encoders = encoders
-    else:
-        scaled_encoders = encoders * (gain / ens.radius)[:, np.newaxis]
+    if ens.dimensions > 0:
+        # Scale the encoders
+        if isinstance(ens.neuron_type, Direct):
+            scaled_encoders = encoders
+        else:
+            scaled_encoders = encoders * (gain / ens.radius)[:, np.newaxis]
 
-    model.sig[ens]["encoders"] = Signal(
-        scaled_encoders, name=f"{ens}.scaled_encoders", readonly=True
-    )
+        model.sig[ens]["encoders"] = Signal(
+            scaled_encoders, name=f"{ens}.scaled_encoders", readonly=True
+        )
+    else:
+        scaled_encoders = None
 
     # Inject noise if specified
     if ens.noise is not None:
         model.build(ens.noise, sig_out=model.sig[ens.neurons]["in"], mode="inc")
 
-    # Create output signal, using built Neurons
-    model.add_op(
-        DotInc(
-            model.sig[ens]["encoders"],
-            model.sig[ens]["in"],
-            model.sig[ens.neurons]["in"],
-            tag=f"{ens} encoding",
+    if ens.dimensions > 0:
+        # Create output signal, using built Neurons
+        model.add_op(
+            DotInc(
+                model.sig[ens]["encoders"],
+                model.sig[ens]["in"],
+                model.sig[ens.neurons]["in"],
+                tag=f"{ens} encoding",
+            )
         )
-    )
 
     # Output is neural output
     model.sig[ens]["out"] = model.sig[ens.neurons]["out"]

--- a/nengo/ensemble.py
+++ b/nengo/ensemble.py
@@ -63,7 +63,10 @@ class Ensemble(NengoObject):
     bias : Distribution or (n_neurons,) array_like or None
         The biases associated with each neuron in the ensemble.
     dimensions : int
-        The number of representational dimensions.
+        The number of representational dimensions.  If 0 (default)
+        then there are no encoders or decoders, and the Ensemble
+        can be treated as a simple layer of neurons (connecting
+        with ens.neurons)
     encoders : Distribution or (n_neurons, dimensions) array_like
         The encoders, used to transform from representational space
         to neuron space. Each row is a neuron's encoder, each column is a
@@ -105,7 +108,7 @@ class Ensemble(NengoObject):
     probeable = ("decoded_output", "input", "scaled_encoders")
 
     n_neurons = IntParam("n_neurons", low=1)
-    dimensions = IntParam("dimensions", low=1)
+    dimensions = IntParam("dimensions", low=0, default=0)
     radius = NumberParam("radius", default=1.0, low=1e-10)
     encoders = DistOrArrayParam(
         "encoders",
@@ -143,7 +146,7 @@ class Ensemble(NengoObject):
     def __init__(
         self,
         n_neurons,
-        dimensions,
+        dimensions=Default,
         radius=Default,
         encoders=Default,
         intercepts=Default,

--- a/nengo/tests/test_ensemble.py
+++ b/nengo/tests/test_ensemble.py
@@ -6,7 +6,7 @@ import pytest
 import nengo
 import nengo.utils.numpy as npext
 from nengo.dists import Choice, Uniform, UniformHypersphere
-from nengo.exceptions import BuildError, NengoWarning, ReadonlyError
+from nengo.exceptions import BuildError, NengoWarning, ReadonlyError, ValidationError
 from nengo.neurons import RegularSpiking
 from nengo.processes import FilteredNoise, WhiteNoise
 from nengo.utils.testing import signals_allclose
@@ -519,3 +519,29 @@ def test_probeable():
     with nengo.Network():
         ens = nengo.Ensemble(10, 1)
         assert ens.probeable == ("decoded_output", "input", "scaled_encoders")
+
+
+def test_no_dimensions():
+    inputs = np.linspace(-1, 10, 100)
+    with nengo.Network() as model:
+        stim = nengo.Node(inputs)
+        ens = nengo.Ensemble(100, neuron_type=nengo.RectifiedLinear(),
+                             gain=[1]*100, bias=[0]*100)
+        nengo.Connection(stim, ens.neurons, synapse=None)
+        p_neurons = nengo.Probe(ens.neurons)
+        output = nengo.Node(None, size_in=1)
+        nengo.Connection(ens.neurons, output, transform=np.ones((1, 100)),
+                         synapse=None)
+        p_output = nengo.Probe(output)
+
+        # make sure NEF-style connections do not work
+        with pytest.raises(ValidationError):
+            nengo.Connection(ens, output)
+        with pytest.raises(ValidationError):
+            nengo.Connection(output, ens)
+
+    with nengo.Simulator(model) as sim:
+        sim.run(0.001)
+    v = sim.data[p_neurons][-1]
+    assert np.allclose(v, np.maximum(inputs, 0))
+    assert np.allclose(sim.data[p_output], np.sum(np.maximum(inputs, 0)))


### PR DESCRIPTION
**Motivation and context:**

This PR allows Ensembles to have dimensions=0.  This makes it clearer for making non-NEF models within nengo.  If an Ensemble has dimensions=0, then it is just a layer of neurons and does not support encoders and decoders.  Thus whenever you make a Connection to Ensemble, you have to do something like Connection(a.neurons, b.neurons) to be clear that you are directly connecting to the neurons themselves.

Note that Ensembles with dimensions=0 still have gains and biases generated in the normal way.

This also makes dimensions=0 the default for Ensembles.  Note that this is completely backwards compatible, as previously `dimensions` was a required parameter (and required to be greater than 0).

The goal here was to make a backwards-compatible change to Nengo that allows non-NEF models to be easy to create, and to avoid having to specify dimensions (and create encoders) when they aren't needed.

**Interactions with other PRs:**

None

**How has this been tested?**

A test was added to test_ensemble, and the suite of pytests was run.  Also, examples were tried in nengo_gui

**How long should this take to review?**

Quick, as it touches very little of the code.  But possibly also worth taking time to think about any other unexpected consequences of making non-NEF model creation easier.

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.