### PR TITLE
Fixing RandomizedSVD behaviour in absence of scikit-learn installation + pkg_resources test fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ Release history
 4.1.1 (unreleased)
 ==================
 
+**Fixes**
+
+- RandomizedSVD solver behaviour falls back to SVD in absence of scikit-learn installation
+- Resolve testing failure due to pkg_resources deprecation
 
 4.1.0 (May 29, 2025)
 ====================

--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -2,7 +2,7 @@ import logging
 import pickle
 
 import numpy as np
-import pkg_resources
+import importlib
 import pytest
 
 import nengo
@@ -188,7 +188,7 @@ def test_warn_on_opensim_del(Simulator):
 
 
 def test_entry_point(Simulator):
-    sims = [ep.load() for ep in pkg_resources.iter_entry_points(group="nengo.backends")]
+    sims = [ep.load() for ep in importlib.metadata.entry_points(group="nengo.backends")]
     assert Simulator in sims
 
 

--- a/nengo/utils/least_squares_solvers.py
+++ b/nengo/utils/least_squares_solvers.py
@@ -15,6 +15,7 @@ For example:
 """
 
 import numpy as np
+import warnings
 
 import nengo.utils.numpy as npext
 from nengo.exceptions import ValidationError
@@ -341,6 +342,9 @@ class RandomizedSVD(LeastSquaresSolver):
 
     Useful for solving large matrices quickly, but non-optimally.
 
+    Depends on scikit-learn, but if scikit-learn is unavailable, defaults
+    to SVD.
+
     Parameters
     ----------
     n_components : int, optional
@@ -362,32 +366,30 @@ class RandomizedSVD(LeastSquaresSolver):
     n_iter = IntParam("n_iter", low=0)
 
     def __init__(self, n_components=60, n_oversamples=10, n_iter=0):
-        from sklearn.utils.extmath import (  # pylint: disable=import-outside-toplevel
-            randomized_svd,
-        )
-
-        assert randomized_svd
+        try:
+            from sklearn.utils.extmath import randomized_svd
+            self.r_svd = randomized_svd
+        except ImportError:
+            warnings.warn("Randomized SVD depends on a valid installation of scikit-learn, defaulting to SVD")
+            self.r_svd = None
         super().__init__()
         self.n_components = n_components
         self.n_oversamples = n_oversamples
         self.n_iter = n_iter
 
     def __call__(self, A, Y, sigma, rng=np.random):
-        from sklearn.utils.extmath import (  # pylint: disable=import-outside-toplevel
-            randomized_svd,
-        )
 
         Y, m, n, _, matrix_in = format_system(A, Y)
-        if min(m, n) <= self.n_components + self.n_oversamples:
+        if min(m, n) <= self.n_components + self.n_oversamples or self.r_svd is None:
             # more efficient to do a full SVD
             return SVD()(A, Y, sigma, rng=rng)
 
-        U, s, V = randomized_svd(
+        U, s, V = self.r_svd(
             A,
             self.n_components,
             n_oversamples=self.n_oversamples,
             n_iter=self.n_iter,
-            random_state=rng,
+            random_state=rng.mtrand.RandomState(),
         )
         si = s / (s**2 + m * sigma**2)
         X = np.dot(V.T, si[:, None] * np.dot(U.T, Y))

--- a/nengo/utils/tests/test_least_squares_solvers.py
+++ b/nengo/utils/tests/test_least_squares_solvers.py
@@ -111,6 +111,6 @@ def test_randomized_svd_fallback(cond, rng, allclose):
     """Test the specific case where RandomizedSVD falls back to SVD."""
     pytest.importorskip("sklearn")
     m, n = 30, 20
-    solver = RandomizedSVD(n_components=min(m, n))
+    solver = RandomizedSVD(n_components=15)
     x, x2, _ = run_solver(solver, m=m, n=n, d=5, cond=cond, sys_rng=rng, sigma=1e-8)
     assert allclose(x2, x, atol=1e-8, rtol=1e-8)


### PR DESCRIPTION
**Motivation and context:**
- Nengo throws and error when trying to use RandomizedSVD without scikit-learn installed
- Broad testing suite fails to run due to pkg_resources deprecation

**Interactions with other PRs:**
- None to my knowledge

**How has this been tested?**
- Ran RandomizedSVD unit test with and without sciki-learn installation, no failures
- Ran broader testing suite and no more testing errors

**How long should this take to review?**
- Quick

**Types of changes:**
- Wrapped scikit-learn with try/except. Throws a warning for an absent install and defaults to SVD.
- Replaced pkg_resources with importlib

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes (N/A)
- [x] I have run the test suite locally and all (relevant) tests passed.
