### PR TITLE
Handle deprecated numpy.core

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Release history
 
 - RandomizedSVD solver behaviour falls back to SVD in absence of scikit-learn installation
 - Resolve testing failure due to pkg_resources deprecation
+- Stop using numpy.core for numpy>=2 due to deprecation
 
 4.1.0 (May 29, 2025)
 ====================

--- a/nengo/utils/numpy.py
+++ b/nengo/utils/numpy.py
@@ -27,9 +27,12 @@ except ImportError as e:
 
 maxseed = np.iinfo(np.uint32).max
 maxint = np.iinfo(np.int32).max
-# numpy 1.17 introduced a slowdown to clip, so
-# use np.core.umath.clip instead of np.clip
-clip = np.core.umath.clip
+if int(np.version.version.split('.')[0]) >= 2:
+    clip = np.clip
+else:
+    # numpy 1.17 introduced a slowdown to clip, so
+    # use np.core.umath.clip instead of np.clip
+    clip = np.core.umath.clip
 
 
 def is_integer(obj):


### PR DESCRIPTION
**Motivation and context:**

Accessing numpy.core has been deprecated since numpy 2.0 and will be removed shortly.  This PR preserves the old behaviour for numpy<2.0, but directly accesses the correct faster numpy.clip available in numpy 2.0


**How has this been tested?**
Ran pytests on Python 3.8 (numpy<2) and 3.13 (numpy>2)

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

