### PR TITLE
Updated entrypoints import

### DIFF
--- a/nengo/tests/test_simulator.py
+++ b/nengo/tests/test_simulator.py
@@ -2,7 +2,7 @@ import logging
 import pickle
 
 import numpy as np
-import pkg_resources
+from importlib.metadata import entry_points
 import pytest
 
 import nengo
@@ -188,7 +188,7 @@ def test_warn_on_opensim_del(Simulator):
 
 
 def test_entry_point(Simulator):
-    sims = [ep.load() for ep in pkg_resources.iter_entry_points(group="nengo.backends")]
+    sims = [ep.load() for ep in entry_points(group="nengo.backends")]
     assert Simulator in sims
 
 


### PR DESCRIPTION
**Motivation and context:**
Made nengo compatible with latest Python and numpy. 
Only incompatibility was in test_simulator.py -- attempting to import depreciated pkg_resources for entry_points function. Changed to using entry_points from Python's importlib.metadata module

**How has this been tested?**
Tested by running all tests in tests directory and by running some of the examples from the Nengo website. Tested with Python==3.14.5 and Python==3.8.2

**How long should this take to review?**
Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
Start reviewing in nengo/nengo/tests/test_simulator.py

**Types of changes:**
nengo/nengo/tests/test_simulator.py line 5 changed import
nengo/nengo/tests/test_simulator.py line 191 changed entry_points call

Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [ x ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ x ] I have run the test suite locally and all tests passed.

**Still to do:**
N/A
